### PR TITLE
PSA tests: use a few common test macros

### DIFF
--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -90,13 +90,23 @@ typedef struct data_tag
         }                                           \
     } while( 0 )
 
+/** Evaluate two expressions and fail the test case if they have different
+ * values.
+ *
+ * \param expr1     An expression to evaluate.
+ * \param expr2     The expected value of \p expr1. This can be any
+ *                  expression, but it is typically a constant.
+ */
+#define TEST_EQUAL( expr1, expr2 )              \
+    TEST_ASSERT( ( expr1 ) == ( expr2 ) )
+
 /** Evaluate an expression and fail the test case if it returns an error.
  *
  * \param expr      The expression to evaluate. This is typically a call
  *                  to a \c psa_xxx function that returns a value of type
  *                  #psa_status_t.
  */
-#define PSA_ASSERT( expr ) TEST_ASSERT( ( expr ) == PSA_SUCCESS )
+#define PSA_ASSERT( expr ) TEST_EQUAL( ( expr ), PSA_SUCCESS )
 
 /** Allocate memory dynamically and fail the test case if this fails.
  *

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -202,6 +202,23 @@ typedef struct data_tag
     ( STATIC_ASSERT_THEN_RETURN( IS_ARRAY_NOT_POINTER( array ),         \
                                  ARRAY_LENGTH_UNSAFE( array ) ) )
 
+/** Return the smaller of two values.
+ *
+ * \param x         An integer-valued expression without side effects.
+ * \param y         An integer-valued expression without side effects.
+ *
+ * \return The smaller of \p x and \p y.
+ */
+#define MIN( x, y ) ( ( x ) < ( y ) ? ( x ) : ( y ) )
+
+/** Return the larger of two values.
+ *
+ * \param x         An integer-valued expression without side effects.
+ * \param y         An integer-valued expression without side effects.
+ *
+ * \return The larger of \p x and \p y.
+ */
+#define MAX( x, y ) ( ( x ) > ( y ) ? ( x ) : ( y ) )
 
 /*
  * 32-bit integer manipulation macros (big endian)

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -90,6 +90,14 @@ typedef struct data_tag
         }                                           \
     } while( 0 )
 
+/** Evaluate an expression and fail the test case if it returns an error.
+ *
+ * \param expr      The expression to evaluate. This is typically a call
+ *                  to a \c psa_xxx function that returns a value of type
+ *                  #psa_status_t.
+ */
+#define PSA_ASSERT( expr ) TEST_ASSERT( ( expr ) == PSA_SUCCESS )
+
 /** Allocate memory dynamically and fail the test case if this fails.
  *
  * You must set \p pointer to \c NULL before calling this macro and

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -150,6 +150,9 @@ typedef struct data_tag
     mbedtls_exit( 1 );                                             \
 }
 
+/** Return the number of elements of a static or stack array. */
+#define ARRAY_LENGTH( array )                   \
+    ( sizeof( array ) / sizeof( *( array ) ) )
 /*
  * 32-bit integer manipulation macros (big endian)
  */

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -150,9 +150,41 @@ typedef struct data_tag
     mbedtls_exit( 1 );                                             \
 }
 
-/** Return the number of elements of a static or stack array. */
-#define ARRAY_LENGTH( array )                   \
+#if defined(__GNUC__)
+/* Test if arg and &(arg)[0] have the same type. This is true if arg is
+ * an array but not if it's a pointer. */
+#define IS_ARRAY_NOT_POINTER( arg )                                     \
+    ( ! __builtin_types_compatible_p( __typeof__( arg ),                \
+                                      __typeof__( &( arg )[0] ) ) )
+#else
+/* On platforms where we don't know how to implement this check,
+ * omit it. Oh well, a non-portable check is better than nothing. */
+#define IS_ARRAY_NOT_POINTER( arg ) 1
+#endif
+
+/* A compile-time constant with the value 0. If `const_expr` is not a
+ * compile-time constant with a nonzero value, cause a compile-time error. */
+#define STATIC_ASSERT_EXPR( const_expr )                                \
+    ( 0 && sizeof( struct { int STATIC_ASSERT : 1 - 2 * ! ( const_expr ); } ) )
+/* Return the scalar value `value` (possibly promoted). This is a compile-time
+ * constant if `value` is. `condition` must be a compile-time constant.
+ * If `condition` is false, arrange to cause a compile-time error. */
+#define STATIC_ASSERT_THEN_RETURN( condition, value )   \
+    ( STATIC_ASSERT_EXPR( condition ) ? 0 : ( value ) )
+
+#define ARRAY_LENGTH_UNSAFE( array )            \
     ( sizeof( array ) / sizeof( *( array ) ) )
+/** Return the number of elements of a static or stack array.
+ *
+ * \param array         A value of array (not pointer) type.
+ *
+ * \return The number of elements of the array.
+ */
+#define ARRAY_LENGTH( array )                                           \
+    ( STATIC_ASSERT_THEN_RETURN( IS_ARRAY_NOT_POINTER( array ),         \
+                                 ARRAY_LENGTH_UNSAFE( array ) ) )
+
+
 /*
  * 32-bit integer manipulation macros (big endian)
  */

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -407,7 +407,6 @@ static psa_status_t key_agreement_with_self( psa_crypto_generator_t *generator,
     public_key_type = PSA_KEY_TYPE_PUBLIC_KEY_OF_KEYPAIR( private_key_type );
     public_key_length = PSA_KEY_EXPORT_MAX_SIZE( public_key_type, key_bits );
     ASSERT_ALLOC( public_key, public_key_length );
-    TEST_ASSERT( public_key != NULL );
     PSA_ASSERT( psa_export_public_key( handle,
                                        public_key, public_key_length,
                                        &public_key_length ) );

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -139,13 +139,13 @@ static int exercise_mac_key( psa_key_handle_t handle,
 
     if( usage & PSA_KEY_USAGE_SIGN )
     {
-        TEST_ASSERT( psa_mac_sign_setup( &operation,
-                                         handle, alg ) == PSA_SUCCESS );
-        TEST_ASSERT( psa_mac_update( &operation,
-                                     input, sizeof( input ) ) == PSA_SUCCESS );
-        TEST_ASSERT( psa_mac_sign_finish( &operation,
-                                          mac, sizeof( mac ),
-                                          &mac_length ) == PSA_SUCCESS );
+        PSA_ASSERT( psa_mac_sign_setup( &operation,
+                                        handle, alg ) );
+        PSA_ASSERT( psa_mac_update( &operation,
+                                    input, sizeof( input ) ) );
+        PSA_ASSERT( psa_mac_sign_finish( &operation,
+                                         mac, sizeof( mac ),
+                                         &mac_length ) );
     }
 
     if( usage & PSA_KEY_USAGE_VERIFY )
@@ -154,10 +154,10 @@ static int exercise_mac_key( psa_key_handle_t handle,
             ( usage & PSA_KEY_USAGE_SIGN ?
               PSA_SUCCESS :
               PSA_ERROR_INVALID_SIGNATURE );
-        TEST_ASSERT( psa_mac_verify_setup( &operation,
-                                           handle, alg ) == PSA_SUCCESS );
-        TEST_ASSERT( psa_mac_update( &operation,
-                                     input, sizeof( input ) ) == PSA_SUCCESS );
+        PSA_ASSERT( psa_mac_verify_setup( &operation,
+                                          handle, alg ) );
+        PSA_ASSERT( psa_mac_update( &operation,
+                                    input, sizeof( input ) ) );
         TEST_ASSERT( psa_mac_verify_finish( &operation,
                                             mac,
                                             mac_length ) == verify_status );
@@ -185,19 +185,19 @@ static int exercise_cipher_key( psa_key_handle_t handle,
 
     if( usage & PSA_KEY_USAGE_ENCRYPT )
     {
-        TEST_ASSERT( psa_cipher_encrypt_setup( &operation,
-                                               handle, alg ) == PSA_SUCCESS );
-        TEST_ASSERT( psa_cipher_generate_iv( &operation,
-                                             iv, sizeof( iv ),
-                                             &iv_length ) == PSA_SUCCESS );
-        TEST_ASSERT( psa_cipher_update( &operation,
-                                        plaintext, sizeof( plaintext ),
-                                        ciphertext, sizeof( ciphertext ),
-                                        &ciphertext_length ) == PSA_SUCCESS );
-        TEST_ASSERT( psa_cipher_finish( &operation,
-                                        ciphertext + ciphertext_length,
-                                        sizeof( ciphertext ) - ciphertext_length,
-                                        &part_length ) == PSA_SUCCESS );
+        PSA_ASSERT( psa_cipher_encrypt_setup( &operation,
+                                              handle, alg ) );
+        PSA_ASSERT( psa_cipher_generate_iv( &operation,
+                                            iv, sizeof( iv ),
+                                            &iv_length ) );
+        PSA_ASSERT( psa_cipher_update( &operation,
+                                       plaintext, sizeof( plaintext ),
+                                       ciphertext, sizeof( ciphertext ),
+                                       &ciphertext_length ) );
+        PSA_ASSERT( psa_cipher_finish( &operation,
+                                       ciphertext + ciphertext_length,
+                                       sizeof( ciphertext ) - ciphertext_length,
+                                       &part_length ) );
         ciphertext_length += part_length;
     }
 
@@ -211,14 +211,14 @@ static int exercise_cipher_key( psa_key_handle_t handle,
             TEST_ASSERT( psa_get_key_information( handle, &type, &bits ) );
             iv_length = PSA_BLOCK_CIPHER_BLOCK_SIZE( type );
         }
-        TEST_ASSERT( psa_cipher_decrypt_setup( &operation,
-                                               handle, alg ) == PSA_SUCCESS );
-        TEST_ASSERT( psa_cipher_set_iv( &operation,
-                                        iv, iv_length ) == PSA_SUCCESS );
-        TEST_ASSERT( psa_cipher_update( &operation,
-                                        ciphertext, ciphertext_length,
-                                        decrypted, sizeof( decrypted ),
-                                        &part_length ) == PSA_SUCCESS );
+        PSA_ASSERT( psa_cipher_decrypt_setup( &operation,
+                                              handle, alg ) );
+        PSA_ASSERT( psa_cipher_set_iv( &operation,
+                                       iv, iv_length ) );
+        PSA_ASSERT( psa_cipher_update( &operation,
+                                       ciphertext, ciphertext_length,
+                                       decrypted, sizeof( decrypted ),
+                                       &part_length ) );
         status = psa_cipher_finish( &operation,
                                     decrypted + part_length,
                                     sizeof( decrypted ) - part_length,
@@ -228,7 +228,7 @@ static int exercise_cipher_key( psa_key_handle_t handle,
          ciphertext, a padding error is likely.  */
         if( ( usage & PSA_KEY_USAGE_ENCRYPT ) ||
             PSA_BLOCK_CIPHER_BLOCK_SIZE( type ) == 1 )
-            TEST_ASSERT( status == PSA_SUCCESS );
+            PSA_ASSERT( status );
         else
             TEST_ASSERT( status == PSA_SUCCESS ||
                          status == PSA_ERROR_INVALID_PADDING );
@@ -254,12 +254,12 @@ static int exercise_aead_key( psa_key_handle_t handle,
 
     if( usage & PSA_KEY_USAGE_ENCRYPT )
     {
-        TEST_ASSERT( psa_aead_encrypt( handle, alg,
-                                       nonce, nonce_length,
-                                       NULL, 0,
-                                       plaintext, sizeof( plaintext ),
-                                       ciphertext, sizeof( ciphertext ),
-                                       &ciphertext_length ) == PSA_SUCCESS );
+        PSA_ASSERT( psa_aead_encrypt( handle, alg,
+                                      nonce, nonce_length,
+                                      NULL, 0,
+                                      plaintext, sizeof( plaintext ),
+                                      ciphertext, sizeof( ciphertext ),
+                                      &ciphertext_length ) );
     }
 
     if( usage & PSA_KEY_USAGE_DECRYPT )
@@ -299,10 +299,10 @@ static int exercise_signature_key( psa_key_handle_t handle,
         psa_algorithm_t hash_alg = PSA_ALG_SIGN_GET_HASH( alg );
         if( hash_alg != 0 )
             payload_length = PSA_HASH_SIZE( hash_alg );
-        TEST_ASSERT( psa_asymmetric_sign( handle, alg,
-                                          payload, payload_length,
-                                          signature, sizeof( signature ),
-                                          &signature_length ) == PSA_SUCCESS );
+        PSA_ASSERT( psa_asymmetric_sign( handle, alg,
+                                         payload, payload_length,
+                                         signature, sizeof( signature ),
+                                         &signature_length ) );
     }
 
     if( usage & PSA_KEY_USAGE_VERIFY )
@@ -334,12 +334,12 @@ static int exercise_asymmetric_encryption_key( psa_key_handle_t handle,
 
     if( usage & PSA_KEY_USAGE_ENCRYPT )
     {
-        TEST_ASSERT(
+        PSA_ASSERT(
             psa_asymmetric_encrypt( handle, alg,
                                     plaintext, plaintext_length,
                                     NULL, 0,
                                     ciphertext, sizeof( ciphertext ),
-                                    &ciphertext_length ) == PSA_SUCCESS );
+                                    &ciphertext_length ) );
     }
 
     if( usage & PSA_KEY_USAGE_DECRYPT )
@@ -375,15 +375,15 @@ static int exercise_key_derivation_key( psa_key_handle_t handle,
 
     if( usage & PSA_KEY_USAGE_DERIVE )
     {
-        TEST_ASSERT( psa_key_derivation( &generator,
-                                         handle, alg,
-                                         label, label_length,
-                                         seed, seed_length,
-                                         sizeof( output ) ) == PSA_SUCCESS );
-        TEST_ASSERT( psa_generator_read( &generator,
-                                         output,
-                                         sizeof( output ) ) == PSA_SUCCESS );
-        TEST_ASSERT( psa_generator_abort( &generator ) == PSA_SUCCESS );
+        PSA_ASSERT( psa_key_derivation( &generator,
+                                        handle, alg,
+                                        label, label_length,
+                                        seed, seed_length,
+                                        sizeof( output ) ) );
+        PSA_ASSERT( psa_generator_read( &generator,
+                                        output,
+                                        sizeof( output ) ) );
+        PSA_ASSERT( psa_generator_abort( &generator ) );
     }
 
     return( 1 );
@@ -408,16 +408,16 @@ static psa_status_t key_agreement_with_self( psa_crypto_generator_t *generator,
      * good enough: callers will report it as a failed test anyway. */
     psa_status_t status = PSA_ERROR_UNKNOWN_ERROR;
 
-    TEST_ASSERT( psa_get_key_information( handle,
-                                          &private_key_type,
-                                          &key_bits ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_get_key_information( handle,
+                                         &private_key_type,
+                                         &key_bits ) );
     public_key_type = PSA_KEY_TYPE_PUBLIC_KEY_OF_KEYPAIR( private_key_type );
     public_key_length = PSA_KEY_EXPORT_MAX_SIZE( public_key_type, key_bits );
     ASSERT_ALLOC( public_key, public_key_length );
     TEST_ASSERT( public_key != NULL );
-    TEST_ASSERT( psa_export_public_key( handle,
-                                        public_key, public_key_length,
-                                        &public_key_length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_export_public_key( handle,
+                                       public_key, public_key_length,
+                                       &public_key_length ) );
 
     status = psa_key_agreement( generator, handle,
                                 public_key, public_key_length,
@@ -439,12 +439,11 @@ static int exercise_key_agreement_key( psa_key_handle_t handle,
     {
         /* We need two keys to exercise key agreement. Exercise the
          * private key against its own public key. */
-        TEST_ASSERT( key_agreement_with_self( &generator, handle, alg ) ==
-                     PSA_SUCCESS );
-        TEST_ASSERT( psa_generator_read( &generator,
-                                         output,
-                                         sizeof( output ) ) == PSA_SUCCESS );
-        TEST_ASSERT( psa_generator_abort( &generator ) == PSA_SUCCESS );
+        PSA_ASSERT( key_agreement_with_self( &generator, handle, alg ) );
+        PSA_ASSERT( psa_generator_read( &generator,
+                                        output,
+                                        sizeof( output ) ) );
+        PSA_ASSERT( psa_generator_abort( &generator ) );
     }
     ok = 1;
 
@@ -721,7 +720,7 @@ static int exercise_export_key( psa_key_handle_t handle,
     size_t exported_length = 0;
     int ok = 0;
 
-    TEST_ASSERT( psa_get_key_information( handle, &type, &bits ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_get_key_information( handle, &type, &bits ) );
 
     if( ( usage & PSA_KEY_USAGE_EXPORT ) == 0 &&
         ! PSA_KEY_TYPE_IS_PUBLIC_KEY( type ) )
@@ -734,9 +733,9 @@ static int exercise_export_key( psa_key_handle_t handle,
     exported_size = PSA_KEY_EXPORT_MAX_SIZE( type, bits );
     ASSERT_ALLOC( exported, exported_size );
 
-    TEST_ASSERT( psa_export_key( handle,
-                                 exported, exported_size,
-                                 &exported_length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_export_key( handle,
+                                exported, exported_size,
+                                &exported_length ) );
     ok = exported_key_sanity_check( type, bits, exported, exported_length );
 
 exit:
@@ -754,7 +753,7 @@ static int exercise_export_public_key( psa_key_handle_t handle )
     size_t exported_length = 0;
     int ok = 0;
 
-    TEST_ASSERT( psa_get_key_information( handle, &type, &bits ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_get_key_information( handle, &type, &bits ) );
     if( ! PSA_KEY_TYPE_IS_ASYMMETRIC( type ) )
     {
         TEST_ASSERT( psa_export_public_key( handle,
@@ -767,9 +766,9 @@ static int exercise_export_public_key( psa_key_handle_t handle )
     exported_size = PSA_KEY_EXPORT_MAX_SIZE( public_type, bits );
     ASSERT_ALLOC( exported, exported_size );
 
-    TEST_ASSERT( psa_export_public_key( handle,
-                                        exported, exported_size,
-                                        &exported_length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_export_public_key( handle,
+                                       exported, exported_size,
+                                       &exported_length ) );
     ok = exported_key_sanity_check( public_type, bits,
                                     exported, exported_length );
 
@@ -885,14 +884,14 @@ void import( data_t *data, int type, int expected_status_arg )
 
     TEST_ASSERT( data != NULL );
     TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( data->len ) );
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( type, KEY_BITS_FROM_DATA( type, data ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( type, KEY_BITS_FROM_DATA( type, data ),
+                                  &handle ) );
     status = psa_import_key( handle, type, data->x, data->len );
     TEST_ASSERT( status == expected_status );
     if( status == PSA_SUCCESS )
-        TEST_ASSERT( psa_destroy_key( handle ) == PSA_SUCCESS );
+        PSA_ASSERT( psa_destroy_key( handle ) );
 
 exit:
     mbedtls_psa_crypto_free( );
@@ -916,15 +915,15 @@ void import_twice( int alg_arg, int usage_arg,
     psa_key_policy_t policy;
     psa_status_t status;
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( type1,
-                                   MAX( KEY_BITS_FROM_DATA( type1, data1 ),
-                                        KEY_BITS_FROM_DATA( type2, data2 ) ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( type1,
+                                  MAX( KEY_BITS_FROM_DATA( type1, data1 ),
+                                       KEY_BITS_FROM_DATA( type2, data2 ) ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, usage, alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
     status = psa_import_key( handle, type1, data1->x, data1->len );
     TEST_ASSERT( status == expected_import1_status );
@@ -958,7 +957,7 @@ void import_rsa_made_up( int bits_arg, int keypair, int expected_status_arg )
     int ret;
     size_t length;
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
     ASSERT_ALLOC( buffer, buffer_size );
 
     TEST_ASSERT( ( ret = construct_fake_rsa_key( buffer, buffer_size, &p,
@@ -966,11 +965,11 @@ void import_rsa_made_up( int bits_arg, int keypair, int expected_status_arg )
     length = ret;
 
     /* Try importing the key */
-    TEST_ASSERT( psa_allocate_key( type, bits, &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( type, bits, &handle ) );
     status = psa_import_key( handle, type, p, length );
     TEST_ASSERT( status == expected_status );
     if( status == PSA_SUCCESS )
-        TEST_ASSERT( psa_destroy_key( handle ) == PSA_SUCCESS );
+        PSA_ASSERT( psa_destroy_key( handle ) );
 
 exit:
     mbedtls_free( buffer );
@@ -1008,25 +1007,24 @@ void import_export( data_t *data,
     ASSERT_ALLOC( exported, export_size );
     if( ! canonical_input )
         ASSERT_ALLOC( reexported, export_size );
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( type, expected_bits, &handle ) ==
-                 PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( type, expected_bits, &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, usage_arg, alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
     TEST_ASSERT( psa_get_key_information(
                      handle, NULL, NULL ) == PSA_ERROR_EMPTY_SLOT );
 
     /* Import the key */
-    TEST_ASSERT( psa_import_key( handle, type,
-                                 data->x, data->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, type,
+                                data->x, data->len ) );
 
     /* Test the key information */
-    TEST_ASSERT( psa_get_key_information( handle,
-                                          &got_type,
-                                          &got_bits ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_get_key_information( handle,
+                                         &got_type,
+                                         &got_bits ) );
     TEST_ASSERT( got_type == type );
     TEST_ASSERT( got_bits == (size_t) expected_bits );
 
@@ -1058,26 +1056,25 @@ void import_export( data_t *data,
     else
     {
         psa_key_handle_t handle2;
-        TEST_ASSERT( psa_allocate_key( type, expected_bits, &handle2 ) ==
-                     PSA_SUCCESS );
-        TEST_ASSERT( psa_set_key_policy( handle2, &policy ) == PSA_SUCCESS );
+        PSA_ASSERT( psa_allocate_key( type, expected_bits, &handle2 ) );
+        PSA_ASSERT( psa_set_key_policy( handle2, &policy ) );
 
-        TEST_ASSERT( psa_import_key( handle2, type,
-                                     exported,
-                                     exported_length ) == PSA_SUCCESS );
-        TEST_ASSERT( psa_export_key( handle2,
-                                     reexported,
-                                     export_size,
-                                     &reexported_length ) == PSA_SUCCESS );
+        PSA_ASSERT( psa_import_key( handle2, type,
+                                    exported,
+                                    exported_length ) );
+        PSA_ASSERT( psa_export_key( handle2,
+                                    reexported,
+                                    export_size,
+                                    &reexported_length ) );
         ASSERT_COMPARE( exported, exported_length,
                         reexported, reexported_length );
-        TEST_ASSERT( psa_close_key( handle2 ) == PSA_SUCCESS );
+        PSA_ASSERT( psa_close_key( handle2 ) );
     }
     TEST_ASSERT( exported_length <= PSA_KEY_EXPORT_MAX_SIZE( type, got_bits ) );
 
 destroy:
     /* Destroy the key */
-    TEST_ASSERT( psa_destroy_key( handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_destroy_key( handle ) );
     TEST_ASSERT( psa_get_key_information(
                      handle, NULL, NULL ) == PSA_ERROR_INVALID_HANDLE );
 
@@ -1095,14 +1092,14 @@ void import_key_nonempty_slot( )
     psa_key_type_t type = PSA_KEY_TYPE_RAW_DATA;
     psa_status_t status;
     const uint8_t data[] = { 0x1, 0x2, 0x3, 0x4, 0x5 };
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( type, PSA_BYTES_TO_BITS( sizeof( data ) ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( type, PSA_BYTES_TO_BITS( sizeof( data ) ),
+                                  &handle ) );
 
     /* Import the key */
-    TEST_ASSERT( psa_import_key( handle, type,
-                                 data, sizeof( data ) ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, type,
+                                data, sizeof( data ) ) );
 
     /* Import the key again */
     status = psa_import_key( handle, type, data, sizeof( data ) );
@@ -1122,7 +1119,7 @@ void export_invalid_handle( int handle, int expected_export_status_arg )
     size_t exported_length = INVALID_EXPORT_LENGTH;
     psa_status_t expected_export_status = expected_export_status_arg;
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
     /* Export the key */
     status = psa_export_key( (psa_key_handle_t) handle,
@@ -1146,13 +1143,13 @@ void export_with_no_key_activity( )
     size_t export_size = 0;
     size_t exported_length = INVALID_EXPORT_LENGTH;
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( PSA_KEY_TYPE_RAW_DATA, 0,
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( PSA_KEY_TYPE_RAW_DATA, 0,
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_EXPORT, alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
     /* Export the key */
     status = psa_export_key( handle,
@@ -1174,13 +1171,13 @@ void cipher_with_no_key_activity( )
     psa_cipher_operation_t operation;
     int exercise_alg = PSA_ALG_CTR;
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( PSA_KEY_TYPE_RAW_DATA, 0,
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( PSA_KEY_TYPE_RAW_DATA, 0,
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_ENCRYPT, exercise_alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
     status = psa_cipher_encrypt_setup( &operation, handle, exercise_alg );
     TEST_ASSERT( status == PSA_ERROR_EMPTY_SLOT );
@@ -1203,10 +1200,10 @@ void export_after_import_failure( data_t *data, int type_arg,
     psa_status_t expected_import_status = expected_import_status_arg;
     size_t exported_length = INVALID_EXPORT_LENGTH;
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( type, KEY_BITS_FROM_DATA( type, data ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( type, KEY_BITS_FROM_DATA( type, data ),
+                                  &handle ) );
 
     /* Import the key - expect failure */
     status = psa_import_key( handle, type,
@@ -1235,10 +1232,10 @@ void cipher_after_import_failure( data_t *data, int type_arg,
     psa_status_t expected_import_status = expected_import_status_arg;
     int exercise_alg = PSA_ALG_CTR;
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( type, KEY_BITS_FROM_DATA( type, data ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( type, KEY_BITS_FROM_DATA( type, data ),
+                                  &handle ) );
 
     /* Import the key - expect failure */
     status = psa_import_key( handle, type,
@@ -1266,25 +1263,25 @@ void export_after_destroy_key( data_t *data, int type_arg )
     size_t export_size = 0;
     size_t exported_length = INVALID_EXPORT_LENGTH;
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( type, KEY_BITS_FROM_DATA( type, data ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( type, KEY_BITS_FROM_DATA( type, data ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_EXPORT, alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
     export_size = (ptrdiff_t) data->len;
     ASSERT_ALLOC( exported, export_size );
 
     /* Import the key */
-    TEST_ASSERT( psa_import_key( handle, type,
-                                 data->x, data->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, type,
+                                data->x, data->len ) );
 
-    TEST_ASSERT( psa_export_key( handle, exported, export_size,
-                                 &exported_length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_export_key( handle, exported, export_size,
+                                &exported_length ) );
 
     /* Destroy the key */
-    TEST_ASSERT( psa_destroy_key( handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_destroy_key( handle ) );
 
     /* Export the key */
     status = psa_export_key( handle, exported, export_size,
@@ -1315,17 +1312,17 @@ void import_export_public_key( data_t *data,
     size_t exported_length = INVALID_EXPORT_LENGTH;
     psa_key_policy_t policy;
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( type, KEY_BITS_FROM_DATA( type, data ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( type, KEY_BITS_FROM_DATA( type, data ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_EXPORT, alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
     /* Import the key */
-    TEST_ASSERT( psa_import_key( handle, type,
-                                 data->x, data->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, type,
+                                data->x, data->len ) );
 
     /* Export the public key */
     ASSERT_ALLOC( exported, export_size );
@@ -1337,8 +1334,7 @@ void import_export_public_key( data_t *data,
     {
         psa_key_type_t public_type = PSA_KEY_TYPE_PUBLIC_KEY_OF_KEYPAIR( type );
         size_t bits;
-        TEST_ASSERT( psa_get_key_information( handle, NULL, &bits ) ==
-                     PSA_SUCCESS );
+        PSA_ASSERT( psa_get_key_information( handle, NULL, &bits ) );
         TEST_ASSERT( expected_public_key->len <=
                      PSA_KEY_EXPORT_MAX_SIZE( public_type, bits ) );
         ASSERT_COMPARE( expected_public_key->x, expected_public_key->len,
@@ -1368,22 +1364,22 @@ void import_and_exercise_key( data_t *data,
     size_t got_bits;
     psa_status_t status;
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( type, KEY_BITS_FROM_DATA( type, data ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( type, KEY_BITS_FROM_DATA( type, data ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, usage, alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
     /* Import the key */
     status = psa_import_key( handle, type, data->x, data->len );
-    TEST_ASSERT( status == PSA_SUCCESS );
+    PSA_ASSERT( status );
 
     /* Test the key information */
-    TEST_ASSERT( psa_get_key_information( handle,
-                                          &got_type,
-                                          &got_bits ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_get_key_information( handle,
+                                         &got_type,
+                                         &got_bits ) );
     TEST_ASSERT( got_type == type );
     TEST_ASSERT( got_bits == bits );
 
@@ -1410,22 +1406,22 @@ void key_policy( int usage_arg, int alg_arg )
 
     memset( key, 0x2a, sizeof( key ) );
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( sizeof( key ) ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( sizeof( key ) ),
+                                  &handle ) );
     psa_key_policy_init( &policy_set );
     psa_key_policy_init( &policy_get );
     psa_key_policy_set_usage( &policy_set, usage, alg );
 
     TEST_ASSERT( psa_key_policy_get_usage( &policy_set ) == usage );
     TEST_ASSERT( psa_key_policy_get_algorithm( &policy_set ) == alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy_set ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy_set ) );
 
-    TEST_ASSERT( psa_import_key( handle, key_type,
-                                 key, sizeof( key ) ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, key_type,
+                                key, sizeof( key ) ) );
 
-    TEST_ASSERT( psa_get_key_policy( handle, &policy_get ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_get_key_policy( handle, &policy_get ) );
 
     TEST_ASSERT( policy_get.usage == policy_set.usage );
     TEST_ASSERT( policy_get.alg == policy_set.alg );
@@ -1449,22 +1445,22 @@ void mac_key_policy( int policy_usage,
     psa_status_t status;
     unsigned char mac[PSA_MAC_MAX_SIZE];
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( key_type,
-                                   KEY_BITS_FROM_DATA( key_type, key_data ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( key_type,
+                                  KEY_BITS_FROM_DATA( key_type, key_data ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, policy_usage, policy_alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
-    TEST_ASSERT( psa_import_key( handle, key_type,
-                                 key_data->x, key_data->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, key_type,
+                                key_data->x, key_data->len ) );
 
     status = psa_mac_sign_setup( &operation, handle, exercise_alg );
     if( policy_alg == exercise_alg &&
         ( policy_usage & PSA_KEY_USAGE_SIGN ) != 0 )
-        TEST_ASSERT( status == PSA_SUCCESS );
+        PSA_ASSERT( status );
     else
         TEST_ASSERT( status == PSA_ERROR_NOT_PERMITTED );
     psa_mac_abort( &operation );
@@ -1473,7 +1469,7 @@ void mac_key_policy( int policy_usage,
     status = psa_mac_verify_setup( &operation, handle, exercise_alg );
     if( policy_alg == exercise_alg &&
         ( policy_usage & PSA_KEY_USAGE_VERIFY ) != 0 )
-        TEST_ASSERT( status == PSA_SUCCESS );
+        PSA_ASSERT( status );
     else
         TEST_ASSERT( status == PSA_ERROR_NOT_PERMITTED );
 
@@ -1496,22 +1492,22 @@ void cipher_key_policy( int policy_usage,
     psa_cipher_operation_t operation;
     psa_status_t status;
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( key_type,
-                                   KEY_BITS_FROM_DATA( key_type, key_data ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( key_type,
+                                  KEY_BITS_FROM_DATA( key_type, key_data ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, policy_usage, policy_alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
-    TEST_ASSERT( psa_import_key( handle, key_type,
-                                 key_data->x, key_data->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, key_type,
+                                key_data->x, key_data->len ) );
 
     status = psa_cipher_encrypt_setup( &operation, handle, exercise_alg );
     if( policy_alg == exercise_alg &&
         ( policy_usage & PSA_KEY_USAGE_ENCRYPT ) != 0 )
-        TEST_ASSERT( status == PSA_SUCCESS );
+        PSA_ASSERT( status );
     else
         TEST_ASSERT( status == PSA_ERROR_NOT_PERMITTED );
     psa_cipher_abort( &operation );
@@ -1519,7 +1515,7 @@ void cipher_key_policy( int policy_usage,
     status = psa_cipher_decrypt_setup( &operation, handle, exercise_alg );
     if( policy_alg == exercise_alg &&
         ( policy_usage & PSA_KEY_USAGE_DECRYPT ) != 0 )
-        TEST_ASSERT( status == PSA_SUCCESS );
+        PSA_ASSERT( status );
     else
         TEST_ASSERT( status == PSA_ERROR_NOT_PERMITTED );
 
@@ -1551,17 +1547,17 @@ void aead_key_policy( int policy_usage,
     TEST_ASSERT( nonce_length <= sizeof( nonce ) );
     TEST_ASSERT( tag_length <= sizeof( tag ) );
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( key_type,
-                                   KEY_BITS_FROM_DATA( key_type, key_data ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( key_type,
+                                  KEY_BITS_FROM_DATA( key_type, key_data ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, policy_usage, policy_alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
-    TEST_ASSERT( psa_import_key( handle, key_type,
-                                 key_data->x, key_data->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, key_type,
+                                key_data->x, key_data->len ) );
 
     status = psa_aead_encrypt( handle, exercise_alg,
                                nonce, nonce_length,
@@ -1571,7 +1567,7 @@ void aead_key_policy( int policy_usage,
                                &output_length );
     if( policy_alg == exercise_alg &&
         ( policy_usage & PSA_KEY_USAGE_ENCRYPT ) != 0 )
-        TEST_ASSERT( status == PSA_SUCCESS );
+        PSA_ASSERT( status );
     else
         TEST_ASSERT( status == PSA_ERROR_NOT_PERMITTED );
 
@@ -1609,21 +1605,21 @@ void asymmetric_encryption_key_policy( int policy_usage,
     unsigned char *buffer = NULL;
     size_t output_length;
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( key_type,
-                                   KEY_BITS_FROM_DATA( key_type, key_data ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( key_type,
+                                  KEY_BITS_FROM_DATA( key_type, key_data ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, policy_usage, policy_alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
-    TEST_ASSERT( psa_import_key( handle, key_type,
-                                 key_data->x, key_data->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, key_type,
+                                key_data->x, key_data->len ) );
 
-    TEST_ASSERT( psa_get_key_information( handle,
-                                          NULL,
-                                          &key_bits ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_get_key_information( handle,
+                                         NULL,
+                                         &key_bits ) );
     buffer_length = PSA_ASYMMETRIC_ENCRYPT_OUTPUT_SIZE( key_type, key_bits,
                                                         exercise_alg );
     ASSERT_ALLOC( buffer, buffer_length );
@@ -1635,7 +1631,7 @@ void asymmetric_encryption_key_policy( int policy_usage,
                                      &output_length );
     if( policy_alg == exercise_alg &&
         ( policy_usage & PSA_KEY_USAGE_ENCRYPT ) != 0 )
-        TEST_ASSERT( status == PSA_SUCCESS );
+        PSA_ASSERT( status );
     else
         TEST_ASSERT( status == PSA_ERROR_NOT_PERMITTED );
 
@@ -1674,17 +1670,17 @@ void asymmetric_signature_key_policy( int policy_usage,
     unsigned char signature[PSA_ASYMMETRIC_SIGNATURE_MAX_SIZE] = {0};
     size_t signature_length;
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( key_type,
-                                   KEY_BITS_FROM_DATA( key_type, key_data ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( key_type,
+                                  KEY_BITS_FROM_DATA( key_type, key_data ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, policy_usage, policy_alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
-    TEST_ASSERT( psa_import_key( handle, key_type,
-                                 key_data->x, key_data->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, key_type,
+                                key_data->x, key_data->len ) );
 
     status = psa_asymmetric_sign( handle, exercise_alg,
                                   payload, payload_length,
@@ -1692,7 +1688,7 @@ void asymmetric_signature_key_policy( int policy_usage,
                                   &signature_length );
     if( policy_alg == exercise_alg &&
         ( policy_usage & PSA_KEY_USAGE_SIGN ) != 0 )
-        TEST_ASSERT( status == PSA_SUCCESS );
+        PSA_ASSERT( status );
     else
         TEST_ASSERT( status == PSA_ERROR_NOT_PERMITTED );
 
@@ -1724,17 +1720,17 @@ void derive_key_policy( int policy_usage,
     psa_crypto_generator_t generator = PSA_CRYPTO_GENERATOR_INIT;
     psa_status_t status;
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( key_type,
-                                   KEY_BITS_FROM_DATA( key_type, key_data ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( key_type,
+                                  KEY_BITS_FROM_DATA( key_type, key_data ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, policy_usage, policy_alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
-    TEST_ASSERT( psa_import_key( handle, key_type,
-                                 key_data->x, key_data->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, key_type,
+                                key_data->x, key_data->len ) );
 
     status = psa_key_derivation( &generator, handle,
                                  exercise_alg,
@@ -1743,7 +1739,7 @@ void derive_key_policy( int policy_usage,
                                  1 );
     if( policy_alg == exercise_alg &&
         ( policy_usage & PSA_KEY_USAGE_DERIVE ) != 0 )
-        TEST_ASSERT( status == PSA_SUCCESS );
+        PSA_ASSERT( status );
     else
         TEST_ASSERT( status == PSA_ERROR_NOT_PERMITTED );
 
@@ -1767,23 +1763,23 @@ void agreement_key_policy( int policy_usage,
     psa_crypto_generator_t generator = PSA_CRYPTO_GENERATOR_INIT;
     psa_status_t status;
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( key_type,
-                                   KEY_BITS_FROM_DATA( key_type, key_data ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( key_type,
+                                  KEY_BITS_FROM_DATA( key_type, key_data ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, policy_usage, policy_alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
-    TEST_ASSERT( psa_import_key( handle, key_type,
-                                 key_data->x, key_data->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, key_type,
+                                key_data->x, key_data->len ) );
 
     status = key_agreement_with_self( &generator, handle, exercise_alg );
 
     if( policy_alg == exercise_alg &&
         ( policy_usage & PSA_KEY_USAGE_DERIVE ) != 0 )
-        TEST_ASSERT( status == PSA_SUCCESS );
+        PSA_ASSERT( status );
     else
         TEST_ASSERT( status == PSA_ERROR_NOT_PERMITTED );
 
@@ -1803,7 +1799,7 @@ void hash_setup( int alg_arg,
     psa_hash_operation_t operation;
     psa_status_t status;
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
     status = psa_hash_setup( &operation, alg );
     psa_hash_abort( &operation );
@@ -1826,7 +1822,7 @@ void hash_bad_order( )
     size_t hash_len;
     psa_hash_operation_t operation;
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
     /* psa_hash_update without calling psa_hash_setup beforehand */
     memset( &operation, 0, sizeof( operation ) );
@@ -1864,22 +1860,22 @@ void hash_verify_bad_args( )
     size_t expected_size = PSA_HASH_SIZE( alg );
     psa_hash_operation_t operation;
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
     /* psa_hash_verify with a smaller hash than expected */
-    TEST_ASSERT( psa_hash_setup( &operation, alg ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_hash_setup( &operation, alg ) );
     TEST_ASSERT( psa_hash_verify( &operation,
                                   hash, expected_size - 1 ) ==
                  PSA_ERROR_INVALID_SIGNATURE );
 
     /* psa_hash_verify with a non-matching hash */
-    TEST_ASSERT( psa_hash_setup( &operation, alg ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_hash_setup( &operation, alg ) );
     TEST_ASSERT( psa_hash_verify( &operation,
                                   hash + 1, expected_size ) ==
                  PSA_ERROR_INVALID_SIGNATURE );
 
     /* psa_hash_verify with a hash longer than expected */
-    TEST_ASSERT( psa_hash_setup( &operation, alg ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_hash_setup( &operation, alg ) );
     TEST_ASSERT( psa_hash_verify( &operation,
                                   hash, sizeof( hash ) ) ==
                  PSA_ERROR_INVALID_SIGNATURE );
@@ -1898,10 +1894,10 @@ void hash_finish_bad_args( )
     psa_hash_operation_t operation;
     size_t hash_len;
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
     /* psa_hash_finish with a smaller hash buffer than expected */
-    TEST_ASSERT( psa_hash_setup( &operation, alg ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_hash_setup( &operation, alg ) );
     TEST_ASSERT( psa_hash_finish( &operation,
                                   hash, expected_size - 1,
                                   &hash_len ) == PSA_ERROR_BUFFER_TOO_SMALL );
@@ -1925,18 +1921,18 @@ void mac_setup( int key_type_arg,
     psa_key_policy_t policy;
     psa_status_t status;
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key->len ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key->len ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy,
                               PSA_KEY_USAGE_SIGN | PSA_KEY_USAGE_VERIFY,
                               alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
-    TEST_ASSERT( psa_import_key( handle, key_type,
-                                 key->x, key->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, key_type,
+                                key->x, key->len ) );
 
     status = psa_mac_sign_setup( &operation, handle, alg );
     psa_mac_abort( &operation );
@@ -1972,25 +1968,25 @@ void mac_sign( int key_type_arg,
     TEST_ASSERT( mac_buffer_size <= PSA_MAC_MAX_SIZE );
     TEST_ASSERT( expected_mac->len <= mac_buffer_size );
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key->len ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key->len ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_SIGN, alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
-    TEST_ASSERT( psa_import_key( handle, key_type,
-                                 key->x, key->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, key_type,
+                                key->x, key->len ) );
 
     /* Calculate the MAC. */
-    TEST_ASSERT( psa_mac_sign_setup( &operation,
-                                     handle, alg ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_mac_update( &operation,
-                                 input->x, input->len ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_mac_sign_finish( &operation,
-                                      actual_mac, mac_buffer_size,
-                                      &mac_length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_mac_sign_setup( &operation,
+                                    handle, alg ) );
+    PSA_ASSERT( psa_mac_update( &operation,
+                                input->x, input->len ) );
+    PSA_ASSERT( psa_mac_sign_finish( &operation,
+                                     actual_mac, mac_buffer_size,
+                                     &mac_length ) );
 
     /* Compare with the expected value. */
     TEST_ASSERT( mac_length == expected_mac->len );
@@ -2028,25 +2024,25 @@ void mac_verify( int key_type_arg,
     TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( input->len ) );
     TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( expected_mac->len ) );
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key->len ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key->len ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_VERIFY, alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
-    TEST_ASSERT( psa_import_key( handle, key_type,
-                                 key->x, key->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, key_type,
+                                key->x, key->len ) );
 
-    TEST_ASSERT( psa_mac_verify_setup( &operation,
-                                       handle, alg ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_destroy_key( handle ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_mac_update( &operation,
-                                 input->x, input->len ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_mac_verify_finish( &operation,
-                                        expected_mac->x,
-                                        expected_mac->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_mac_verify_setup( &operation,
+                                      handle, alg ) );
+    PSA_ASSERT( psa_destroy_key( handle ) );
+    PSA_ASSERT( psa_mac_update( &operation,
+                                input->x, input->len ) );
+    PSA_ASSERT( psa_mac_verify_finish( &operation,
+                                       expected_mac->x,
+                                       expected_mac->len ) );
 
 exit:
     psa_destroy_key( handle );
@@ -2068,16 +2064,16 @@ void cipher_setup( int key_type_arg,
     psa_key_policy_t policy;
     psa_status_t status;
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key->len ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key->len ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_ENCRYPT, alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
-    TEST_ASSERT( psa_import_key( handle, key_type,
-                                 key->x, key->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, key_type,
+                                key->x, key->len ) );
 
     status = psa_cipher_encrypt_setup( &operation, handle, alg );
     psa_cipher_abort( &operation );
@@ -2119,30 +2115,30 @@ void cipher_encrypt( int alg_arg, int key_type_arg,
     iv_size = PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type );
     memset( iv, 0x2a, iv_size );
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key->len ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key->len ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_ENCRYPT, alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
-    TEST_ASSERT( psa_import_key( handle, key_type,
-                                 key->x, key->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, key_type,
+                                key->x, key->len ) );
 
-    TEST_ASSERT( psa_cipher_encrypt_setup( &operation,
-                                           handle, alg ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_encrypt_setup( &operation,
+                                          handle, alg ) );
 
-    TEST_ASSERT( psa_cipher_set_iv( &operation,
-                                    iv, iv_size ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_set_iv( &operation,
+                                   iv, iv_size ) );
     output_buffer_size = ( (size_t) input->len +
                            PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type ) );
     ASSERT_ALLOC( output, output_buffer_size );
 
-    TEST_ASSERT( psa_cipher_update( &operation,
-                                    input->x, input->len,
-                                    output, output_buffer_size,
-                                    &function_output_length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_update( &operation,
+                                   input->x, input->len,
+                                   output, output_buffer_size,
+                                   &function_output_length ) );
     total_output_length += function_output_length;
     status = psa_cipher_finish( &operation,
                                 output + function_output_length,
@@ -2153,7 +2149,7 @@ void cipher_encrypt( int alg_arg, int key_type_arg,
     TEST_ASSERT( status == expected_status );
     if( expected_status == PSA_SUCCESS )
     {
-        TEST_ASSERT( psa_cipher_abort( &operation ) == PSA_SUCCESS );
+        PSA_ASSERT( psa_cipher_abort( &operation ) );
         ASSERT_COMPARE( expected_output->x, expected_output->len,
                         output, total_output_length );
     }
@@ -2194,43 +2190,43 @@ void cipher_encrypt_multipart( int alg_arg, int key_type_arg,
     iv_size = PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type );
     memset( iv, 0x2a, iv_size );
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key->len ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key->len ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_ENCRYPT, alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
-    TEST_ASSERT( psa_import_key( handle, key_type,
-                                 key->x, key->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, key_type,
+                                key->x, key->len ) );
 
-    TEST_ASSERT( psa_cipher_encrypt_setup( &operation,
-                                           handle, alg ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_encrypt_setup( &operation,
+                                          handle, alg ) );
 
-    TEST_ASSERT( psa_cipher_set_iv( &operation,
-                                    iv, sizeof( iv ) ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_set_iv( &operation,
+                                   iv, sizeof( iv ) ) );
     output_buffer_size = ( (size_t) input->len +
                            PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type ) );
     ASSERT_ALLOC( output, output_buffer_size );
 
     TEST_ASSERT( (unsigned int) first_part_size < input->len );
-    TEST_ASSERT( psa_cipher_update( &operation, input->x, first_part_size,
-                                    output, output_buffer_size,
-                                    &function_output_length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_update( &operation, input->x, first_part_size,
+                                   output, output_buffer_size,
+                                   &function_output_length ) );
     total_output_length += function_output_length;
-    TEST_ASSERT( psa_cipher_update( &operation,
-                                    input->x + first_part_size,
-                                    input->len - first_part_size,
-                                    output, output_buffer_size,
-                                    &function_output_length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_update( &operation,
+                                   input->x + first_part_size,
+                                   input->len - first_part_size,
+                                   output, output_buffer_size,
+                                   &function_output_length ) );
     total_output_length += function_output_length;
-    TEST_ASSERT( psa_cipher_finish( &operation,
-                                    output + function_output_length,
-                                    output_buffer_size,
-                                    &function_output_length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_finish( &operation,
+                                   output + function_output_length,
+                                   output_buffer_size,
+                                   &function_output_length ) );
     total_output_length += function_output_length;
-    TEST_ASSERT( psa_cipher_abort( &operation ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_abort( &operation ) );
 
     ASSERT_COMPARE( expected_output->x, expected_output->len,
                     output, total_output_length );
@@ -2272,45 +2268,45 @@ void cipher_decrypt_multipart( int alg_arg, int key_type_arg,
     iv_size = PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type );
     memset( iv, 0x2a, iv_size );
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key->len ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key->len ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_DECRYPT, alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
-    TEST_ASSERT( psa_import_key( handle, key_type,
-                                 key->x, key->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, key_type,
+                                key->x, key->len ) );
 
-    TEST_ASSERT( psa_cipher_decrypt_setup( &operation,
-                                           handle, alg ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_decrypt_setup( &operation,
+                                          handle, alg ) );
 
-    TEST_ASSERT( psa_cipher_set_iv( &operation,
-                                    iv, sizeof( iv ) ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_set_iv( &operation,
+                                   iv, sizeof( iv ) ) );
 
     output_buffer_size = ( (size_t) input->len +
                            PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type ) );
     ASSERT_ALLOC( output, output_buffer_size );
 
     TEST_ASSERT( (unsigned int) first_part_size < input->len );
-    TEST_ASSERT( psa_cipher_update( &operation,
-                                    input->x, first_part_size,
-                                    output, output_buffer_size,
-                                    &function_output_length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_update( &operation,
+                                   input->x, first_part_size,
+                                   output, output_buffer_size,
+                                   &function_output_length ) );
     total_output_length += function_output_length;
-    TEST_ASSERT( psa_cipher_update( &operation,
-                                    input->x + first_part_size,
-                                    input->len - first_part_size,
-                                    output, output_buffer_size,
-                                    &function_output_length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_update( &operation,
+                                   input->x + first_part_size,
+                                   input->len - first_part_size,
+                                   output, output_buffer_size,
+                                   &function_output_length ) );
     total_output_length += function_output_length;
-    TEST_ASSERT( psa_cipher_finish( &operation,
-                                    output + function_output_length,
-                                    output_buffer_size,
-                                    &function_output_length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_finish( &operation,
+                                   output + function_output_length,
+                                   output_buffer_size,
+                                   &function_output_length ) );
     total_output_length += function_output_length;
-    TEST_ASSERT( psa_cipher_abort( &operation ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_abort( &operation ) );
 
     ASSERT_COMPARE( expected_output->x, expected_output->len,
                     output, total_output_length );
@@ -2352,31 +2348,31 @@ void cipher_decrypt( int alg_arg, int key_type_arg,
     iv_size = PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type );
     memset( iv, 0x2a, iv_size );
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key->len ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key->len ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_DECRYPT, alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
-    TEST_ASSERT( psa_import_key( handle, key_type,
-                                 key->x, key->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, key_type,
+                                key->x, key->len ) );
 
-    TEST_ASSERT( psa_cipher_decrypt_setup( &operation,
-                                           handle, alg ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_decrypt_setup( &operation,
+                                          handle, alg ) );
 
-    TEST_ASSERT( psa_cipher_set_iv( &operation,
-                                    iv, iv_size ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_set_iv( &operation,
+                                   iv, iv_size ) );
 
     output_buffer_size = ( (size_t) input->len +
                            PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type ) );
     ASSERT_ALLOC( output, output_buffer_size );
 
-    TEST_ASSERT( psa_cipher_update( &operation,
-                                    input->x, input->len,
-                                    output, output_buffer_size,
-                                    &function_output_length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_update( &operation,
+                                   input->x, input->len,
+                                   output, output_buffer_size,
+                                   &function_output_length ) );
     total_output_length += function_output_length;
     status = psa_cipher_finish( &operation,
                                 output + function_output_length,
@@ -2387,7 +2383,7 @@ void cipher_decrypt( int alg_arg, int key_type_arg,
 
     if( expected_status == PSA_SUCCESS )
     {
-        TEST_ASSERT( psa_cipher_abort( &operation ) == PSA_SUCCESS );
+        PSA_ASSERT( psa_cipher_abort( &operation ) );
         ASSERT_COMPARE( expected_output->x, expected_output->len,
                         output, total_output_length );
     }
@@ -2426,57 +2422,57 @@ void cipher_verify_output( int alg_arg, int key_type_arg,
     TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( key->len ) );
     TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( input->len ) );
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key->len ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key->len ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_ENCRYPT | PSA_KEY_USAGE_DECRYPT, alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
-    TEST_ASSERT( psa_import_key( handle, key_type,
-                                 key->x, key->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, key_type,
+                                key->x, key->len ) );
 
-    TEST_ASSERT( psa_cipher_encrypt_setup( &operation1,
-                                           handle, alg ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_cipher_decrypt_setup( &operation2,
-                                           handle, alg ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_encrypt_setup( &operation1,
+                                          handle, alg ) );
+    PSA_ASSERT( psa_cipher_decrypt_setup( &operation2,
+                                          handle, alg ) );
 
-    TEST_ASSERT( psa_cipher_generate_iv( &operation1,
-                                         iv, iv_size,
-                                         &iv_length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_generate_iv( &operation1,
+                                        iv, iv_size,
+                                        &iv_length ) );
     output1_size = ( (size_t) input->len +
                      PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type ) );
     ASSERT_ALLOC( output1, output1_size );
 
-    TEST_ASSERT( psa_cipher_update( &operation1, input->x, input->len,
-                                    output1, output1_size,
-                                    &output1_length ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_cipher_finish( &operation1,
-                                    output1 + output1_length, output1_size,
-                                    &function_output_length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_update( &operation1, input->x, input->len,
+                                   output1, output1_size,
+                                   &output1_length ) );
+    PSA_ASSERT( psa_cipher_finish( &operation1,
+                                   output1 + output1_length, output1_size,
+                                   &function_output_length ) );
 
     output1_length += function_output_length;
 
-    TEST_ASSERT( psa_cipher_abort( &operation1 ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_abort( &operation1 ) );
 
     output2_size = output1_length;
     ASSERT_ALLOC( output2, output2_size );
 
-    TEST_ASSERT( psa_cipher_set_iv( &operation2,
-                                    iv, iv_length ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_cipher_update( &operation2, output1, output1_length,
-                                    output2, output2_size,
-                                    &output2_length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_set_iv( &operation2,
+                                   iv, iv_length ) );
+    PSA_ASSERT( psa_cipher_update( &operation2, output1, output1_length,
+                                   output2, output2_size,
+                                   &output2_length ) );
     function_output_length = 0;
-    TEST_ASSERT( psa_cipher_finish( &operation2,
-                                    output2 + output2_length,
-                                    output2_size,
-                                    &function_output_length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_finish( &operation2,
+                                   output2 + output2_length,
+                                   output2_size,
+                                   &function_output_length ) );
 
     output2_length += function_output_length;
 
-    TEST_ASSERT( psa_cipher_abort( &operation2 ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_abort( &operation2 ) );
 
     ASSERT_COMPARE( input->x, input->len, output2, output2_length );
 
@@ -2517,76 +2513,76 @@ void cipher_verify_output_multipart( int alg_arg,
     TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( key->len ) );
     TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( input->len ) );
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key->len ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key->len ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_ENCRYPT | PSA_KEY_USAGE_DECRYPT, alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
-    TEST_ASSERT( psa_import_key( handle, key_type,
-                                 key->x, key->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, key_type,
+                                key->x, key->len ) );
 
-    TEST_ASSERT( psa_cipher_encrypt_setup( &operation1,
-                                           handle, alg ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_cipher_decrypt_setup( &operation2,
-                                           handle, alg ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_encrypt_setup( &operation1,
+                                          handle, alg ) );
+    PSA_ASSERT( psa_cipher_decrypt_setup( &operation2,
+                                          handle, alg ) );
 
-    TEST_ASSERT( psa_cipher_generate_iv( &operation1,
-                                         iv, iv_size,
-                                         &iv_length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_generate_iv( &operation1,
+                                        iv, iv_size,
+                                        &iv_length ) );
     output1_buffer_size = ( (size_t) input->len +
                             PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type ) );
     ASSERT_ALLOC( output1, output1_buffer_size );
 
     TEST_ASSERT( (unsigned int) first_part_size < input->len );
 
-    TEST_ASSERT( psa_cipher_update( &operation1, input->x, first_part_size,
-                                    output1, output1_buffer_size,
-                                    &function_output_length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_update( &operation1, input->x, first_part_size,
+                                   output1, output1_buffer_size,
+                                   &function_output_length ) );
     output1_length += function_output_length;
 
-    TEST_ASSERT( psa_cipher_update( &operation1,
-                                    input->x + first_part_size,
-                                    input->len - first_part_size,
-                                    output1, output1_buffer_size,
-                                    &function_output_length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_update( &operation1,
+                                   input->x + first_part_size,
+                                   input->len - first_part_size,
+                                   output1, output1_buffer_size,
+                                   &function_output_length ) );
     output1_length += function_output_length;
 
-    TEST_ASSERT( psa_cipher_finish( &operation1,
-                                    output1 + output1_length,
-                                    output1_buffer_size - output1_length,
-                                    &function_output_length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_finish( &operation1,
+                                   output1 + output1_length,
+                                   output1_buffer_size - output1_length,
+                                   &function_output_length ) );
     output1_length += function_output_length;
 
-    TEST_ASSERT( psa_cipher_abort( &operation1 ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_abort( &operation1 ) );
 
     output2_buffer_size = output1_length;
     ASSERT_ALLOC( output2, output2_buffer_size );
 
-    TEST_ASSERT( psa_cipher_set_iv( &operation2,
-                                    iv, iv_length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_set_iv( &operation2,
+                                   iv, iv_length ) );
 
-    TEST_ASSERT( psa_cipher_update( &operation2, output1, first_part_size,
-                                    output2, output2_buffer_size,
-                                    &function_output_length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_update( &operation2, output1, first_part_size,
+                                   output2, output2_buffer_size,
+                                   &function_output_length ) );
     output2_length += function_output_length;
 
-    TEST_ASSERT( psa_cipher_update( &operation2,
-                                    output1 + first_part_size,
-                                    output1_length - first_part_size,
-                                    output2, output2_buffer_size,
-                                    &function_output_length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_update( &operation2,
+                                   output1 + first_part_size,
+                                   output1_length - first_part_size,
+                                   output2, output2_buffer_size,
+                                   &function_output_length ) );
     output2_length += function_output_length;
 
-    TEST_ASSERT( psa_cipher_finish( &operation2,
-                                    output2 + output2_length,
-                                    output2_buffer_size - output2_length,
-                                    &function_output_length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_finish( &operation2,
+                                   output2 + output2_length,
+                                   output2_buffer_size - output2_length,
+                                   &function_output_length ) );
     output2_length += function_output_length;
 
-    TEST_ASSERT( psa_cipher_abort( &operation2 ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_cipher_abort( &operation2 ) );
 
     ASSERT_COMPARE( input->x, input->len, output2, output2_length );
 
@@ -2630,18 +2626,18 @@ void aead_encrypt_decrypt( int key_type_arg, data_t *key_data,
     output_size = input_data->len + tag_length;
     ASSERT_ALLOC( output_data, output_size );
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key_data->len ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key_data->len ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy,
                               PSA_KEY_USAGE_ENCRYPT | PSA_KEY_USAGE_DECRYPT,
                               alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
-    TEST_ASSERT( psa_import_key( handle, key_type,
-                                 key_data->x, key_data->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, key_type,
+                                key_data->x, key_data->len ) );
 
     TEST_ASSERT( psa_aead_encrypt( handle, alg,
                                    nonce->x, nonce->len,
@@ -2706,24 +2702,24 @@ void aead_encrypt( int key_type_arg, data_t *key_data,
     output_size = input_data->len + tag_length;
     ASSERT_ALLOC( output_data, output_size );
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key_data->len ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key_data->len ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_ENCRYPT , alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
-    TEST_ASSERT( psa_import_key( handle, key_type,
-                                 key_data->x,
-                                 key_data->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, key_type,
+                                key_data->x,
+                                key_data->len ) );
 
-    TEST_ASSERT( psa_aead_encrypt( handle, alg,
-                                   nonce->x, nonce->len,
-                                   additional_data->x, additional_data->len,
-                                   input_data->x, input_data->len,
-                                   output_data, output_size,
-                                   &output_length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_aead_encrypt( handle, alg,
+                                  nonce->x, nonce->len,
+                                  additional_data->x, additional_data->len,
+                                  input_data->x, input_data->len,
+                                  output_data, output_size,
+                                  &output_length ) );
 
     ASSERT_COMPARE( expected_result->x, expected_result->len,
                     output_data, output_length );
@@ -2768,17 +2764,17 @@ void aead_decrypt( int key_type_arg, data_t *key_data,
     output_size = input_data->len + tag_length;
     ASSERT_ALLOC( output_data, output_size );
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key_data->len ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key_data->len ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_DECRYPT , alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
-    TEST_ASSERT( psa_import_key( handle, key_type,
-                                 key_data->x,
-                                 key_data->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, key_type,
+                                key_data->x,
+                                key_data->len ) );
 
     TEST_ASSERT( psa_aead_decrypt( handle, alg,
                                    nonce->x, nonce->len,
@@ -2835,21 +2831,21 @@ void sign_deterministic( int key_type_arg, data_t *key_data,
     TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( input_data->len ) );
     TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( output_data->len ) );
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( key_type,
-                                   KEY_BITS_FROM_DATA( key_type, key_data ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( key_type,
+                                  KEY_BITS_FROM_DATA( key_type, key_data ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_SIGN, alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
-    TEST_ASSERT( psa_import_key( handle, key_type,
-                                 key_data->x,
-                                 key_data->len ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_get_key_information( handle,
-                                          NULL,
-                                          &key_bits ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, key_type,
+                                key_data->x,
+                                key_data->len ) );
+    PSA_ASSERT( psa_get_key_information( handle,
+                                         NULL,
+                                         &key_bits ) );
 
     /* Allocate a buffer which has the size advertized by the
      * library. */
@@ -2860,10 +2856,10 @@ void sign_deterministic( int key_type_arg, data_t *key_data,
     ASSERT_ALLOC( signature, signature_size );
 
     /* Perform the signature. */
-    TEST_ASSERT( psa_asymmetric_sign( handle, alg,
-                                      input_data->x, input_data->len,
-                                      signature, signature_size,
-                                      &signature_length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_asymmetric_sign( handle, alg,
+                                     input_data->x, input_data->len,
+                                     signature, signature_size,
+                                     &signature_length ) );
     /* Verify that the signature is what is expected. */
     ASSERT_COMPARE( output_data->x, output_data->len,
                     signature, signature_length );
@@ -2897,18 +2893,18 @@ void sign_fail( int key_type_arg, data_t *key_data,
 
     ASSERT_ALLOC( signature, signature_size );
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( key_type,
-                                   KEY_BITS_FROM_DATA( key_type, key_data ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( key_type,
+                                  KEY_BITS_FROM_DATA( key_type, key_data ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_SIGN, alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
-    TEST_ASSERT( psa_import_key( handle, key_type,
-                                 key_data->x,
-                                 key_data->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, key_type,
+                                key_data->x,
+                                key_data->len ) );
 
     actual_status = psa_asymmetric_sign( handle, alg,
                                          input_data->x, input_data->len,
@@ -2941,23 +2937,23 @@ void sign_verify( int key_type_arg, data_t *key_data,
     size_t signature_length = 0xdeadbeef;
     psa_key_policy_t policy;
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( key_type,
-                                   KEY_BITS_FROM_DATA( key_type, key_data ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( key_type,
+                                  KEY_BITS_FROM_DATA( key_type, key_data ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy,
                               PSA_KEY_USAGE_SIGN | PSA_KEY_USAGE_VERIFY,
                               alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
-    TEST_ASSERT( psa_import_key( handle, key_type,
-                                 key_data->x,
-                                 key_data->len ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_get_key_information( handle,
-                                          NULL,
-                                          &key_bits ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, key_type,
+                                key_data->x,
+                                key_data->len ) );
+    PSA_ASSERT( psa_get_key_information( handle,
+                                         NULL,
+                                         &key_bits ) );
 
     /* Allocate a buffer which has the size advertized by the
      * library. */
@@ -2968,19 +2964,19 @@ void sign_verify( int key_type_arg, data_t *key_data,
     ASSERT_ALLOC( signature, signature_size );
 
     /* Perform the signature. */
-    TEST_ASSERT( psa_asymmetric_sign( handle, alg,
-                                      input_data->x, input_data->len,
-                                      signature, signature_size,
-                                      &signature_length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_asymmetric_sign( handle, alg,
+                                     input_data->x, input_data->len,
+                                     signature, signature_size,
+                                     &signature_length ) );
     /* Check that the signature length looks sensible. */
     TEST_ASSERT( signature_length <= signature_size );
     TEST_ASSERT( signature_length > 0 );
 
     /* Use the library to verify that the signature is correct. */
-    TEST_ASSERT( psa_asymmetric_verify(
-                     handle, alg,
-                     input_data->x, input_data->len,
-                     signature, signature_length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_asymmetric_verify(
+                    handle, alg,
+                    input_data->x, input_data->len,
+                    signature, signature_length ) );
 
     if( input_data->len != 0 )
     {
@@ -3021,23 +3017,23 @@ void asymmetric_verify( int key_type_arg, data_t *key_data,
     TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( hash_data->len ) );
     TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( signature_data->len ) );
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( key_type,
-                                   KEY_BITS_FROM_DATA( key_type, key_data ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( key_type,
+                                  KEY_BITS_FROM_DATA( key_type, key_data ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_VERIFY, alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
-    TEST_ASSERT( psa_import_key( handle, key_type,
-                                 key_data->x,
-                                 key_data->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, key_type,
+                                key_data->x,
+                                key_data->len ) );
 
-    TEST_ASSERT( psa_asymmetric_verify( handle, alg,
-                                        hash_data->x, hash_data->len,
-                                        signature_data->x,
-                                        signature_data->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_asymmetric_verify( handle, alg,
+                                       hash_data->x, hash_data->len,
+                                       signature_data->x,
+                                       signature_data->len ) );
 exit:
     psa_destroy_key( handle );
     mbedtls_psa_crypto_free( );
@@ -3064,18 +3060,18 @@ void asymmetric_verify_fail( int key_type_arg, data_t *key_data,
     TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( hash_data->len ) );
     TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( signature_data->len ) );
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( key_type,
-                                   KEY_BITS_FROM_DATA( key_type, key_data ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( key_type,
+                                  KEY_BITS_FROM_DATA( key_type, key_data ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_VERIFY, alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
-    TEST_ASSERT( psa_import_key( handle, key_type,
-                                 key_data->x,
-                                 key_data->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, key_type,
+                                key_data->x,
+                                key_data->len ) );
 
     actual_status = psa_asymmetric_verify( handle, alg,
                                            hash_data->x, hash_data->len,
@@ -3111,24 +3107,23 @@ void asymmetric_encrypt( int key_type_arg,
     psa_status_t expected_status = expected_status_arg;
     psa_key_policy_t policy;
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
-
+    PSA_ASSERT( psa_crypto_init( ) );
 
     /* Import the key */
-    TEST_ASSERT( psa_allocate_key( key_type,
-                                   KEY_BITS_FROM_DATA( key_type, key_data ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( key_type,
+                                  KEY_BITS_FROM_DATA( key_type, key_data ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_ENCRYPT, alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_import_key( handle, key_type,
-                                 key_data->x,
-                                 key_data->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
+    PSA_ASSERT( psa_import_key( handle, key_type,
+                                key_data->x,
+                                key_data->len ) );
 
     /* Determine the maximum output length */
-    TEST_ASSERT( psa_get_key_information( handle,
-                                          NULL,
-                                          &key_bits ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_get_key_information( handle,
+                                         NULL,
+                                         &key_bits ) );
     output_size = PSA_ASYMMETRIC_ENCRYPT_OUTPUT_SIZE( key_type, key_bits, alg );
     ASSERT_ALLOC( output, output_size );
 
@@ -3188,26 +3183,25 @@ void asymmetric_encrypt_decrypt( int key_type_arg,
     TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( key_data->len ) );
     TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( input_data->len ) );
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( key_type,
-                                   KEY_BITS_FROM_DATA( key_type, key_data ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( key_type,
+                                  KEY_BITS_FROM_DATA( key_type, key_data ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy,
                               PSA_KEY_USAGE_ENCRYPT | PSA_KEY_USAGE_DECRYPT,
                               alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
-    TEST_ASSERT( psa_import_key( handle, key_type,
-                                 key_data->x,
-                                 key_data->len ) == PSA_SUCCESS );
-
+    PSA_ASSERT( psa_import_key( handle, key_type,
+                                key_data->x,
+                                key_data->len ) );
 
     /* Determine the maximum ciphertext length */
-    TEST_ASSERT( psa_get_key_information( handle,
-                                          NULL,
-                                          &key_bits ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_get_key_information( handle,
+                                         NULL,
+                                         &key_bits ) );
     output_size = PSA_ASYMMETRIC_ENCRYPT_OUTPUT_SIZE( key_type, key_bits, alg );
     ASSERT_ALLOC( output, output_size );
     output2_size = input_data->len;
@@ -3216,20 +3210,20 @@ void asymmetric_encrypt_decrypt( int key_type_arg,
     /* We test encryption by checking that encrypt-then-decrypt gives back
      * the original plaintext because of the non-optional random
      * part of encryption process which prevents using fixed vectors. */
-    TEST_ASSERT( psa_asymmetric_encrypt( handle, alg,
-                                         input_data->x, input_data->len,
-                                         label->x, label->len,
-                                         output, output_size,
-                                         &output_length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_asymmetric_encrypt( handle, alg,
+                                        input_data->x, input_data->len,
+                                        label->x, label->len,
+                                        output, output_size,
+                                        &output_length ) );
     /* We don't know what ciphertext length to expect, but check that
      * it looks sensible. */
     TEST_ASSERT( output_length <= output_size );
 
-    TEST_ASSERT( psa_asymmetric_decrypt( handle, alg,
-                                         output, output_length,
-                                         label->x, label->len,
-                                         output2, output2_size,
-                                         &output2_length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_asymmetric_decrypt( handle, alg,
+                                        output, output_length,
+                                        label->x, label->len,
+                                        output2, output2_size,
+                                        &output2_length ) );
     ASSERT_COMPARE( input_data->x, input_data->len,
                     output2, output2_length );
 
@@ -3267,25 +3261,25 @@ void asymmetric_decrypt( int key_type_arg,
     output_size = key_data->len;
     ASSERT_ALLOC( output, output_size );
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( key_type,
-                                   KEY_BITS_FROM_DATA( key_type, key_data ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( key_type,
+                                  KEY_BITS_FROM_DATA( key_type, key_data ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_DECRYPT, alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
-    TEST_ASSERT( psa_import_key( handle, key_type,
-                                 key_data->x,
-                                 key_data->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, key_type,
+                                key_data->x,
+                                key_data->len ) );
 
-    TEST_ASSERT( psa_asymmetric_decrypt( handle, alg,
-                                         input_data->x, input_data->len,
-                                         label->x, label->len,
-                                         output,
-                                         output_size,
-                                         &output_length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_asymmetric_decrypt( handle, alg,
+                                        input_data->x, input_data->len,
+                                        label->x, label->len,
+                                        output,
+                                        output_size,
+                                        &output_length ) );
     ASSERT_COMPARE( expected_data->x, expected_data->len,
                     output, output_length );
 
@@ -3296,12 +3290,12 @@ void asymmetric_decrypt( int key_type_arg,
         output_length = ~0;
         if( output_size != 0 )
             memset( output, 0, output_size );
-        TEST_ASSERT( psa_asymmetric_decrypt( handle, alg,
-                                             input_data->x, input_data->len,
-                                             NULL, label->len,
-                                             output,
-                                             output_size,
-                                             &output_length ) == PSA_SUCCESS );
+        PSA_ASSERT( psa_asymmetric_decrypt( handle, alg,
+                                            input_data->x, input_data->len,
+                                            NULL, label->len,
+                                            output,
+                                            output_size,
+                                            &output_length ) );
         ASSERT_COMPARE( expected_data->x, expected_data->len,
                         output, output_length );
     }
@@ -3339,18 +3333,18 @@ void asymmetric_decrypt_fail( int key_type_arg,
     output_size = key_data->len;
     ASSERT_ALLOC( output, output_size );
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( key_type,
-                                   KEY_BITS_FROM_DATA( key_type, key_data ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( key_type,
+                                  KEY_BITS_FROM_DATA( key_type, key_data ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_DECRYPT, alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
-    TEST_ASSERT( psa_import_key( handle, key_type,
-                                 key_data->x,
-                                 key_data->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, key_type,
+                                key_data->x,
+                                key_data->len ) );
 
     actual_status = psa_asymmetric_decrypt( handle, alg,
                                             input_data->x, input_data->len,
@@ -3400,17 +3394,17 @@ void derive_setup( int key_type_arg,
     psa_crypto_generator_t generator = PSA_CRYPTO_GENERATOR_INIT;
     psa_key_policy_t policy;
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key_data->len ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key_data->len ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_DERIVE, alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
-    TEST_ASSERT( psa_import_key( handle, key_type,
-                                 key_data->x,
-                                 key_data->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, key_type,
+                                key_data->x,
+                                key_data->len ) );
 
     TEST_ASSERT( psa_key_derivation( &generator, handle, alg,
                                      salt->x, salt->len,
@@ -3438,24 +3432,24 @@ void test_derive_invalid_generator_state( )
                                    0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b};
     psa_key_policy_t policy;
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( key_type,
-                                   PSA_BYTES_TO_BITS( sizeof( key_data ) ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( key_type,
+                                  PSA_BYTES_TO_BITS( sizeof( key_data ) ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_DERIVE, alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
-    TEST_ASSERT( psa_import_key( handle, key_type,
-                                 key_data,
-                                 sizeof( key_data ) ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, key_type,
+                                key_data,
+                                sizeof( key_data ) ) );
 
     /* valid key derivation */
-    TEST_ASSERT(  psa_key_derivation( &generator, handle, alg,
-                                      NULL, 0,
-                                      NULL, 0,
-                                      capacity ) == PSA_SUCCESS );
+    PSA_ASSERT(  psa_key_derivation( &generator, handle, alg,
+                                     NULL, 0,
+                                     NULL, 0,
+                                     capacity ) );
 
     /* state of generator shouldn't allow additional generation */
     TEST_ASSERT(  psa_key_derivation( &generator, handle, alg,
@@ -3463,12 +3457,11 @@ void test_derive_invalid_generator_state( )
                                       NULL, 0,
                                       capacity ) == PSA_ERROR_BAD_STATE );
 
-    TEST_ASSERT( psa_generator_read( &generator, buffer, capacity )
-                 == PSA_SUCCESS );
+    PSA_ASSERT( psa_generator_read( &generator, buffer, capacity )
+        );
 
     TEST_ASSERT( psa_generator_read( &generator, buffer, capacity )
                  == PSA_ERROR_INSUFFICIENT_CAPACITY );
-
 
 exit:
     psa_generator_abort( &generator );
@@ -3476,7 +3469,6 @@ exit:
     mbedtls_psa_crypto_free( );
 }
 /* END_CASE */
-
 
 /* BEGIN_CASE */
 void test_derive_invalid_generator_tests( )
@@ -3492,7 +3484,7 @@ void test_derive_invalid_generator_tests( )
     TEST_ASSERT( psa_get_generator_capacity( &generator, &capacity )
                  == PSA_SUCCESS ); // should be PSA_ERROR_BAD_STATE:#183
 
-    TEST_ASSERT( psa_generator_abort( &generator ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_generator_abort( &generator ) );
 
     TEST_ASSERT( psa_generator_read( &generator, output_buffer, buffer_size )
                  == PSA_ERROR_INSUFFICIENT_CAPACITY ); // should be PSA_ERROR_BAD_STATE:#183
@@ -3538,27 +3530,26 @@ void derive_output( int alg_arg,
             expected_outputs[i] = NULL;
     }
     ASSERT_ALLOC( output_buffer, output_buffer_size );
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( PSA_KEY_TYPE_DERIVE,
-                                   PSA_BYTES_TO_BITS( key_data->len ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( PSA_KEY_TYPE_DERIVE,
+                                  PSA_BYTES_TO_BITS( key_data->len ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_DERIVE, alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
-    TEST_ASSERT( psa_import_key( handle, PSA_KEY_TYPE_DERIVE,
-                                 key_data->x,
-                                 key_data->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, PSA_KEY_TYPE_DERIVE,
+                                key_data->x,
+                                key_data->len ) );
 
     /* Extraction phase. */
-    TEST_ASSERT( psa_key_derivation( &generator, handle, alg,
-                                     salt->x, salt->len,
-                                     label->x, label->len,
-                                     requested_capacity ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_get_generator_capacity( &generator,
-                                             &current_capacity ) ==
-                 PSA_SUCCESS );
+    PSA_ASSERT( psa_key_derivation( &generator, handle, alg,
+                                    salt->x, salt->len,
+                                    label->x, label->len,
+                                    requested_capacity ) );
+    PSA_ASSERT( psa_get_generator_capacity( &generator,
+                                            &current_capacity ) );
     TEST_ASSERT( current_capacity == requested_capacity );
     expected_capacity = requested_capacity;
 
@@ -3584,18 +3575,17 @@ void derive_output( int alg_arg,
             continue;
         }
         /* Success. Check the read data. */
-        TEST_ASSERT( status == PSA_SUCCESS );
+        PSA_ASSERT( status );
         if( output_sizes[i] != 0 )
             TEST_ASSERT( memcmp( output_buffer, expected_outputs[i],
                                  output_sizes[i] ) == 0 );
         /* Check the generator status. */
         expected_capacity -= output_sizes[i];
-        TEST_ASSERT( psa_get_generator_capacity( &generator,
-                                                 &current_capacity ) ==
-                     PSA_SUCCESS );
+        PSA_ASSERT( psa_get_generator_capacity( &generator,
+                                                &current_capacity ) );
         TEST_ASSERT( expected_capacity == current_capacity );
     }
-    TEST_ASSERT( psa_generator_abort( &generator ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_generator_abort( &generator ) );
 
 exit:
     mbedtls_free( output_buffer );
@@ -3621,27 +3611,26 @@ void derive_full( int alg_arg,
     size_t current_capacity;
     psa_key_policy_t policy;
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( PSA_KEY_TYPE_DERIVE,
-                                   PSA_BYTES_TO_BITS( key_data->len ),
-                                   &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( PSA_KEY_TYPE_DERIVE,
+                                  PSA_BYTES_TO_BITS( key_data->len ),
+                                  &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_DERIVE, alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
-    TEST_ASSERT( psa_import_key( handle, PSA_KEY_TYPE_DERIVE,
-                                 key_data->x,
-                                 key_data->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, PSA_KEY_TYPE_DERIVE,
+                                key_data->x,
+                                key_data->len ) );
 
     /* Extraction phase. */
-    TEST_ASSERT( psa_key_derivation( &generator, handle, alg,
-                                     salt->x, salt->len,
-                                     label->x, label->len,
-                                     requested_capacity ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_get_generator_capacity( &generator,
-                                             &current_capacity ) ==
-                 PSA_SUCCESS );
+    PSA_ASSERT( psa_key_derivation( &generator, handle, alg,
+                                    salt->x, salt->len,
+                                    label->x, label->len,
+                                    requested_capacity ) );
+    PSA_ASSERT( psa_get_generator_capacity( &generator,
+                                            &current_capacity ) );
     TEST_ASSERT( current_capacity == expected_capacity );
 
     /* Expansion phase. */
@@ -3650,13 +3639,12 @@ void derive_full( int alg_arg,
         size_t read_size = sizeof( output_buffer );
         if( read_size > current_capacity )
             read_size = current_capacity;
-        TEST_ASSERT( psa_generator_read( &generator,
-                                         output_buffer,
-                                         read_size ) == PSA_SUCCESS );
+        PSA_ASSERT( psa_generator_read( &generator,
+                                        output_buffer,
+                                        read_size ) );
         expected_capacity -= read_size;
-        TEST_ASSERT( psa_get_generator_capacity( &generator,
-                                                 &current_capacity ) ==
-                     PSA_SUCCESS );
+        PSA_ASSERT( psa_get_generator_capacity( &generator,
+                                                &current_capacity ) );
         TEST_ASSERT( current_capacity == expected_capacity );
     }
 
@@ -3665,7 +3653,7 @@ void derive_full( int alg_arg,
                                      output_buffer,
                                      1 ) == PSA_ERROR_INSUFFICIENT_CAPACITY );
 
-    TEST_ASSERT( psa_generator_abort( &generator ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_generator_abort( &generator ) );
 
 exit:
     psa_generator_abort( &generator );
@@ -3697,36 +3685,36 @@ void derive_key_exercise( int alg_arg,
     psa_key_type_t got_type;
     size_t got_bits;
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( PSA_KEY_TYPE_DERIVE,
-                                   PSA_BYTES_TO_BITS( key_data->len ),
-                                   &base_handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( PSA_KEY_TYPE_DERIVE,
+                                  PSA_BYTES_TO_BITS( key_data->len ),
+                                  &base_handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_DERIVE, alg );
-    TEST_ASSERT( psa_set_key_policy( base_handle, &policy ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_import_key( base_handle, PSA_KEY_TYPE_DERIVE,
-                                 key_data->x,
-                                 key_data->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( base_handle, &policy ) );
+    PSA_ASSERT( psa_import_key( base_handle, PSA_KEY_TYPE_DERIVE,
+                                key_data->x,
+                                key_data->len ) );
 
     /* Derive a key. */
-    TEST_ASSERT( psa_key_derivation( &generator, base_handle, alg,
-                                     salt->x, salt->len,
-                                     label->x, label->len,
-                                     capacity ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_allocate_key( derived_type, derived_bits,
-                                   &derived_handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_key_derivation( &generator, base_handle, alg,
+                                    salt->x, salt->len,
+                                    label->x, label->len,
+                                    capacity ) );
+    PSA_ASSERT( psa_allocate_key( derived_type, derived_bits,
+                                  &derived_handle ) );
     psa_key_policy_set_usage( &policy, derived_usage, derived_alg );
-    TEST_ASSERT( psa_set_key_policy( derived_handle, &policy ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_generator_import_key( derived_handle,
-                                           derived_type,
-                                           derived_bits,
-                                           &generator ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( derived_handle, &policy ) );
+    PSA_ASSERT( psa_generator_import_key( derived_handle,
+                                          derived_type,
+                                          derived_bits,
+                                          &generator ) );
 
     /* Test the key information */
-    TEST_ASSERT( psa_get_key_information( derived_handle,
-                                          &got_type,
-                                          &got_bits ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_get_key_information( derived_handle,
+                                         &got_type,
+                                         &got_bits ) );
     TEST_ASSERT( got_type == derived_type );
     TEST_ASSERT( got_bits == derived_bits );
 
@@ -3765,57 +3753,57 @@ void derive_key_export( int alg_arg,
 
     ASSERT_ALLOC( output_buffer, capacity );
     ASSERT_ALLOC( export_buffer, capacity );
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( PSA_KEY_TYPE_DERIVE,
-                                   PSA_BYTES_TO_BITS( key_data->len ),
-                                   &base_handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( PSA_KEY_TYPE_DERIVE,
+                                  PSA_BYTES_TO_BITS( key_data->len ),
+                                  &base_handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_DERIVE, alg );
-    TEST_ASSERT( psa_set_key_policy( base_handle, &policy ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_import_key( base_handle, PSA_KEY_TYPE_DERIVE,
-                                 key_data->x,
-                                 key_data->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( base_handle, &policy ) );
+    PSA_ASSERT( psa_import_key( base_handle, PSA_KEY_TYPE_DERIVE,
+                                key_data->x,
+                                key_data->len ) );
 
     /* Derive some material and output it. */
-    TEST_ASSERT( psa_key_derivation( &generator, base_handle, alg,
-                                     salt->x, salt->len,
-                                     label->x, label->len,
-                                     capacity ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_generator_read( &generator,
-                                     output_buffer,
-                                     capacity ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_generator_abort( &generator ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_key_derivation( &generator, base_handle, alg,
+                                    salt->x, salt->len,
+                                    label->x, label->len,
+                                    capacity ) );
+    PSA_ASSERT( psa_generator_read( &generator,
+                                    output_buffer,
+                                    capacity ) );
+    PSA_ASSERT( psa_generator_abort( &generator ) );
 
     /* Derive the same output again, but this time store it in key objects. */
-    TEST_ASSERT( psa_key_derivation( &generator, base_handle, alg,
-                                     salt->x, salt->len,
-                                     label->x, label->len,
-                                     capacity ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_allocate_key( PSA_KEY_TYPE_RAW_DATA, derived_bits,
-                                   &derived_handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_key_derivation( &generator, base_handle, alg,
+                                    salt->x, salt->len,
+                                    label->x, label->len,
+                                    capacity ) );
+    PSA_ASSERT( psa_allocate_key( PSA_KEY_TYPE_RAW_DATA, derived_bits,
+                                  &derived_handle ) );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_EXPORT, 0 );
-    TEST_ASSERT( psa_set_key_policy( derived_handle, &policy ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_generator_import_key( derived_handle,
-                                           PSA_KEY_TYPE_RAW_DATA,
-                                           derived_bits,
-                                           &generator ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_export_key( derived_handle,
-                                 export_buffer, bytes1,
-                                 &length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( derived_handle, &policy ) );
+    PSA_ASSERT( psa_generator_import_key( derived_handle,
+                                          PSA_KEY_TYPE_RAW_DATA,
+                                          derived_bits,
+                                          &generator ) );
+    PSA_ASSERT( psa_export_key( derived_handle,
+                                export_buffer, bytes1,
+                                &length ) );
     TEST_ASSERT( length == bytes1 );
-    TEST_ASSERT( psa_destroy_key( derived_handle ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_allocate_key( PSA_KEY_TYPE_RAW_DATA,
-                                   PSA_BYTES_TO_BITS( bytes2 ),
-                                   &derived_handle ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_set_key_policy( derived_handle, &policy ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_generator_import_key( derived_handle,
-                                           PSA_KEY_TYPE_RAW_DATA,
-                                           PSA_BYTES_TO_BITS( bytes2 ),
-                                           &generator ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_export_key( derived_handle,
-                                 export_buffer + bytes1, bytes2,
-                                 &length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_destroy_key( derived_handle ) );
+    PSA_ASSERT( psa_allocate_key( PSA_KEY_TYPE_RAW_DATA,
+                                  PSA_BYTES_TO_BITS( bytes2 ),
+                                  &derived_handle ) );
+    PSA_ASSERT( psa_set_key_policy( derived_handle, &policy ) );
+    PSA_ASSERT( psa_generator_import_key( derived_handle,
+                                          PSA_KEY_TYPE_RAW_DATA,
+                                          PSA_BYTES_TO_BITS( bytes2 ),
+                                          &generator ) );
+    PSA_ASSERT( psa_export_key( derived_handle,
+                                export_buffer + bytes1, bytes2,
+                                &length ) );
     TEST_ASSERT( length == bytes2 );
 
     /* Compare the outputs from the two runs. */
@@ -3843,18 +3831,18 @@ void key_agreement_setup( int alg_arg,
     psa_crypto_generator_t generator = PSA_CRYPTO_GENERATOR_INIT;
     psa_key_policy_t policy;
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( our_key_type,
-                                   KEY_BITS_FROM_DATA( our_key_type,
-                                                       our_key_data ),
-                                   &our_key ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( our_key_type,
+                                  KEY_BITS_FROM_DATA( our_key_type,
+                                                      our_key_data ),
+                                  &our_key ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_DERIVE, alg );
-    TEST_ASSERT( psa_set_key_policy( our_key, &policy ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_import_key( our_key, our_key_type,
-                                 our_key_data->x,
-                                 our_key_data->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( our_key, &policy ) );
+    PSA_ASSERT( psa_import_key( our_key, our_key_type,
+                                our_key_data->x,
+                                our_key_data->len ) );
 
     TEST_ASSERT( psa_key_agreement( &generator,
                                     our_key,
@@ -3882,40 +3870,38 @@ void key_agreement_capacity( int alg_arg,
     size_t actual_capacity;
     unsigned char output[16];
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( our_key_type,
-                                   KEY_BITS_FROM_DATA( our_key_type,
-                                                       our_key_data ),
-                                   &our_key ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( our_key_type,
+                                  KEY_BITS_FROM_DATA( our_key_type,
+                                                      our_key_data ),
+                                  &our_key ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_DERIVE, alg );
-    TEST_ASSERT( psa_set_key_policy( our_key, &policy ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_import_key( our_key, our_key_type,
-                                 our_key_data->x,
-                                 our_key_data->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( our_key, &policy ) );
+    PSA_ASSERT( psa_import_key( our_key, our_key_type,
+                                our_key_data->x,
+                                our_key_data->len ) );
 
-    TEST_ASSERT( psa_key_agreement( &generator,
-                                    our_key,
-                                    peer_key_data->x, peer_key_data->len,
-                                    alg ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_key_agreement( &generator,
+                                   our_key,
+                                   peer_key_data->x, peer_key_data->len,
+                                   alg ) );
 
     /* Test the advertized capacity. */
-    TEST_ASSERT( psa_get_generator_capacity(
-                     &generator, &actual_capacity ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_get_generator_capacity(
+                    &generator, &actual_capacity ) );
     TEST_ASSERT( actual_capacity == (size_t) expected_capacity_arg );
 
     /* Test the actual capacity by reading the output. */
     while( actual_capacity > sizeof( output ) )
     {
-        TEST_ASSERT( psa_generator_read( &generator,
-                                         output, sizeof( output ) ) ==
-                     PSA_SUCCESS );
+        PSA_ASSERT( psa_generator_read( &generator,
+                                        output, sizeof( output ) ) );
         actual_capacity -= sizeof( output );
     }
-    TEST_ASSERT( psa_generator_read( &generator,
-                                     output, actual_capacity ) ==
-                 PSA_SUCCESS );
+    PSA_ASSERT( psa_generator_read( &generator,
+                                    output, actual_capacity ) );
     TEST_ASSERT( psa_generator_read( &generator, output, 1 ) ==
                  PSA_ERROR_INSUFFICIENT_CAPACITY );
 
@@ -3942,36 +3928,36 @@ void key_agreement_output( int alg_arg,
     ASSERT_ALLOC( actual_output, MAX( expected_output1->len,
                                       expected_output2->len ) );
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( our_key_type,
-                                   KEY_BITS_FROM_DATA( our_key_type,
-                                                       our_key_data ),
-                                   &our_key ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( our_key_type,
+                                  KEY_BITS_FROM_DATA( our_key_type,
+                                                      our_key_data ),
+                                  &our_key ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_DERIVE, alg );
-    TEST_ASSERT( psa_set_key_policy( our_key, &policy ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_import_key( our_key, our_key_type,
-                                 our_key_data->x,
-                                 our_key_data->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( our_key, &policy ) );
+    PSA_ASSERT( psa_import_key( our_key, our_key_type,
+                                our_key_data->x,
+                                our_key_data->len ) );
 
-    TEST_ASSERT( psa_key_agreement( &generator,
-                                    our_key,
-                                    peer_key_data->x, peer_key_data->len,
-                                    alg ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_key_agreement( &generator,
+                                   our_key,
+                                   peer_key_data->x, peer_key_data->len,
+                                   alg ) );
 
-    TEST_ASSERT(
+    PSA_ASSERT(
         psa_generator_read( &generator,
                             actual_output,
-                            expected_output1->len ) == PSA_SUCCESS );
+                            expected_output1->len ) );
     TEST_ASSERT( memcmp( actual_output, expected_output1->x,
                          expected_output1->len ) == 0 );
     if( expected_output2->len != 0 )
     {
-        TEST_ASSERT(
+        PSA_ASSERT(
             psa_generator_read( &generator,
                                 actual_output,
-                                expected_output2->len ) == PSA_SUCCESS );
+                                expected_output2->len ) );
         TEST_ASSERT( memcmp( actual_output, expected_output2->x,
                              expected_output2->len ) == 0 );
     }
@@ -3998,7 +3984,7 @@ void generate_random( int bytes_arg )
     ASSERT_ALLOC( changed, bytes );
     memcpy( output + bytes, trail, sizeof( trail ) );
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
     /* Run several times, to ensure that every output byte will be
      * nonzero at least once with overwhelming probability
@@ -4007,7 +3993,7 @@ void generate_random( int bytes_arg )
     {
         if( bytes != 0 )
             memset( output, 0, bytes );
-        TEST_ASSERT( psa_generate_random( output, bytes ) == PSA_SUCCESS );
+        PSA_ASSERT( psa_generate_random( output, bytes ) );
 
         /* Check that no more than bytes have been overwritten */
         TEST_ASSERT( memcmp( output + bytes, trail, sizeof( trail ) ) == 0 );
@@ -4053,12 +4039,12 @@ void generate_key( int type_arg,
         expected_status == PSA_SUCCESS ? PSA_SUCCESS : PSA_ERROR_EMPTY_SLOT;
     psa_key_policy_t policy;
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_allocate_key( type, bits, &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_allocate_key( type, bits, &handle ) );
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, usage, alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
     /* Generate a key */
     TEST_ASSERT( psa_generate_key( handle, type, bits,
@@ -4110,50 +4096,50 @@ void persistent_key_load_key_from_storage( data_t *data, int type_arg,
     ASSERT_ALLOC( first_export, export_size );
     ASSERT_ALLOC( second_export, export_size );
 
-    TEST_ASSERT( psa_crypto_init() == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init() );
 
-    TEST_ASSERT( psa_create_key( PSA_KEY_LIFETIME_PERSISTENT, 1,
-                                 type, bits,
-                                 &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_create_key( PSA_KEY_LIFETIME_PERSISTENT, 1,
+                                type, bits,
+                                &handle ) );
     psa_key_policy_init( &policy_set );
     psa_key_policy_set_usage( &policy_set, policy_usage,
                               policy_alg );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy_set ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy_set ) );
 
     switch( generation_method )
     {
         case IMPORT_KEY:
             /* Import the key */
-            TEST_ASSERT( psa_import_key( handle, type,
-                                         data->x, data->len ) == PSA_SUCCESS );
+            PSA_ASSERT( psa_import_key( handle, type,
+                                        data->x, data->len ) );
             break;
 
         case GENERATE_KEY:
             /* Generate a key */
-            TEST_ASSERT( psa_generate_key( handle, type, bits,
-                                           NULL, 0 ) == PSA_SUCCESS );
+            PSA_ASSERT( psa_generate_key( handle, type, bits,
+                                          NULL, 0 ) );
             break;
 
         case DERIVE_KEY:
             /* Create base key */
-            TEST_ASSERT( psa_allocate_key( PSA_KEY_TYPE_DERIVE,
-                                           PSA_BYTES_TO_BITS( data->len ),
-                                           &base_key ) == PSA_SUCCESS );
+            PSA_ASSERT( psa_allocate_key( PSA_KEY_TYPE_DERIVE,
+                                          PSA_BYTES_TO_BITS( data->len ),
+                                          &base_key ) );
             psa_key_policy_init( &base_policy_set );
             psa_key_policy_set_usage( &base_policy_set, PSA_KEY_USAGE_DERIVE,
                                       base_policy_alg );
-            TEST_ASSERT( psa_set_key_policy(
-                             base_key, &base_policy_set ) == PSA_SUCCESS );
-            TEST_ASSERT( psa_import_key( base_key, PSA_KEY_TYPE_DERIVE,
-                                         data->x, data->len ) == PSA_SUCCESS );
+            PSA_ASSERT( psa_set_key_policy(
+                            base_key, &base_policy_set ) );
+            PSA_ASSERT( psa_import_key( base_key, PSA_KEY_TYPE_DERIVE,
+                                        data->x, data->len ) );
             /* Derive a key. */
-            TEST_ASSERT( psa_key_derivation( &generator, base_key,
-                                             base_policy_alg,
-                                             NULL, 0, NULL, 0,
-                                             export_size ) == PSA_SUCCESS );
-            TEST_ASSERT( psa_generator_import_key(
-                             handle, PSA_KEY_TYPE_RAW_DATA,
-                             bits, &generator ) == PSA_SUCCESS );
+            PSA_ASSERT( psa_key_derivation( &generator, base_key,
+                                            base_policy_alg,
+                                            NULL, 0, NULL, 0,
+                                            export_size ) );
+            PSA_ASSERT( psa_generator_import_key(
+                            handle, PSA_KEY_TYPE_RAW_DATA,
+                            bits, &generator ) );
             break;
     }
 
@@ -4163,17 +4149,17 @@ void persistent_key_load_key_from_storage( data_t *data, int type_arg,
 
     /* Shutdown and restart */
     mbedtls_psa_crypto_free();
-    TEST_ASSERT( psa_crypto_init() == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init() );
 
     /* Check key slot still contains key data */
-    TEST_ASSERT( psa_open_key( PSA_KEY_LIFETIME_PERSISTENT, 1,
-                               &handle ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_get_key_information(
-                     handle, &type_get, &bits_get ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_open_key( PSA_KEY_LIFETIME_PERSISTENT, 1,
+                              &handle ) );
+    PSA_ASSERT( psa_get_key_information(
+                    handle, &type_get, &bits_get ) );
     TEST_ASSERT( type_get == type );
     TEST_ASSERT( bits_get == (size_t) bits );
 
-    TEST_ASSERT( psa_get_key_policy( handle, &policy_get ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_get_key_policy( handle, &policy_get ) );
     TEST_ASSERT( psa_key_policy_get_usage(
                      &policy_get ) == policy_usage );
     TEST_ASSERT( psa_key_policy_get_algorithm(

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -158,9 +158,9 @@ static int exercise_mac_key( psa_key_handle_t handle,
                                           handle, alg ) );
         PSA_ASSERT( psa_mac_update( &operation,
                                     input, sizeof( input ) ) );
-        TEST_ASSERT( psa_mac_verify_finish( &operation,
-                                            mac,
-                                            mac_length ) == verify_status );
+        TEST_EQUAL( psa_mac_verify_finish( &operation,
+                                           mac,
+                                           mac_length ), verify_status );
     }
 
     return( 1 );
@@ -268,12 +268,12 @@ static int exercise_aead_key( psa_key_handle_t handle,
             ( usage & PSA_KEY_USAGE_ENCRYPT ?
               PSA_SUCCESS :
               PSA_ERROR_INVALID_SIGNATURE );
-        TEST_ASSERT( psa_aead_decrypt( handle, alg,
-                                       nonce, nonce_length,
-                                       NULL, 0,
-                                       ciphertext, ciphertext_length,
-                                       plaintext, sizeof( plaintext ),
-                                       &plaintext_length ) == verify_status );
+        TEST_EQUAL( psa_aead_decrypt( handle, alg,
+                                      nonce, nonce_length,
+                                      NULL, 0,
+                                      ciphertext, ciphertext_length,
+                                      plaintext, sizeof( plaintext ),
+                                      &plaintext_length ), verify_status );
     }
 
     return( 1 );
@@ -311,10 +311,10 @@ static int exercise_signature_key( psa_key_handle_t handle,
             ( usage & PSA_KEY_USAGE_SIGN ?
               PSA_SUCCESS :
               PSA_ERROR_INVALID_SIGNATURE );
-        TEST_ASSERT( psa_asymmetric_verify( handle, alg,
-                                            payload, payload_length,
-                                            signature, signature_length ) ==
-                     verify_status );
+        TEST_EQUAL( psa_asymmetric_verify( handle, alg,
+                                           payload, payload_length,
+                                           signature, signature_length ),
+                    verify_status );
     }
 
     return( 1 );
@@ -495,8 +495,8 @@ static int asn1_skip_integer( unsigned char **p, const unsigned char *end,
     size_t len;
     size_t actual_bits;
     unsigned char msb;
-    TEST_ASSERT( mbedtls_asn1_get_tag( p, end, &len,
-                                       MBEDTLS_ASN1_INTEGER ) == 0 );
+    TEST_EQUAL( mbedtls_asn1_get_tag( p, end, &len,
+                                      MBEDTLS_ASN1_INTEGER ), 0 );
     /* Tolerate a slight departure from DER encoding:
      * - 0 may be represented by an empty string or a 1-byte string.
      * - The sign bit may be used as a value bit. */
@@ -549,7 +549,7 @@ static int exported_key_sanity_check( psa_key_type_t type, size_t bits,
                                       uint8_t *exported, size_t exported_length )
 {
     if( PSA_KEY_TYPE_IS_UNSTRUCTURED( type ) )
-        TEST_ASSERT( exported_length == ( bits + 7 ) / 8 );
+        TEST_EQUAL( exported_length, ( bits + 7 ) / 8 );
     else
         TEST_ASSERT( exported_length <= PSA_KEY_EXPORT_MAX_SIZE( type, bits ) );
 
@@ -591,10 +591,10 @@ static int exported_key_sanity_check( psa_key_type_t type, size_t bits,
          *       coefficient         INTEGER,  -- (inverse of q) mod p
          *   }
          */
-        TEST_ASSERT( mbedtls_asn1_get_tag( &p, end, &len,
-                                           MBEDTLS_ASN1_SEQUENCE |
-                                           MBEDTLS_ASN1_CONSTRUCTED ) == 0 );
-        TEST_ASSERT( p + len == end );
+        TEST_EQUAL( mbedtls_asn1_get_tag( &p, end, &len,
+                                          MBEDTLS_ASN1_SEQUENCE |
+                                          MBEDTLS_ASN1_CONSTRUCTED ), 0 );
+        TEST_EQUAL( p + len, end );
         if( ! asn1_skip_integer( &p, end, 0, 0, 0 ) )
             goto exit;
         if( ! asn1_skip_integer( &p, end, bits, bits, 1 ) )
@@ -615,7 +615,7 @@ static int exported_key_sanity_check( psa_key_type_t type, size_t bits,
             goto exit;
         if( ! asn1_skip_integer( &p, end, 1, bits / 2 + 1, 0 ) )
             goto exit;
-        TEST_ASSERT( p == end );
+        TEST_EQUAL( p, end );
     }
     else
 #endif /* MBEDTLS_RSA_C */
@@ -624,7 +624,7 @@ static int exported_key_sanity_check( psa_key_type_t type, size_t bits,
     if( PSA_KEY_TYPE_IS_ECC_KEYPAIR( type ) )
     {
         /* Just the secret value */
-        TEST_ASSERT( exported_length == PSA_BITS_TO_BYTES( bits ) );
+        TEST_EQUAL( exported_length, PSA_BITS_TO_BYTES( bits ) );
     }
     else
 #endif /* MBEDTLS_ECP_C */
@@ -644,15 +644,15 @@ static int exported_key_sanity_check( psa_key_type_t type, size_t bits,
          *      algorithm          OBJECT IDENTIFIER,
          *      parameters         ANY DEFINED BY algorithm OPTIONAL  }
          */
-        TEST_ASSERT( mbedtls_asn1_get_tag( &p, end, &len,
-                                           MBEDTLS_ASN1_SEQUENCE |
-                                           MBEDTLS_ASN1_CONSTRUCTED ) == 0 );
-        TEST_ASSERT( p + len == end );
-        TEST_ASSERT( mbedtls_asn1_get_alg( &p, end, &alg, &params ) == 0 );
+        TEST_EQUAL( mbedtls_asn1_get_tag( &p, end, &len,
+                                          MBEDTLS_ASN1_SEQUENCE |
+                                          MBEDTLS_ASN1_CONSTRUCTED ), 0 );
+        TEST_EQUAL( p + len, end );
+        TEST_EQUAL( mbedtls_asn1_get_alg( &p, end, &alg, &params ), 0 );
         if( ! is_oid_of_key_type( type, alg.p, alg.len ) )
             goto exit;
-        TEST_ASSERT( mbedtls_asn1_get_bitstring( &p, end, &bitstring ) == 0 );
-        TEST_ASSERT( p == end );
+        TEST_EQUAL( mbedtls_asn1_get_bitstring( &p, end, &bitstring ), 0 );
+        TEST_EQUAL( p, end );
         p = bitstring.p;
 #if defined(MBEDTLS_RSA_C)
         if( type == PSA_KEY_TYPE_RSA_PUBLIC_KEY )
@@ -661,16 +661,16 @@ static int exported_key_sanity_check( psa_key_type_t type, size_t bits,
              *      modulus            INTEGER,    -- n
              *      publicExponent     INTEGER  }  -- e
              */
-            TEST_ASSERT( bitstring.unused_bits == 0 );
-            TEST_ASSERT( mbedtls_asn1_get_tag( &p, end, &len,
-                                               MBEDTLS_ASN1_SEQUENCE |
-                                               MBEDTLS_ASN1_CONSTRUCTED ) == 0 );
-            TEST_ASSERT( p + len == end );
+            TEST_EQUAL( bitstring.unused_bits, 0 );
+            TEST_EQUAL( mbedtls_asn1_get_tag( &p, end, &len,
+                                              MBEDTLS_ASN1_SEQUENCE |
+                                              MBEDTLS_ASN1_CONSTRUCTED ), 0 );
+            TEST_EQUAL( p + len, end );
             if( ! asn1_skip_integer( &p, end, bits, bits, 1 ) )
                 goto exit;
             if( ! asn1_skip_integer( &p, end, 2, bits, 1 ) )
                 goto exit;
-            TEST_ASSERT( p == end );
+            TEST_EQUAL( p, end );
         }
         else
 #endif /* MBEDTLS_RSA_C */
@@ -683,9 +683,9 @@ static int exported_key_sanity_check( psa_key_type_t type, size_t bits,
              *      -- then y_P as a n-bit string, big endian,
              *      -- where n is the order of the curve.
              */
-            TEST_ASSERT( bitstring.unused_bits == 0 );
-            TEST_ASSERT( p + 1 + 2 * PSA_BITS_TO_BYTES( bits ) == end );
-            TEST_ASSERT( p[0] == 4 );
+            TEST_EQUAL( bitstring.unused_bits, 0 );
+            TEST_EQUAL( p + 1 + 2 * PSA_BITS_TO_BYTES( bits ), end );
+            TEST_EQUAL( p[0], 4 );
         }
         else
 #endif /* MBEDTLS_ECP_C */
@@ -725,8 +725,8 @@ static int exercise_export_key( psa_key_handle_t handle,
     if( ( usage & PSA_KEY_USAGE_EXPORT ) == 0 &&
         ! PSA_KEY_TYPE_IS_PUBLIC_KEY( type ) )
     {
-        TEST_ASSERT( psa_export_key( handle, NULL, 0, &exported_length ) ==
-                     PSA_ERROR_NOT_PERMITTED );
+        TEST_EQUAL( psa_export_key( handle, NULL, 0, &exported_length ),
+                    PSA_ERROR_NOT_PERMITTED );
         return( 1 );
     }
 
@@ -756,9 +756,9 @@ static int exercise_export_public_key( psa_key_handle_t handle )
     PSA_ASSERT( psa_get_key_information( handle, &type, &bits ) );
     if( ! PSA_KEY_TYPE_IS_ASYMMETRIC( type ) )
     {
-        TEST_ASSERT( psa_export_public_key( handle,
-                                            NULL, 0, &exported_length ) ==
-                     PSA_ERROR_INVALID_ARGUMENT );
+        TEST_EQUAL( psa_export_public_key( handle,
+                                           NULL, 0, &exported_length ),
+                    PSA_ERROR_INVALID_ARGUMENT );
         return( 1 );
     }
 
@@ -889,7 +889,7 @@ void import( data_t *data, int type, int expected_status_arg )
     PSA_ASSERT( psa_allocate_key( type, KEY_BITS_FROM_DATA( type, data ),
                                   &handle ) );
     status = psa_import_key( handle, type, data->x, data->len );
-    TEST_ASSERT( status == expected_status );
+    TEST_EQUAL( status, expected_status );
     if( status == PSA_SUCCESS )
         PSA_ASSERT( psa_destroy_key( handle ) );
 
@@ -926,9 +926,9 @@ void import_twice( int alg_arg, int usage_arg,
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
     status = psa_import_key( handle, type1, data1->x, data1->len );
-    TEST_ASSERT( status == expected_import1_status );
+    TEST_EQUAL( status, expected_import1_status );
     status = psa_import_key( handle, type2, data2->x, data2->len );
-    TEST_ASSERT( status == expected_import2_status );
+    TEST_EQUAL( status, expected_import2_status );
 
     if( expected_import1_status == PSA_SUCCESS ||
         expected_import2_status == PSA_SUCCESS )
@@ -967,7 +967,7 @@ void import_rsa_made_up( int bits_arg, int keypair, int expected_status_arg )
     /* Try importing the key */
     PSA_ASSERT( psa_allocate_key( type, bits, &handle ) );
     status = psa_import_key( handle, type, p, length );
-    TEST_ASSERT( status == expected_status );
+    TEST_EQUAL( status, expected_status );
     if( status == PSA_SUCCESS )
         PSA_ASSERT( psa_destroy_key( handle ) );
 
@@ -1014,8 +1014,8 @@ void import_export( data_t *data,
     psa_key_policy_set_usage( &policy, usage_arg, alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
-    TEST_ASSERT( psa_get_key_information(
-                     handle, NULL, NULL ) == PSA_ERROR_EMPTY_SLOT );
+    TEST_EQUAL( psa_get_key_information(
+                    handle, NULL, NULL ), PSA_ERROR_EMPTY_SLOT );
 
     /* Import the key */
     PSA_ASSERT( psa_import_key( handle, type,
@@ -1025,14 +1025,14 @@ void import_export( data_t *data,
     PSA_ASSERT( psa_get_key_information( handle,
                                          &got_type,
                                          &got_bits ) );
-    TEST_ASSERT( got_type == type );
-    TEST_ASSERT( got_bits == (size_t) expected_bits );
+    TEST_EQUAL( got_type, type );
+    TEST_EQUAL( got_bits, (size_t) expected_bits );
 
     /* Export the key */
     status = psa_export_key( handle,
                              exported, export_size,
                              &exported_length );
-    TEST_ASSERT( status == expected_export_status );
+    TEST_EQUAL( status, expected_export_status );
 
     /* The exported length must be set by psa_export_key() to a value between 0
      * and export_size. On errors, the exported length must be 0. */
@@ -1044,7 +1044,7 @@ void import_export( data_t *data,
                               export_size - exported_length ) );
     if( status != PSA_SUCCESS )
     {
-        TEST_ASSERT( exported_length == 0 );
+        TEST_EQUAL( exported_length, 0 );
         goto destroy;
     }
 
@@ -1075,8 +1075,8 @@ void import_export( data_t *data,
 destroy:
     /* Destroy the key */
     PSA_ASSERT( psa_destroy_key( handle ) );
-    TEST_ASSERT( psa_get_key_information(
-                     handle, NULL, NULL ) == PSA_ERROR_INVALID_HANDLE );
+    TEST_EQUAL( psa_get_key_information(
+                    handle, NULL, NULL ), PSA_ERROR_INVALID_HANDLE );
 
 exit:
     mbedtls_free( exported );
@@ -1103,7 +1103,7 @@ void import_key_nonempty_slot( )
 
     /* Import the key again */
     status = psa_import_key( handle, type, data, sizeof( data ) );
-    TEST_ASSERT( status == PSA_ERROR_OCCUPIED_SLOT );
+    TEST_EQUAL( status, PSA_ERROR_OCCUPIED_SLOT );
 
 exit:
     mbedtls_psa_crypto_free( );
@@ -1125,7 +1125,7 @@ void export_invalid_handle( int handle, int expected_export_status_arg )
     status = psa_export_key( (psa_key_handle_t) handle,
                              exported, export_size,
                              &exported_length );
-    TEST_ASSERT( status == expected_export_status );
+    TEST_EQUAL( status, expected_export_status );
 
 exit:
     mbedtls_psa_crypto_free( );
@@ -1155,7 +1155,7 @@ void export_with_no_key_activity( )
     status = psa_export_key( handle,
                              exported, export_size,
                              &exported_length );
-    TEST_ASSERT( status == PSA_ERROR_EMPTY_SLOT );
+    TEST_EQUAL( status, PSA_ERROR_EMPTY_SLOT );
 
 exit:
     mbedtls_psa_crypto_free( );
@@ -1180,7 +1180,7 @@ void cipher_with_no_key_activity( )
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
     status = psa_cipher_encrypt_setup( &operation, handle, exercise_alg );
-    TEST_ASSERT( status == PSA_ERROR_EMPTY_SLOT );
+    TEST_EQUAL( status, PSA_ERROR_EMPTY_SLOT );
 
 exit:
     psa_cipher_abort( &operation );
@@ -1208,13 +1208,13 @@ void export_after_import_failure( data_t *data, int type_arg,
     /* Import the key - expect failure */
     status = psa_import_key( handle, type,
                              data->x, data->len );
-    TEST_ASSERT( status == expected_import_status );
+    TEST_EQUAL( status, expected_import_status );
 
     /* Export the key */
     status = psa_export_key( handle,
                              exported, export_size,
                              &exported_length );
-    TEST_ASSERT( status == PSA_ERROR_EMPTY_SLOT );
+    TEST_EQUAL( status, PSA_ERROR_EMPTY_SLOT );
 
 exit:
     mbedtls_psa_crypto_free( );
@@ -1240,10 +1240,10 @@ void cipher_after_import_failure( data_t *data, int type_arg,
     /* Import the key - expect failure */
     status = psa_import_key( handle, type,
                              data->x, data->len );
-    TEST_ASSERT( status == expected_import_status );
+    TEST_EQUAL( status, expected_import_status );
 
     status = psa_cipher_encrypt_setup( &operation, handle, exercise_alg );
-    TEST_ASSERT( status == PSA_ERROR_EMPTY_SLOT );
+    TEST_EQUAL( status, PSA_ERROR_EMPTY_SLOT );
 
 exit:
     psa_cipher_abort( &operation );
@@ -1286,7 +1286,7 @@ void export_after_destroy_key( data_t *data, int type_arg )
     /* Export the key */
     status = psa_export_key( handle, exported, export_size,
                              &exported_length );
-    TEST_ASSERT( status == PSA_ERROR_INVALID_HANDLE );
+    TEST_EQUAL( status, PSA_ERROR_INVALID_HANDLE );
 
 exit:
     mbedtls_free( exported );
@@ -1329,7 +1329,7 @@ void import_export_public_key( data_t *data,
     status = psa_export_public_key( handle,
                                     exported, export_size,
                                     &exported_length );
-    TEST_ASSERT( status == expected_export_status );
+    TEST_EQUAL( status, expected_export_status );
     if( status == PSA_SUCCESS )
     {
         psa_key_type_t public_type = PSA_KEY_TYPE_PUBLIC_KEY_OF_KEYPAIR( type );
@@ -1380,8 +1380,8 @@ void import_and_exercise_key( data_t *data,
     PSA_ASSERT( psa_get_key_information( handle,
                                          &got_type,
                                          &got_bits ) );
-    TEST_ASSERT( got_type == type );
-    TEST_ASSERT( got_bits == bits );
+    TEST_EQUAL( got_type, type );
+    TEST_EQUAL( got_bits, bits );
 
     /* Do something with the key according to its type and permitted usage. */
     if( ! exercise_key( handle, usage, alg ) )
@@ -1414,8 +1414,8 @@ void key_policy( int usage_arg, int alg_arg )
     psa_key_policy_init( &policy_get );
     psa_key_policy_set_usage( &policy_set, usage, alg );
 
-    TEST_ASSERT( psa_key_policy_get_usage( &policy_set ) == usage );
-    TEST_ASSERT( psa_key_policy_get_algorithm( &policy_set ) == alg );
+    TEST_EQUAL( psa_key_policy_get_usage( &policy_set ), usage );
+    TEST_EQUAL( psa_key_policy_get_algorithm( &policy_set ), alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy_set ) );
 
     PSA_ASSERT( psa_import_key( handle, key_type,
@@ -1423,8 +1423,8 @@ void key_policy( int usage_arg, int alg_arg )
 
     PSA_ASSERT( psa_get_key_policy( handle, &policy_get ) );
 
-    TEST_ASSERT( policy_get.usage == policy_set.usage );
-    TEST_ASSERT( policy_get.alg == policy_set.alg );
+    TEST_EQUAL( policy_get.usage, policy_set.usage );
+    TEST_EQUAL( policy_get.alg, policy_set.alg );
 
 exit:
     psa_destroy_key( handle );
@@ -1462,7 +1462,7 @@ void mac_key_policy( int policy_usage,
         ( policy_usage & PSA_KEY_USAGE_SIGN ) != 0 )
         PSA_ASSERT( status );
     else
-        TEST_ASSERT( status == PSA_ERROR_NOT_PERMITTED );
+        TEST_EQUAL( status, PSA_ERROR_NOT_PERMITTED );
     psa_mac_abort( &operation );
 
     memset( mac, 0, sizeof( mac ) );
@@ -1471,7 +1471,7 @@ void mac_key_policy( int policy_usage,
         ( policy_usage & PSA_KEY_USAGE_VERIFY ) != 0 )
         PSA_ASSERT( status );
     else
-        TEST_ASSERT( status == PSA_ERROR_NOT_PERMITTED );
+        TEST_EQUAL( status, PSA_ERROR_NOT_PERMITTED );
 
 exit:
     psa_mac_abort( &operation );
@@ -1509,7 +1509,7 @@ void cipher_key_policy( int policy_usage,
         ( policy_usage & PSA_KEY_USAGE_ENCRYPT ) != 0 )
         PSA_ASSERT( status );
     else
-        TEST_ASSERT( status == PSA_ERROR_NOT_PERMITTED );
+        TEST_EQUAL( status, PSA_ERROR_NOT_PERMITTED );
     psa_cipher_abort( &operation );
 
     status = psa_cipher_decrypt_setup( &operation, handle, exercise_alg );
@@ -1517,7 +1517,7 @@ void cipher_key_policy( int policy_usage,
         ( policy_usage & PSA_KEY_USAGE_DECRYPT ) != 0 )
         PSA_ASSERT( status );
     else
-        TEST_ASSERT( status == PSA_ERROR_NOT_PERMITTED );
+        TEST_EQUAL( status, PSA_ERROR_NOT_PERMITTED );
 
 exit:
     psa_cipher_abort( &operation );
@@ -1569,7 +1569,7 @@ void aead_key_policy( int policy_usage,
         ( policy_usage & PSA_KEY_USAGE_ENCRYPT ) != 0 )
         PSA_ASSERT( status );
     else
-        TEST_ASSERT( status == PSA_ERROR_NOT_PERMITTED );
+        TEST_EQUAL( status, PSA_ERROR_NOT_PERMITTED );
 
     memset( tag, 0, sizeof( tag ) );
     status = psa_aead_decrypt( handle, exercise_alg,
@@ -1580,9 +1580,9 @@ void aead_key_policy( int policy_usage,
                                &output_length );
     if( policy_alg == exercise_alg &&
         ( policy_usage & PSA_KEY_USAGE_DECRYPT ) != 0 )
-        TEST_ASSERT( status == PSA_ERROR_INVALID_SIGNATURE );
+        TEST_EQUAL( status, PSA_ERROR_INVALID_SIGNATURE );
     else
-        TEST_ASSERT( status == PSA_ERROR_NOT_PERMITTED );
+        TEST_EQUAL( status, PSA_ERROR_NOT_PERMITTED );
 
 exit:
     psa_destroy_key( handle );
@@ -1633,7 +1633,7 @@ void asymmetric_encryption_key_policy( int policy_usage,
         ( policy_usage & PSA_KEY_USAGE_ENCRYPT ) != 0 )
         PSA_ASSERT( status );
     else
-        TEST_ASSERT( status == PSA_ERROR_NOT_PERMITTED );
+        TEST_EQUAL( status, PSA_ERROR_NOT_PERMITTED );
 
     if( buffer_length != 0 )
         memset( buffer, 0, buffer_length );
@@ -1644,9 +1644,9 @@ void asymmetric_encryption_key_policy( int policy_usage,
                                      &output_length );
     if( policy_alg == exercise_alg &&
         ( policy_usage & PSA_KEY_USAGE_DECRYPT ) != 0 )
-        TEST_ASSERT( status == PSA_ERROR_INVALID_PADDING );
+        TEST_EQUAL( status, PSA_ERROR_INVALID_PADDING );
     else
-        TEST_ASSERT( status == PSA_ERROR_NOT_PERMITTED );
+        TEST_EQUAL( status, PSA_ERROR_NOT_PERMITTED );
 
 exit:
     psa_destroy_key( handle );
@@ -1690,7 +1690,7 @@ void asymmetric_signature_key_policy( int policy_usage,
         ( policy_usage & PSA_KEY_USAGE_SIGN ) != 0 )
         PSA_ASSERT( status );
     else
-        TEST_ASSERT( status == PSA_ERROR_NOT_PERMITTED );
+        TEST_EQUAL( status, PSA_ERROR_NOT_PERMITTED );
 
     memset( signature, 0, sizeof( signature ) );
     status = psa_asymmetric_verify( handle, exercise_alg,
@@ -1698,9 +1698,9 @@ void asymmetric_signature_key_policy( int policy_usage,
                                     signature, sizeof( signature ) );
     if( policy_alg == exercise_alg &&
         ( policy_usage & PSA_KEY_USAGE_VERIFY ) != 0 )
-        TEST_ASSERT( status == PSA_ERROR_INVALID_SIGNATURE );
+        TEST_EQUAL( status, PSA_ERROR_INVALID_SIGNATURE );
     else
-        TEST_ASSERT( status == PSA_ERROR_NOT_PERMITTED );
+        TEST_EQUAL( status, PSA_ERROR_NOT_PERMITTED );
 
 exit:
     psa_destroy_key( handle );
@@ -1741,7 +1741,7 @@ void derive_key_policy( int policy_usage,
         ( policy_usage & PSA_KEY_USAGE_DERIVE ) != 0 )
         PSA_ASSERT( status );
     else
-        TEST_ASSERT( status == PSA_ERROR_NOT_PERMITTED );
+        TEST_EQUAL( status, PSA_ERROR_NOT_PERMITTED );
 
 exit:
     psa_generator_abort( &generator );
@@ -1781,7 +1781,7 @@ void agreement_key_policy( int policy_usage,
         ( policy_usage & PSA_KEY_USAGE_DERIVE ) != 0 )
         PSA_ASSERT( status );
     else
-        TEST_ASSERT( status == PSA_ERROR_NOT_PERMITTED );
+        TEST_EQUAL( status, PSA_ERROR_NOT_PERMITTED );
 
 exit:
     psa_generator_abort( &generator );
@@ -1803,7 +1803,7 @@ void hash_setup( int alg_arg,
 
     status = psa_hash_setup( &operation, alg );
     psa_hash_abort( &operation );
-    TEST_ASSERT( status == expected_status );
+    TEST_EQUAL( status, expected_status );
 
 exit:
     mbedtls_psa_crypto_free( );
@@ -1826,21 +1826,21 @@ void hash_bad_order( )
 
     /* psa_hash_update without calling psa_hash_setup beforehand */
     memset( &operation, 0, sizeof( operation ) );
-    TEST_ASSERT( psa_hash_update( &operation,
-                                  input, sizeof( input ) ) ==
-                 PSA_ERROR_INVALID_ARGUMENT );
+    TEST_EQUAL( psa_hash_update( &operation,
+                                 input, sizeof( input ) ),
+                PSA_ERROR_INVALID_ARGUMENT );
 
     /* psa_hash_verify without calling psa_hash_setup beforehand */
     memset( &operation, 0, sizeof( operation ) );
-    TEST_ASSERT( psa_hash_verify( &operation,
-                                  hash, sizeof( hash ) ) ==
-                 PSA_ERROR_INVALID_ARGUMENT );
+    TEST_EQUAL( psa_hash_verify( &operation,
+                                 hash, sizeof( hash ) ),
+                PSA_ERROR_INVALID_ARGUMENT );
 
     /* psa_hash_finish without calling psa_hash_setup beforehand */
     memset( &operation, 0, sizeof( operation ) );
-    TEST_ASSERT( psa_hash_finish( &operation,
-                                  hash, sizeof( hash ), &hash_len ) ==
-                 PSA_ERROR_INVALID_ARGUMENT );
+    TEST_EQUAL( psa_hash_finish( &operation,
+                                 hash, sizeof( hash ), &hash_len ),
+                PSA_ERROR_INVALID_ARGUMENT );
 
 exit:
     mbedtls_psa_crypto_free( );
@@ -1864,21 +1864,21 @@ void hash_verify_bad_args( )
 
     /* psa_hash_verify with a smaller hash than expected */
     PSA_ASSERT( psa_hash_setup( &operation, alg ) );
-    TEST_ASSERT( psa_hash_verify( &operation,
-                                  hash, expected_size - 1 ) ==
-                 PSA_ERROR_INVALID_SIGNATURE );
+    TEST_EQUAL( psa_hash_verify( &operation,
+                                 hash, expected_size - 1 ),
+                PSA_ERROR_INVALID_SIGNATURE );
 
     /* psa_hash_verify with a non-matching hash */
     PSA_ASSERT( psa_hash_setup( &operation, alg ) );
-    TEST_ASSERT( psa_hash_verify( &operation,
-                                  hash + 1, expected_size ) ==
-                 PSA_ERROR_INVALID_SIGNATURE );
+    TEST_EQUAL( psa_hash_verify( &operation,
+                                 hash + 1, expected_size ),
+                PSA_ERROR_INVALID_SIGNATURE );
 
     /* psa_hash_verify with a hash longer than expected */
     PSA_ASSERT( psa_hash_setup( &operation, alg ) );
-    TEST_ASSERT( psa_hash_verify( &operation,
-                                  hash, sizeof( hash ) ) ==
-                 PSA_ERROR_INVALID_SIGNATURE );
+    TEST_EQUAL( psa_hash_verify( &operation,
+                                 hash, sizeof( hash ) ),
+                PSA_ERROR_INVALID_SIGNATURE );
 
 exit:
     mbedtls_psa_crypto_free( );
@@ -1898,9 +1898,9 @@ void hash_finish_bad_args( )
 
     /* psa_hash_finish with a smaller hash buffer than expected */
     PSA_ASSERT( psa_hash_setup( &operation, alg ) );
-    TEST_ASSERT( psa_hash_finish( &operation,
-                                  hash, expected_size - 1,
-                                  &hash_len ) == PSA_ERROR_BUFFER_TOO_SMALL );
+    TEST_EQUAL( psa_hash_finish( &operation,
+                                 hash, expected_size - 1,
+                                 &hash_len ), PSA_ERROR_BUFFER_TOO_SMALL );
 
 exit:
     mbedtls_psa_crypto_free( );
@@ -1936,7 +1936,7 @@ void mac_setup( int key_type_arg,
 
     status = psa_mac_sign_setup( &operation, handle, alg );
     psa_mac_abort( &operation );
-    TEST_ASSERT( status == expected_status );
+    TEST_EQUAL( status, expected_status );
 
 exit:
     psa_destroy_key( handle );
@@ -1989,8 +1989,8 @@ void mac_sign( int key_type_arg,
                                      &mac_length ) );
 
     /* Compare with the expected value. */
-    TEST_ASSERT( mac_length == expected_mac->len );
-    TEST_ASSERT( memcmp( actual_mac, expected_mac->x, mac_length ) == 0 );
+    TEST_EQUAL( mac_length, expected_mac->len );
+    TEST_EQUAL( memcmp( actual_mac, expected_mac->x, mac_length ), 0 );
 
     /* Verify that the end of the buffer is untouched. */
     TEST_ASSERT( mem_is_char( actual_mac + mac_length, '+',
@@ -2077,7 +2077,7 @@ void cipher_setup( int key_type_arg,
 
     status = psa_cipher_encrypt_setup( &operation, handle, alg );
     psa_cipher_abort( &operation );
-    TEST_ASSERT( status == expected_status );
+    TEST_EQUAL( status, expected_status );
 
 exit:
     psa_destroy_key( handle );
@@ -2146,7 +2146,7 @@ void cipher_encrypt( int alg_arg, int key_type_arg,
                                 &function_output_length );
     total_output_length += function_output_length;
 
-    TEST_ASSERT( status == expected_status );
+    TEST_EQUAL( status, expected_status );
     if( expected_status == PSA_SUCCESS )
     {
         PSA_ASSERT( psa_cipher_abort( &operation ) );
@@ -2379,7 +2379,7 @@ void cipher_decrypt( int alg_arg, int key_type_arg,
                                 output_buffer_size,
                                 &function_output_length );
     total_output_length += function_output_length;
-    TEST_ASSERT( status == expected_status );
+    TEST_EQUAL( status, expected_status );
 
     if( expected_status == PSA_SUCCESS )
     {
@@ -2639,25 +2639,25 @@ void aead_encrypt_decrypt( int key_type_arg, data_t *key_data,
     PSA_ASSERT( psa_import_key( handle, key_type,
                                 key_data->x, key_data->len ) );
 
-    TEST_ASSERT( psa_aead_encrypt( handle, alg,
-                                   nonce->x, nonce->len,
-                                   additional_data->x,
-                                   additional_data->len,
-                                   input_data->x, input_data->len,
-                                   output_data, output_size,
-                                   &output_length ) == expected_result );
+    TEST_EQUAL( psa_aead_encrypt( handle, alg,
+                                  nonce->x, nonce->len,
+                                  additional_data->x,
+                                  additional_data->len,
+                                  input_data->x, input_data->len,
+                                  output_data, output_size,
+                                  &output_length ), expected_result );
 
     if( PSA_SUCCESS == expected_result )
     {
         ASSERT_ALLOC( output_data2, output_length );
 
-        TEST_ASSERT( psa_aead_decrypt( handle, alg,
-                                       nonce->x, nonce->len,
-                                       additional_data->x,
-                                       additional_data->len,
-                                       output_data, output_length,
-                                       output_data2, output_length,
-                                       &output_length2 ) == expected_result );
+        TEST_EQUAL( psa_aead_decrypt( handle, alg,
+                                      nonce->x, nonce->len,
+                                      additional_data->x,
+                                      additional_data->len,
+                                      output_data, output_length,
+                                      output_data2, output_length,
+                                      &output_length2 ), expected_result );
 
         ASSERT_COMPARE( input_data->x, input_data->len,
                         output_data2, output_length2 );
@@ -2776,13 +2776,13 @@ void aead_decrypt( int key_type_arg, data_t *key_data,
                                 key_data->x,
                                 key_data->len ) );
 
-    TEST_ASSERT( psa_aead_decrypt( handle, alg,
-                                   nonce->x, nonce->len,
-                                   additional_data->x,
-                                   additional_data->len,
-                                   input_data->x, input_data->len,
-                                   output_data, output_size,
-                                   &output_length ) == expected_result );
+    TEST_EQUAL( psa_aead_decrypt( handle, alg,
+                                  nonce->x, nonce->len,
+                                  additional_data->x,
+                                  additional_data->len,
+                                  input_data->x, input_data->len,
+                                  output_data, output_size,
+                                  &output_length ), expected_result );
 
     if( expected_result == PSA_SUCCESS )
         ASSERT_COMPARE( expected_data->x, expected_data->len,
@@ -2804,7 +2804,7 @@ void signature_size( int type_arg,
     psa_key_type_t type = type_arg;
     psa_algorithm_t alg = alg_arg;
     size_t actual_size = PSA_ASYMMETRIC_SIGN_OUTPUT_SIZE( type, bits, alg );
-    TEST_ASSERT( actual_size == (size_t) expected_size_arg );
+    TEST_EQUAL( actual_size, (size_t) expected_size_arg );
 exit:
     ;
 }
@@ -2910,7 +2910,7 @@ void sign_fail( int key_type_arg, data_t *key_data,
                                          input_data->x, input_data->len,
                                          signature, signature_size,
                                          &signature_length );
-    TEST_ASSERT( actual_status == expected_status );
+    TEST_EQUAL( actual_status, expected_status );
     /* The value of *signature_length is unspecified on error, but
      * whatever it is, it should be less than signature_size, so that
      * if the caller tries to read *signature_length bytes without
@@ -2984,11 +2984,11 @@ void sign_verify( int key_type_arg, data_t *key_data,
          * detected as invalid. Flip a bit at the beginning, not at the end,
          * because ECDSA may ignore the last few bits of the input. */
         input_data->x[0] ^= 1;
-        TEST_ASSERT( psa_asymmetric_verify(
-                         handle, alg,
-                         input_data->x, input_data->len,
-                         signature,
-                         signature_length ) == PSA_ERROR_INVALID_SIGNATURE );
+        TEST_EQUAL( psa_asymmetric_verify(
+                        handle, alg,
+                        input_data->x, input_data->len,
+                        signature,
+                        signature_length ), PSA_ERROR_INVALID_SIGNATURE );
     }
 
 exit:
@@ -3078,7 +3078,7 @@ void asymmetric_verify_fail( int key_type_arg, data_t *key_data,
                                            signature_data->x,
                                            signature_data->len );
 
-    TEST_ASSERT( actual_status == expected_status );
+    TEST_EQUAL( actual_status, expected_status );
 
 exit:
     psa_destroy_key( handle );
@@ -3133,8 +3133,8 @@ void asymmetric_encrypt( int key_type_arg,
                                             label->x, label->len,
                                             output, output_size,
                                             &output_length );
-    TEST_ASSERT( actual_status == expected_status );
-    TEST_ASSERT( output_length == expected_output_length );
+    TEST_EQUAL( actual_status, expected_status );
+    TEST_EQUAL( output_length, expected_output_length );
 
     /* If the label is empty, the test framework puts a non-null pointer
      * in label->x. Test that a null pointer works as well. */
@@ -3148,8 +3148,8 @@ void asymmetric_encrypt( int key_type_arg,
                                                 NULL, label->len,
                                                 output, output_size,
                                                 &output_length );
-        TEST_ASSERT( actual_status == expected_status );
-        TEST_ASSERT( output_length == expected_output_length );
+        TEST_EQUAL( actual_status, expected_status );
+        TEST_EQUAL( output_length, expected_output_length );
     }
 
 exit:
@@ -3351,7 +3351,7 @@ void asymmetric_decrypt_fail( int key_type_arg,
                                             label->x, label->len,
                                             output, output_size,
                                             &output_length );
-    TEST_ASSERT( actual_status == expected_status );
+    TEST_EQUAL( actual_status, expected_status );
     TEST_ASSERT( output_length <= output_size );
 
     /* If the label is empty, the test framework puts a non-null pointer
@@ -3366,7 +3366,7 @@ void asymmetric_decrypt_fail( int key_type_arg,
                                                 NULL, label->len,
                                                 output, output_size,
                                                 &output_length );
-        TEST_ASSERT( actual_status == expected_status );
+        TEST_EQUAL( actual_status, expected_status );
         TEST_ASSERT( output_length <= output_size );
     }
 
@@ -3406,10 +3406,10 @@ void derive_setup( int key_type_arg,
                                 key_data->x,
                                 key_data->len ) );
 
-    TEST_ASSERT( psa_key_derivation( &generator, handle, alg,
-                                     salt->x, salt->len,
-                                     label->x, label->len,
-                                     requested_capacity ) == expected_status );
+    TEST_EQUAL( psa_key_derivation( &generator, handle, alg,
+                                    salt->x, salt->len,
+                                    label->x, label->len,
+                                    requested_capacity ), expected_status );
 
 exit:
     psa_generator_abort( &generator );
@@ -3452,16 +3452,16 @@ void test_derive_invalid_generator_state( )
                                      capacity ) );
 
     /* state of generator shouldn't allow additional generation */
-    TEST_ASSERT(  psa_key_derivation( &generator, handle, alg,
-                                      NULL, 0,
-                                      NULL, 0,
-                                      capacity ) == PSA_ERROR_BAD_STATE );
+    TEST_EQUAL(  psa_key_derivation( &generator, handle, alg,
+                                     NULL, 0,
+                                     NULL, 0,
+                                     capacity ), PSA_ERROR_BAD_STATE );
 
     PSA_ASSERT( psa_generator_read( &generator, buffer, capacity )
         );
 
-    TEST_ASSERT( psa_generator_read( &generator, buffer, capacity )
-                 == PSA_ERROR_INSUFFICIENT_CAPACITY );
+    TEST_EQUAL( psa_generator_read( &generator, buffer, capacity )
+                , PSA_ERROR_INSUFFICIENT_CAPACITY );
 
 exit:
     psa_generator_abort( &generator );
@@ -3550,7 +3550,7 @@ void derive_output( int alg_arg,
                                     requested_capacity ) );
     PSA_ASSERT( psa_get_generator_capacity( &generator,
                                             &current_capacity ) );
-    TEST_ASSERT( current_capacity == requested_capacity );
+    TEST_EQUAL( current_capacity, requested_capacity );
     expected_capacity = requested_capacity;
 
     /* Expansion phase. */
@@ -3570,20 +3570,20 @@ void derive_output( int alg_arg,
                  output_sizes[i] > expected_capacity )
         {
             /* Capacity exceeded. */
-            TEST_ASSERT( status == PSA_ERROR_INSUFFICIENT_CAPACITY );
+            TEST_EQUAL( status, PSA_ERROR_INSUFFICIENT_CAPACITY );
             expected_capacity = 0;
             continue;
         }
         /* Success. Check the read data. */
         PSA_ASSERT( status );
         if( output_sizes[i] != 0 )
-            TEST_ASSERT( memcmp( output_buffer, expected_outputs[i],
-                                 output_sizes[i] ) == 0 );
+            TEST_EQUAL( memcmp( output_buffer, expected_outputs[i],
+                                output_sizes[i] ), 0 );
         /* Check the generator status. */
         expected_capacity -= output_sizes[i];
         PSA_ASSERT( psa_get_generator_capacity( &generator,
                                                 &current_capacity ) );
-        TEST_ASSERT( expected_capacity == current_capacity );
+        TEST_EQUAL( expected_capacity, current_capacity );
     }
     PSA_ASSERT( psa_generator_abort( &generator ) );
 
@@ -3631,7 +3631,7 @@ void derive_full( int alg_arg,
                                     requested_capacity ) );
     PSA_ASSERT( psa_get_generator_capacity( &generator,
                                             &current_capacity ) );
-    TEST_ASSERT( current_capacity == expected_capacity );
+    TEST_EQUAL( current_capacity, expected_capacity );
 
     /* Expansion phase. */
     while( current_capacity > 0 )
@@ -3645,13 +3645,13 @@ void derive_full( int alg_arg,
         expected_capacity -= read_size;
         PSA_ASSERT( psa_get_generator_capacity( &generator,
                                                 &current_capacity ) );
-        TEST_ASSERT( current_capacity == expected_capacity );
+        TEST_EQUAL( current_capacity, expected_capacity );
     }
 
     /* Check that the generator refuses to go over capacity. */
-    TEST_ASSERT( psa_generator_read( &generator,
-                                     output_buffer,
-                                     1 ) == PSA_ERROR_INSUFFICIENT_CAPACITY );
+    TEST_EQUAL( psa_generator_read( &generator,
+                                    output_buffer,
+                                    1 ), PSA_ERROR_INSUFFICIENT_CAPACITY );
 
     PSA_ASSERT( psa_generator_abort( &generator ) );
 
@@ -3715,8 +3715,8 @@ void derive_key_exercise( int alg_arg,
     PSA_ASSERT( psa_get_key_information( derived_handle,
                                          &got_type,
                                          &got_bits ) );
-    TEST_ASSERT( got_type == derived_type );
-    TEST_ASSERT( got_bits == derived_bits );
+    TEST_EQUAL( got_type, derived_type );
+    TEST_EQUAL( got_bits, derived_bits );
 
     /* Exercise the derived key. */
     if( ! exercise_key( derived_handle, derived_usage, derived_alg ) )
@@ -3791,7 +3791,7 @@ void derive_key_export( int alg_arg,
     PSA_ASSERT( psa_export_key( derived_handle,
                                 export_buffer, bytes1,
                                 &length ) );
-    TEST_ASSERT( length == bytes1 );
+    TEST_EQUAL( length, bytes1 );
     PSA_ASSERT( psa_destroy_key( derived_handle ) );
     PSA_ASSERT( psa_allocate_key( PSA_KEY_TYPE_RAW_DATA,
                                   PSA_BYTES_TO_BITS( bytes2 ),
@@ -3804,10 +3804,10 @@ void derive_key_export( int alg_arg,
     PSA_ASSERT( psa_export_key( derived_handle,
                                 export_buffer + bytes1, bytes2,
                                 &length ) );
-    TEST_ASSERT( length == bytes2 );
+    TEST_EQUAL( length, bytes2 );
 
     /* Compare the outputs from the two runs. */
-    TEST_ASSERT( memcmp( output_buffer, export_buffer, capacity ) == 0 );
+    TEST_EQUAL( memcmp( output_buffer, export_buffer, capacity ), 0 );
 
 exit:
     mbedtls_free( output_buffer );
@@ -3844,10 +3844,10 @@ void key_agreement_setup( int alg_arg,
                                 our_key_data->x,
                                 our_key_data->len ) );
 
-    TEST_ASSERT( psa_key_agreement( &generator,
-                                    our_key,
-                                    peer_key_data->x, peer_key_data->len,
-                                    alg ) == expected_status_arg );
+    TEST_EQUAL( psa_key_agreement( &generator,
+                                   our_key,
+                                   peer_key_data->x, peer_key_data->len,
+                                   alg ), expected_status_arg );
 
 exit:
     psa_generator_abort( &generator );
@@ -3891,7 +3891,7 @@ void key_agreement_capacity( int alg_arg,
     /* Test the advertized capacity. */
     PSA_ASSERT( psa_get_generator_capacity(
                     &generator, &actual_capacity ) );
-    TEST_ASSERT( actual_capacity == (size_t) expected_capacity_arg );
+    TEST_EQUAL( actual_capacity, (size_t) expected_capacity_arg );
 
     /* Test the actual capacity by reading the output. */
     while( actual_capacity > sizeof( output ) )
@@ -3902,8 +3902,8 @@ void key_agreement_capacity( int alg_arg,
     }
     PSA_ASSERT( psa_generator_read( &generator,
                                     output, actual_capacity ) );
-    TEST_ASSERT( psa_generator_read( &generator, output, 1 ) ==
-                 PSA_ERROR_INSUFFICIENT_CAPACITY );
+    TEST_EQUAL( psa_generator_read( &generator, output, 1 ),
+                PSA_ERROR_INSUFFICIENT_CAPACITY );
 
 exit:
     psa_generator_abort( &generator );
@@ -3950,16 +3950,16 @@ void key_agreement_output( int alg_arg,
         psa_generator_read( &generator,
                             actual_output,
                             expected_output1->len ) );
-    TEST_ASSERT( memcmp( actual_output, expected_output1->x,
-                         expected_output1->len ) == 0 );
+    TEST_EQUAL( memcmp( actual_output, expected_output1->x,
+                        expected_output1->len ), 0 );
     if( expected_output2->len != 0 )
     {
         PSA_ASSERT(
             psa_generator_read( &generator,
                                 actual_output,
                                 expected_output2->len ) );
-        TEST_ASSERT( memcmp( actual_output, expected_output2->x,
-                             expected_output2->len ) == 0 );
+        TEST_EQUAL( memcmp( actual_output, expected_output2->x,
+                            expected_output2->len ), 0 );
     }
 
 exit:
@@ -3996,7 +3996,7 @@ void generate_random( int bytes_arg )
         PSA_ASSERT( psa_generate_random( output, bytes ) );
 
         /* Check that no more than bytes have been overwritten */
-        TEST_ASSERT( memcmp( output + bytes, trail, sizeof( trail ) ) == 0 );
+        TEST_EQUAL( memcmp( output + bytes, trail, sizeof( trail ) ), 0 );
 
         for( i = 0; i < bytes; i++ )
         {
@@ -4047,17 +4047,17 @@ void generate_key( int type_arg,
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
     /* Generate a key */
-    TEST_ASSERT( psa_generate_key( handle, type, bits,
-                                   NULL, 0 ) == expected_status );
+    TEST_EQUAL( psa_generate_key( handle, type, bits,
+                                  NULL, 0 ), expected_status );
 
     /* Test the key information */
-    TEST_ASSERT( psa_get_key_information( handle,
-                                          &got_type,
-                                          &got_bits ) == expected_info_status );
+    TEST_EQUAL( psa_get_key_information( handle,
+                                         &got_type,
+                                         &got_bits ), expected_info_status );
     if( expected_info_status != PSA_SUCCESS )
         goto exit;
-    TEST_ASSERT( got_type == type );
-    TEST_ASSERT( got_bits == bits );
+    TEST_EQUAL( got_type, type );
+    TEST_EQUAL( got_bits, bits );
 
     /* Do something with the key according to its type and permitted usage. */
     if( ! exercise_key( handle, usage, alg ) )
@@ -4144,8 +4144,8 @@ void persistent_key_load_key_from_storage( data_t *data, int type_arg,
     }
 
     /* Export the key */
-    TEST_ASSERT( psa_export_key( handle, first_export, export_size,
-                                 &first_exported_length ) == export_status );
+    TEST_EQUAL( psa_export_key( handle, first_export, export_size,
+                                &first_exported_length ), export_status );
 
     /* Shutdown and restart */
     mbedtls_psa_crypto_free();
@@ -4156,18 +4156,18 @@ void persistent_key_load_key_from_storage( data_t *data, int type_arg,
                               &handle ) );
     PSA_ASSERT( psa_get_key_information(
                     handle, &type_get, &bits_get ) );
-    TEST_ASSERT( type_get == type );
-    TEST_ASSERT( bits_get == (size_t) bits );
+    TEST_EQUAL( type_get, type );
+    TEST_EQUAL( bits_get, (size_t) bits );
 
     PSA_ASSERT( psa_get_key_policy( handle, &policy_get ) );
-    TEST_ASSERT( psa_key_policy_get_usage(
-                     &policy_get ) == policy_usage );
-    TEST_ASSERT( psa_key_policy_get_algorithm(
-                     &policy_get ) == policy_alg );
+    TEST_EQUAL( psa_key_policy_get_usage(
+                    &policy_get ), policy_usage );
+    TEST_EQUAL( psa_key_policy_get_algorithm(
+                    &policy_get ), policy_alg );
 
     /* Export the key again */
-    TEST_ASSERT( psa_export_key( handle, second_export, export_size,
-                                 &second_exported_length ) == export_status );
+    TEST_EQUAL( psa_export_key( handle, second_export, export_size,
+                                &second_exported_length ), export_status );
 
     if( export_status == PSA_SUCCESS )
     {

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -877,7 +877,6 @@ void import( data_t *data, int type, int expected_status_arg )
     psa_status_t expected_status = expected_status_arg;
     psa_status_t status;
 
-    TEST_ASSERT( data != NULL );
     PSA_ASSERT( psa_crypto_init( ) );
 
     PSA_ASSERT( psa_allocate_key( type, KEY_BITS_FROM_DATA( type, data ),
@@ -995,7 +994,6 @@ void import_export( data_t *data,
     size_t got_bits;
     psa_key_policy_t policy;
 
-    TEST_ASSERT( data != NULL );
     export_size = (ptrdiff_t) data->len + export_size_delta;
     ASSERT_ALLOC( exported, export_size );
     if( ! canonical_input )
@@ -2005,10 +2003,6 @@ void mac_verify( int key_type_arg,
 
     TEST_ASSERT( expected_mac->len <= PSA_MAC_MAX_SIZE );
 
-    TEST_ASSERT( key != NULL );
-    TEST_ASSERT( input != NULL );
-    TEST_ASSERT( expected_mac != NULL );
-
     PSA_ASSERT( psa_crypto_init( ) );
 
     PSA_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key->len ),
@@ -2090,10 +2084,6 @@ void cipher_encrypt( int alg_arg, int key_type_arg,
     psa_cipher_operation_t operation;
     psa_key_policy_t policy;
 
-    TEST_ASSERT( key != NULL );
-    TEST_ASSERT( input != NULL );
-    TEST_ASSERT( expected_output != NULL );
-
     iv_size = PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type );
     memset( iv, 0x2a, iv_size );
 
@@ -2161,10 +2151,6 @@ void cipher_encrypt_multipart( int alg_arg, int key_type_arg,
     size_t total_output_length = 0;
     psa_cipher_operation_t operation;
     psa_key_policy_t policy;
-
-    TEST_ASSERT( key != NULL );
-    TEST_ASSERT( input != NULL );
-    TEST_ASSERT( expected_output != NULL );
 
     iv_size = PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type );
     memset( iv, 0x2a, iv_size );
@@ -2236,10 +2222,6 @@ void cipher_decrypt_multipart( int alg_arg, int key_type_arg,
     size_t total_output_length = 0;
     psa_cipher_operation_t operation;
     psa_key_policy_t policy;
-
-    TEST_ASSERT( key != NULL );
-    TEST_ASSERT( input != NULL );
-    TEST_ASSERT( expected_output != NULL );
 
     iv_size = PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type );
     memset( iv, 0x2a, iv_size );
@@ -2314,10 +2296,6 @@ void cipher_decrypt( int alg_arg, int key_type_arg,
     psa_cipher_operation_t operation;
     psa_key_policy_t policy;
 
-    TEST_ASSERT( key != NULL );
-    TEST_ASSERT( input != NULL );
-    TEST_ASSERT( expected_output != NULL );
-
     iv_size = PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type );
     memset( iv, 0x2a, iv_size );
 
@@ -2389,9 +2367,6 @@ void cipher_verify_output( int alg_arg, int key_type_arg,
     psa_cipher_operation_t operation1;
     psa_cipher_operation_t operation2;
     psa_key_policy_t policy;
-
-    TEST_ASSERT( key != NULL );
-    TEST_ASSERT( input != NULL );
 
     PSA_ASSERT( psa_crypto_init( ) );
 
@@ -2478,9 +2453,6 @@ void cipher_verify_output_multipart( int alg_arg,
     psa_cipher_operation_t operation1;
     psa_cipher_operation_t operation2;
     psa_key_policy_t policy;
-
-    TEST_ASSERT( key != NULL );
-    TEST_ASSERT( input != NULL );
 
     PSA_ASSERT( psa_crypto_init( ) );
 
@@ -2583,11 +2555,6 @@ void aead_encrypt_decrypt( int key_type_arg, data_t *key_data,
     psa_status_t expected_result = expected_result_arg;
     psa_key_policy_t policy;
 
-    TEST_ASSERT( key_data != NULL );
-    TEST_ASSERT( input_data != NULL );
-    TEST_ASSERT( nonce != NULL );
-    TEST_ASSERT( additional_data != NULL );
-
     output_size = input_data->len + tag_length;
     ASSERT_ALLOC( output_data, output_size );
 
@@ -2655,12 +2622,6 @@ void aead_encrypt( int key_type_arg, data_t *key_data,
     size_t tag_length = 16;
     psa_key_policy_t policy;
 
-    TEST_ASSERT( key_data != NULL );
-    TEST_ASSERT( input_data != NULL );
-    TEST_ASSERT( additional_data != NULL );
-    TEST_ASSERT( nonce != NULL );
-    TEST_ASSERT( expected_result != NULL );
-
     output_size = input_data->len + tag_length;
     ASSERT_ALLOC( output_data, output_size );
 
@@ -2711,12 +2672,6 @@ void aead_decrypt( int key_type_arg, data_t *key_data,
     size_t tag_length = 16;
     psa_key_policy_t policy;
     psa_status_t expected_result = expected_result_arg;
-
-    TEST_ASSERT( key_data != NULL );
-    TEST_ASSERT( input_data != NULL );
-    TEST_ASSERT( additional_data != NULL );
-    TEST_ASSERT( nonce != NULL );
-    TEST_ASSERT( expected_data != NULL );
 
     output_size = input_data->len + tag_length;
     ASSERT_ALLOC( output_data, output_size );
@@ -2782,10 +2737,6 @@ void sign_deterministic( int key_type_arg, data_t *key_data,
     size_t signature_length = 0xdeadbeef;
     psa_key_policy_t policy;
 
-    TEST_ASSERT( key_data != NULL );
-    TEST_ASSERT( input_data != NULL );
-    TEST_ASSERT( output_data != NULL );
-
     PSA_ASSERT( psa_crypto_init( ) );
 
     PSA_ASSERT( psa_allocate_key( key_type,
@@ -2840,9 +2791,6 @@ void sign_fail( int key_type_arg, data_t *key_data,
     unsigned char *signature = NULL;
     size_t signature_length = 0xdeadbeef;
     psa_key_policy_t policy;
-
-    TEST_ASSERT( key_data != NULL );
-    TEST_ASSERT( input_data != NULL );
 
     ASSERT_ALLOC( signature, signature_size );
 
@@ -2962,10 +2910,6 @@ void asymmetric_verify( int key_type_arg, data_t *key_data,
 
     TEST_ASSERT( signature_data->len <= PSA_ASYMMETRIC_SIGNATURE_MAX_SIZE );
 
-    TEST_ASSERT( key_data != NULL );
-    TEST_ASSERT( hash_data != NULL );
-    TEST_ASSERT( signature_data != NULL );
-
     PSA_ASSERT( psa_crypto_init( ) );
 
     PSA_ASSERT( psa_allocate_key( key_type,
@@ -3001,10 +2945,6 @@ void asymmetric_verify_fail( int key_type_arg, data_t *key_data,
     psa_status_t actual_status;
     psa_status_t expected_status = expected_status_arg;
     psa_key_policy_t policy;
-
-    TEST_ASSERT( key_data != NULL );
-    TEST_ASSERT( hash_data != NULL );
-    TEST_ASSERT( signature_data != NULL );
 
     PSA_ASSERT( psa_crypto_init( ) );
 
@@ -3124,9 +3064,6 @@ void asymmetric_encrypt_decrypt( int key_type_arg,
     size_t output2_length = ~0;
     psa_key_policy_t policy;
 
-    TEST_ASSERT( key_data != NULL );
-    TEST_ASSERT( input_data != NULL );
-
     PSA_ASSERT( psa_crypto_init( ) );
 
     PSA_ASSERT( psa_allocate_key( key_type,
@@ -3195,10 +3132,6 @@ void asymmetric_decrypt( int key_type_arg,
     size_t output_length = ~0;
     psa_key_policy_t policy;
 
-    TEST_ASSERT( key_data != NULL );
-    TEST_ASSERT( input_data != NULL );
-    TEST_ASSERT( expected_data != NULL );
-
     output_size = key_data->len;
     ASSERT_ALLOC( output, output_size );
 
@@ -3265,9 +3198,6 @@ void asymmetric_decrypt_fail( int key_type_arg,
     psa_status_t actual_status;
     psa_status_t expected_status = expected_status_arg;
     psa_key_policy_t policy;
-
-    TEST_ASSERT( key_data != NULL );
-    TEST_ASSERT( input_data != NULL );
 
     output_size = key_data->len;
     ASSERT_ALLOC( output, output_size );

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -617,7 +617,7 @@ static int exported_key_sanity_check( psa_key_type_t type, size_t bits,
         if( ! asn1_skip_integer( &p, end, 1, bits / 2 + 1, 0 ) )
             goto exit;
         TEST_ASSERT( p == end );
-     }
+    }
     else
 #endif /* MBEDTLS_RSA_C */
 
@@ -1210,7 +1210,7 @@ void export_after_import_failure( data_t *data, int type_arg,
 
     /* Import the key - expect failure */
     status = psa_import_key( handle, type,
-                                 data->x, data->len );
+                             data->x, data->len );
     TEST_ASSERT( status == expected_import_status );
 
     /* Export the key */
@@ -1242,7 +1242,7 @@ void cipher_after_import_failure( data_t *data, int type_arg,
 
     /* Import the key - expect failure */
     status = psa_import_key( handle, type,
-                                 data->x, data->len );
+                             data->x, data->len );
     TEST_ASSERT( status == expected_import_status );
 
     status = psa_cipher_encrypt_setup( &operation, handle, exercise_alg );
@@ -1832,19 +1832,19 @@ void hash_bad_order( )
     memset( &operation, 0, sizeof( operation ) );
     TEST_ASSERT( psa_hash_update( &operation,
                                   input, sizeof( input ) ) ==
-                                  PSA_ERROR_INVALID_ARGUMENT );
+                 PSA_ERROR_INVALID_ARGUMENT );
 
     /* psa_hash_verify without calling psa_hash_setup beforehand */
     memset( &operation, 0, sizeof( operation ) );
     TEST_ASSERT( psa_hash_verify( &operation,
                                   hash, sizeof( hash ) ) ==
-                                  PSA_ERROR_INVALID_ARGUMENT );
+                 PSA_ERROR_INVALID_ARGUMENT );
 
     /* psa_hash_finish without calling psa_hash_setup beforehand */
     memset( &operation, 0, sizeof( operation ) );
     TEST_ASSERT( psa_hash_finish( &operation,
                                   hash, sizeof( hash ), &hash_len ) ==
-                                  PSA_ERROR_INVALID_ARGUMENT );
+                 PSA_ERROR_INVALID_ARGUMENT );
 
 exit:
     mbedtls_psa_crypto_free( );
@@ -1870,19 +1870,19 @@ void hash_verify_bad_args( )
     TEST_ASSERT( psa_hash_setup( &operation, alg ) == PSA_SUCCESS );
     TEST_ASSERT( psa_hash_verify( &operation,
                                   hash, expected_size - 1 ) ==
-                                  PSA_ERROR_INVALID_SIGNATURE );
+                 PSA_ERROR_INVALID_SIGNATURE );
 
     /* psa_hash_verify with a non-matching hash */
     TEST_ASSERT( psa_hash_setup( &operation, alg ) == PSA_SUCCESS );
     TEST_ASSERT( psa_hash_verify( &operation,
                                   hash + 1, expected_size ) ==
-                                  PSA_ERROR_INVALID_SIGNATURE );
+                 PSA_ERROR_INVALID_SIGNATURE );
 
     /* psa_hash_verify with a hash longer than expected */
     TEST_ASSERT( psa_hash_setup( &operation, alg ) == PSA_SUCCESS );
     TEST_ASSERT( psa_hash_verify( &operation,
                                   hash, sizeof( hash ) ) ==
-                                  PSA_ERROR_INVALID_SIGNATURE );
+                 PSA_ERROR_INVALID_SIGNATURE );
 
 exit:
     mbedtls_psa_crypto_free( );
@@ -4143,7 +4143,7 @@ void persistent_key_load_key_from_storage( data_t *data, int type_arg,
             psa_key_policy_set_usage( &base_policy_set, PSA_KEY_USAGE_DERIVE,
                                       base_policy_alg );
             TEST_ASSERT( psa_set_key_policy(
-                base_key, &base_policy_set ) == PSA_SUCCESS );
+                             base_key, &base_policy_set ) == PSA_SUCCESS );
             TEST_ASSERT( psa_import_key( base_key, PSA_KEY_TYPE_DERIVE,
                                          data->x, data->len ) == PSA_SUCCESS );
             /* Derive a key. */
@@ -4152,8 +4152,8 @@ void persistent_key_load_key_from_storage( data_t *data, int type_arg,
                                              NULL, 0, NULL, 0,
                                              export_size ) == PSA_SUCCESS );
             TEST_ASSERT( psa_generator_import_key(
-                handle, PSA_KEY_TYPE_RAW_DATA,
-                bits, &generator ) == PSA_SUCCESS );
+                             handle, PSA_KEY_TYPE_RAW_DATA,
+                             bits, &generator ) == PSA_SUCCESS );
             break;
     }
 
@@ -4169,15 +4169,15 @@ void persistent_key_load_key_from_storage( data_t *data, int type_arg,
     TEST_ASSERT( psa_open_key( PSA_KEY_LIFETIME_PERSISTENT, 1,
                                &handle ) == PSA_SUCCESS );
     TEST_ASSERT( psa_get_key_information(
-        handle, &type_get, &bits_get ) == PSA_SUCCESS );
+                     handle, &type_get, &bits_get ) == PSA_SUCCESS );
     TEST_ASSERT( type_get == type );
     TEST_ASSERT( bits_get == (size_t) bits );
 
     TEST_ASSERT( psa_get_key_policy( handle, &policy_get ) == PSA_SUCCESS );
     TEST_ASSERT( psa_key_policy_get_usage(
-        &policy_get ) == policy_usage );
+                     &policy_get ) == policy_usage );
     TEST_ASSERT( psa_key_policy_get_algorithm(
-        &policy_get ) == policy_alg );
+                     &policy_get ) == policy_alg );
 
     /* Export the key again */
     TEST_ASSERT( psa_export_key( handle, second_export, export_size,

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -13,12 +13,6 @@
 
 #define MAX( x, y ) ( ( x ) > ( y ) ? ( x ) : ( y ) )
 
-#if(UINT32_MAX > SIZE_MAX)
-#define PSA_CRYPTO_TEST_SIZE_T_RANGE( x ) ( ( x ) <= SIZE_MAX )
-#else
-#define PSA_CRYPTO_TEST_SIZE_T_RANGE( x ) 1
-#endif
-
 /** An invalid export length that will never be set by psa_export_key(). */
 static const size_t INVALID_EXPORT_LENGTH = ~0U;
 
@@ -884,7 +878,6 @@ void import( data_t *data, int type, int expected_status_arg )
     psa_status_t status;
 
     TEST_ASSERT( data != NULL );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( data->len ) );
     PSA_ASSERT( psa_crypto_init( ) );
 
     PSA_ASSERT( psa_allocate_key( type, KEY_BITS_FROM_DATA( type, data ),
@@ -1003,7 +996,6 @@ void import_export( data_t *data,
     psa_key_policy_t policy;
 
     TEST_ASSERT( data != NULL );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( data->len ) );
     export_size = (ptrdiff_t) data->len + export_size_delta;
     ASSERT_ALLOC( exported, export_size );
     if( ! canonical_input )
@@ -2016,9 +2008,6 @@ void mac_verify( int key_type_arg,
     TEST_ASSERT( key != NULL );
     TEST_ASSERT( input != NULL );
     TEST_ASSERT( expected_mac != NULL );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( key->len ) );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( input->len ) );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( expected_mac->len ) );
 
     PSA_ASSERT( psa_crypto_init( ) );
 
@@ -2104,9 +2093,6 @@ void cipher_encrypt( int alg_arg, int key_type_arg,
     TEST_ASSERT( key != NULL );
     TEST_ASSERT( input != NULL );
     TEST_ASSERT( expected_output != NULL );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( key->len ) );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( input->len ) );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( expected_output->len ) );
 
     iv_size = PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type );
     memset( iv, 0x2a, iv_size );
@@ -2179,9 +2165,6 @@ void cipher_encrypt_multipart( int alg_arg, int key_type_arg,
     TEST_ASSERT( key != NULL );
     TEST_ASSERT( input != NULL );
     TEST_ASSERT( expected_output != NULL );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( key->len ) );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( input->len ) );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( expected_output->len ) );
 
     iv_size = PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type );
     memset( iv, 0x2a, iv_size );
@@ -2257,9 +2240,6 @@ void cipher_decrypt_multipart( int alg_arg, int key_type_arg,
     TEST_ASSERT( key != NULL );
     TEST_ASSERT( input != NULL );
     TEST_ASSERT( expected_output != NULL );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( key->len ) );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( input->len ) );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( expected_output->len ) );
 
     iv_size = PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type );
     memset( iv, 0x2a, iv_size );
@@ -2337,9 +2317,6 @@ void cipher_decrypt( int alg_arg, int key_type_arg,
     TEST_ASSERT( key != NULL );
     TEST_ASSERT( input != NULL );
     TEST_ASSERT( expected_output != NULL );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( key->len ) );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( input->len ) );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( expected_output->len ) );
 
     iv_size = PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type );
     memset( iv, 0x2a, iv_size );
@@ -2415,8 +2392,6 @@ void cipher_verify_output( int alg_arg, int key_type_arg,
 
     TEST_ASSERT( key != NULL );
     TEST_ASSERT( input != NULL );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( key->len ) );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( input->len ) );
 
     PSA_ASSERT( psa_crypto_init( ) );
 
@@ -2506,8 +2481,6 @@ void cipher_verify_output_multipart( int alg_arg,
 
     TEST_ASSERT( key != NULL );
     TEST_ASSERT( input != NULL );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( key->len ) );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( input->len ) );
 
     PSA_ASSERT( psa_crypto_init( ) );
 
@@ -2614,10 +2587,6 @@ void aead_encrypt_decrypt( int key_type_arg, data_t *key_data,
     TEST_ASSERT( input_data != NULL );
     TEST_ASSERT( nonce != NULL );
     TEST_ASSERT( additional_data != NULL );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( key_data->len ) );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( input_data->len ) );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( nonce->len ) );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( additional_data->len ) );
 
     output_size = input_data->len + tag_length;
     ASSERT_ALLOC( output_data, output_size );
@@ -2691,11 +2660,6 @@ void aead_encrypt( int key_type_arg, data_t *key_data,
     TEST_ASSERT( additional_data != NULL );
     TEST_ASSERT( nonce != NULL );
     TEST_ASSERT( expected_result != NULL );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( key_data->len ) );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( input_data->len ) );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( additional_data->len ) );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( nonce->len ) );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( expected_result->len ) );
 
     output_size = input_data->len + tag_length;
     ASSERT_ALLOC( output_data, output_size );
@@ -2753,11 +2717,6 @@ void aead_decrypt( int key_type_arg, data_t *key_data,
     TEST_ASSERT( additional_data != NULL );
     TEST_ASSERT( nonce != NULL );
     TEST_ASSERT( expected_data != NULL );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( key_data->len ) );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( input_data->len ) );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( additional_data->len ) );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( nonce->len ) );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( expected_data->len ) );
 
     output_size = input_data->len + tag_length;
     ASSERT_ALLOC( output_data, output_size );
@@ -2826,9 +2785,6 @@ void sign_deterministic( int key_type_arg, data_t *key_data,
     TEST_ASSERT( key_data != NULL );
     TEST_ASSERT( input_data != NULL );
     TEST_ASSERT( output_data != NULL );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( key_data->len ) );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( input_data->len ) );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( output_data->len ) );
 
     PSA_ASSERT( psa_crypto_init( ) );
 
@@ -2887,8 +2843,6 @@ void sign_fail( int key_type_arg, data_t *key_data,
 
     TEST_ASSERT( key_data != NULL );
     TEST_ASSERT( input_data != NULL );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( key_data->len ) );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( input_data->len ) );
 
     ASSERT_ALLOC( signature, signature_size );
 
@@ -3011,9 +2965,6 @@ void asymmetric_verify( int key_type_arg, data_t *key_data,
     TEST_ASSERT( key_data != NULL );
     TEST_ASSERT( hash_data != NULL );
     TEST_ASSERT( signature_data != NULL );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( key_data->len ) );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( hash_data->len ) );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( signature_data->len ) );
 
     PSA_ASSERT( psa_crypto_init( ) );
 
@@ -3054,9 +3005,6 @@ void asymmetric_verify_fail( int key_type_arg, data_t *key_data,
     TEST_ASSERT( key_data != NULL );
     TEST_ASSERT( hash_data != NULL );
     TEST_ASSERT( signature_data != NULL );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( key_data->len ) );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( hash_data->len ) );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( signature_data->len ) );
 
     PSA_ASSERT( psa_crypto_init( ) );
 
@@ -3178,8 +3126,6 @@ void asymmetric_encrypt_decrypt( int key_type_arg,
 
     TEST_ASSERT( key_data != NULL );
     TEST_ASSERT( input_data != NULL );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( key_data->len ) );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( input_data->len ) );
 
     PSA_ASSERT( psa_crypto_init( ) );
 
@@ -3252,9 +3198,6 @@ void asymmetric_decrypt( int key_type_arg,
     TEST_ASSERT( key_data != NULL );
     TEST_ASSERT( input_data != NULL );
     TEST_ASSERT( expected_data != NULL );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( key_data->len ) );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( input_data->len ) );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( expected_data->len ) );
 
     output_size = key_data->len;
     ASSERT_ALLOC( output, output_size );
@@ -3325,8 +3268,6 @@ void asymmetric_decrypt_fail( int key_type_arg,
 
     TEST_ASSERT( key_data != NULL );
     TEST_ASSERT( input_data != NULL );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( key_data->len ) );
-    TEST_ASSERT( PSA_CRYPTO_TEST_SIZE_T_RANGE( input_data->len ) );
 
     output_size = key_data->len;
     ASSERT_ALLOC( output, output_size );

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -2135,8 +2135,8 @@ void cipher_encrypt( int alg_arg, int key_type_arg,
 
     TEST_ASSERT( psa_cipher_set_iv( &operation,
                                     iv, iv_size ) == PSA_SUCCESS );
-    output_buffer_size = (size_t) input->len +
-                         PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type );
+    output_buffer_size = ( (size_t) input->len +
+                           PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type ) );
     ASSERT_ALLOC( output, output_buffer_size );
 
     TEST_ASSERT( psa_cipher_update( &operation,
@@ -2210,8 +2210,8 @@ void cipher_encrypt_multipart( int alg_arg, int key_type_arg,
 
     TEST_ASSERT( psa_cipher_set_iv( &operation,
                                     iv, sizeof( iv ) ) == PSA_SUCCESS );
-    output_buffer_size = (size_t) input->len +
-                         PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type );
+    output_buffer_size = ( (size_t) input->len +
+                           PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type ) );
     ASSERT_ALLOC( output, output_buffer_size );
 
     TEST_ASSERT( (unsigned int) first_part_size < input->len );
@@ -2289,8 +2289,8 @@ void cipher_decrypt_multipart( int alg_arg, int key_type_arg,
     TEST_ASSERT( psa_cipher_set_iv( &operation,
                                     iv, sizeof( iv ) ) == PSA_SUCCESS );
 
-    output_buffer_size = (size_t) input->len +
-                         PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type );
+    output_buffer_size = ( (size_t) input->len +
+                           PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type ) );
     ASSERT_ALLOC( output, output_buffer_size );
 
     TEST_ASSERT( (unsigned int) first_part_size < input->len );
@@ -2369,8 +2369,8 @@ void cipher_decrypt( int alg_arg, int key_type_arg,
     TEST_ASSERT( psa_cipher_set_iv( &operation,
                                     iv, iv_size ) == PSA_SUCCESS );
 
-    output_buffer_size = (size_t) input->len +
-                         PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type );
+    output_buffer_size = ( (size_t) input->len +
+                           PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type ) );
     ASSERT_ALLOC( output, output_buffer_size );
 
     TEST_ASSERT( psa_cipher_update( &operation,
@@ -2445,8 +2445,8 @@ void cipher_verify_output( int alg_arg, int key_type_arg,
     TEST_ASSERT( psa_cipher_generate_iv( &operation1,
                                          iv, iv_size,
                                          &iv_length ) == PSA_SUCCESS );
-    output1_size = (size_t) input->len +
-                   PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type );
+    output1_size = ( (size_t) input->len +
+                     PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type ) );
     ASSERT_ALLOC( output1, output1_size );
 
     TEST_ASSERT( psa_cipher_update( &operation1, input->x, input->len,
@@ -2536,8 +2536,8 @@ void cipher_verify_output_multipart( int alg_arg,
     TEST_ASSERT( psa_cipher_generate_iv( &operation1,
                                          iv, iv_size,
                                          &iv_length ) == PSA_SUCCESS );
-    output1_buffer_size = (size_t) input->len +
-                          PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type );
+    output1_buffer_size = ( (size_t) input->len +
+                            PSA_BLOCK_CIPHER_BLOCK_SIZE( key_type ) );
     ASSERT_ALLOC( output1, output1_buffer_size );
 
     TEST_ASSERT( (unsigned int) first_part_size < input->len );

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -11,8 +11,6 @@
 
 #include "psa/crypto.h"
 
-#define MAX( x, y ) ( ( x ) > ( y ) ? ( x ) : ( y ) )
-
 /** An invalid export length that will never be set by psa_export_key(). */
 static const size_t INVALID_EXPORT_LENGTH = ~0U;
 

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -158,9 +158,8 @@ static int exercise_mac_key( psa_key_handle_t handle,
                                           handle, alg ) );
         PSA_ASSERT( psa_mac_update( &operation,
                                     input, sizeof( input ) ) );
-        TEST_EQUAL( psa_mac_verify_finish( &operation,
-                                           mac,
-                                           mac_length ), verify_status );
+        TEST_EQUAL( psa_mac_verify_finish( &operation, mac, mac_length ),
+                    verify_status );
     }
 
     return( 1 );
@@ -273,7 +272,8 @@ static int exercise_aead_key( psa_key_handle_t handle,
                                       NULL, 0,
                                       ciphertext, ciphertext_length,
                                       plaintext, sizeof( plaintext ),
-                                      &plaintext_length ), verify_status );
+                                      &plaintext_length ),
+                    verify_status );
     }
 
     return( 1 );
@@ -334,12 +334,11 @@ static int exercise_asymmetric_encryption_key( psa_key_handle_t handle,
 
     if( usage & PSA_KEY_USAGE_ENCRYPT )
     {
-        PSA_ASSERT(
-            psa_asymmetric_encrypt( handle, alg,
-                                    plaintext, plaintext_length,
-                                    NULL, 0,
-                                    ciphertext, sizeof( ciphertext ),
-                                    &ciphertext_length ) );
+        PSA_ASSERT( psa_asymmetric_encrypt( handle, alg,
+                                            plaintext, plaintext_length,
+                                            NULL, 0,
+                                            ciphertext, sizeof( ciphertext ),
+                                            &ciphertext_length ) );
     }
 
     if( usage & PSA_KEY_USAGE_DECRYPT )
@@ -496,7 +495,8 @@ static int asn1_skip_integer( unsigned char **p, const unsigned char *end,
     size_t actual_bits;
     unsigned char msb;
     TEST_EQUAL( mbedtls_asn1_get_tag( p, end, &len,
-                                      MBEDTLS_ASN1_INTEGER ), 0 );
+                                      MBEDTLS_ASN1_INTEGER ),
+                0 );
     /* Tolerate a slight departure from DER encoding:
      * - 0 may be represented by an empty string or a 1-byte string.
      * - The sign bit may be used as a value bit. */
@@ -646,7 +646,8 @@ static int exported_key_sanity_check( psa_key_type_t type, size_t bits,
          */
         TEST_EQUAL( mbedtls_asn1_get_tag( &p, end, &len,
                                           MBEDTLS_ASN1_SEQUENCE |
-                                          MBEDTLS_ASN1_CONSTRUCTED ), 0 );
+                                          MBEDTLS_ASN1_CONSTRUCTED ),
+                    0 );
         TEST_EQUAL( p + len, end );
         TEST_EQUAL( mbedtls_asn1_get_alg( &p, end, &alg, &params ), 0 );
         if( ! is_oid_of_key_type( type, alg.p, alg.len ) )
@@ -664,7 +665,8 @@ static int exported_key_sanity_check( psa_key_type_t type, size_t bits,
             TEST_EQUAL( bitstring.unused_bits, 0 );
             TEST_EQUAL( mbedtls_asn1_get_tag( &p, end, &len,
                                               MBEDTLS_ASN1_SEQUENCE |
-                                              MBEDTLS_ASN1_CONSTRUCTED ), 0 );
+                                              MBEDTLS_ASN1_CONSTRUCTED ),
+                        0 );
             TEST_EQUAL( p + len, end );
             if( ! asn1_skip_integer( &p, end, bits, bits, 1 ) )
                 goto exit;
@@ -756,8 +758,7 @@ static int exercise_export_public_key( psa_key_handle_t handle )
     PSA_ASSERT( psa_get_key_information( handle, &type, &bits ) );
     if( ! PSA_KEY_TYPE_IS_ASYMMETRIC( type ) )
     {
-        TEST_EQUAL( psa_export_public_key( handle,
-                                           NULL, 0, &exported_length ),
+        TEST_EQUAL( psa_export_public_key( handle, NULL, 0, &exported_length ),
                     PSA_ERROR_INVALID_ARGUMENT );
         return( 1 );
     }
@@ -1014,8 +1015,8 @@ void import_export( data_t *data,
     psa_key_policy_set_usage( &policy, usage_arg, alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
-    TEST_EQUAL( psa_get_key_information(
-                    handle, NULL, NULL ), PSA_ERROR_EMPTY_SLOT );
+    TEST_EQUAL( psa_get_key_information( handle, NULL, NULL ),
+                PSA_ERROR_EMPTY_SLOT );
 
     /* Import the key */
     PSA_ASSERT( psa_import_key( handle, type,
@@ -1075,8 +1076,8 @@ void import_export( data_t *data,
 destroy:
     /* Destroy the key */
     PSA_ASSERT( psa_destroy_key( handle ) );
-    TEST_EQUAL( psa_get_key_information(
-                    handle, NULL, NULL ), PSA_ERROR_INVALID_HANDLE );
+    TEST_EQUAL( psa_get_key_information( handle, NULL, NULL ),
+                PSA_ERROR_INVALID_HANDLE );
 
 exit:
     mbedtls_free( exported );
@@ -1826,14 +1827,12 @@ void hash_bad_order( )
 
     /* psa_hash_update without calling psa_hash_setup beforehand */
     memset( &operation, 0, sizeof( operation ) );
-    TEST_EQUAL( psa_hash_update( &operation,
-                                 input, sizeof( input ) ),
+    TEST_EQUAL( psa_hash_update( &operation, input, sizeof( input ) ),
                 PSA_ERROR_INVALID_ARGUMENT );
 
     /* psa_hash_verify without calling psa_hash_setup beforehand */
     memset( &operation, 0, sizeof( operation ) );
-    TEST_EQUAL( psa_hash_verify( &operation,
-                                 hash, sizeof( hash ) ),
+    TEST_EQUAL( psa_hash_verify( &operation, hash, sizeof( hash ) ),
                 PSA_ERROR_INVALID_ARGUMENT );
 
     /* psa_hash_finish without calling psa_hash_setup beforehand */
@@ -1864,20 +1863,17 @@ void hash_verify_bad_args( )
 
     /* psa_hash_verify with a smaller hash than expected */
     PSA_ASSERT( psa_hash_setup( &operation, alg ) );
-    TEST_EQUAL( psa_hash_verify( &operation,
-                                 hash, expected_size - 1 ),
+    TEST_EQUAL( psa_hash_verify( &operation, hash, expected_size - 1 ),
                 PSA_ERROR_INVALID_SIGNATURE );
 
     /* psa_hash_verify with a non-matching hash */
     PSA_ASSERT( psa_hash_setup( &operation, alg ) );
-    TEST_EQUAL( psa_hash_verify( &operation,
-                                 hash + 1, expected_size ),
+    TEST_EQUAL( psa_hash_verify( &operation, hash + 1, expected_size ),
                 PSA_ERROR_INVALID_SIGNATURE );
 
     /* psa_hash_verify with a hash longer than expected */
     PSA_ASSERT( psa_hash_setup( &operation, alg ) );
-    TEST_EQUAL( psa_hash_verify( &operation,
-                                 hash, sizeof( hash ) ),
+    TEST_EQUAL( psa_hash_verify( &operation, hash, sizeof( hash ) ),
                 PSA_ERROR_INVALID_SIGNATURE );
 
 exit:
@@ -1899,8 +1895,8 @@ void hash_finish_bad_args( )
     /* psa_hash_finish with a smaller hash buffer than expected */
     PSA_ASSERT( psa_hash_setup( &operation, alg ) );
     TEST_EQUAL( psa_hash_finish( &operation,
-                                 hash, expected_size - 1,
-                                 &hash_len ), PSA_ERROR_BUFFER_TOO_SMALL );
+                                 hash, expected_size - 1, &hash_len ),
+                PSA_ERROR_BUFFER_TOO_SMALL );
 
 exit:
     mbedtls_psa_crypto_free( );
@@ -2645,7 +2641,8 @@ void aead_encrypt_decrypt( int key_type_arg, data_t *key_data,
                                   additional_data->len,
                                   input_data->x, input_data->len,
                                   output_data, output_size,
-                                  &output_length ), expected_result );
+                                  &output_length ),
+                expected_result );
 
     if( PSA_SUCCESS == expected_result )
     {
@@ -2657,7 +2654,8 @@ void aead_encrypt_decrypt( int key_type_arg, data_t *key_data,
                                       additional_data->len,
                                       output_data, output_length,
                                       output_data2, output_length,
-                                      &output_length2 ), expected_result );
+                                      &output_length2 ),
+                    expected_result );
 
         ASSERT_COMPARE( input_data->x, input_data->len,
                         output_data2, output_length2 );
@@ -2782,7 +2780,8 @@ void aead_decrypt( int key_type_arg, data_t *key_data,
                                   additional_data->len,
                                   input_data->x, input_data->len,
                                   output_data, output_size,
-                                  &output_length ), expected_result );
+                                  &output_length ),
+                expected_result );
 
     if( expected_result == PSA_SUCCESS )
         ASSERT_COMPARE( expected_data->x, expected_data->len,
@@ -2984,11 +2983,10 @@ void sign_verify( int key_type_arg, data_t *key_data,
          * detected as invalid. Flip a bit at the beginning, not at the end,
          * because ECDSA may ignore the last few bits of the input. */
         input_data->x[0] ^= 1;
-        TEST_EQUAL( psa_asymmetric_verify(
-                        handle, alg,
-                        input_data->x, input_data->len,
-                        signature,
-                        signature_length ), PSA_ERROR_INVALID_SIGNATURE );
+        TEST_EQUAL( psa_asymmetric_verify( handle, alg,
+                                           input_data->x, input_data->len,
+                                           signature, signature_length ),
+                    PSA_ERROR_INVALID_SIGNATURE );
     }
 
 exit:
@@ -3409,7 +3407,8 @@ void derive_setup( int key_type_arg,
     TEST_EQUAL( psa_key_derivation( &generator, handle, alg,
                                     salt->x, salt->len,
                                     label->x, label->len,
-                                    requested_capacity ), expected_status );
+                                    requested_capacity ),
+                expected_status );
 
 exit:
     psa_generator_abort( &generator );
@@ -3455,13 +3454,13 @@ void test_derive_invalid_generator_state( )
     TEST_EQUAL(  psa_key_derivation( &generator, handle, alg,
                                      NULL, 0,
                                      NULL, 0,
-                                     capacity ), PSA_ERROR_BAD_STATE );
+                                     capacity ),
+                 PSA_ERROR_BAD_STATE );
 
-    PSA_ASSERT( psa_generator_read( &generator, buffer, capacity )
-        );
+    PSA_ASSERT( psa_generator_read( &generator, buffer, capacity ) );
 
-    TEST_EQUAL( psa_generator_read( &generator, buffer, capacity )
-                , PSA_ERROR_INSUFFICIENT_CAPACITY );
+    TEST_EQUAL( psa_generator_read( &generator, buffer, capacity ),
+                PSA_ERROR_INSUFFICIENT_CAPACITY );
 
 exit:
     psa_generator_abort( &generator );
@@ -3649,9 +3648,8 @@ void derive_full( int alg_arg,
     }
 
     /* Check that the generator refuses to go over capacity. */
-    TEST_EQUAL( psa_generator_read( &generator,
-                                    output_buffer,
-                                    1 ), PSA_ERROR_INSUFFICIENT_CAPACITY );
+    TEST_EQUAL( psa_generator_read( &generator, output_buffer, 1 ),
+                PSA_ERROR_INSUFFICIENT_CAPACITY );
 
     PSA_ASSERT( psa_generator_abort( &generator ) );
 
@@ -3847,7 +3845,8 @@ void key_agreement_setup( int alg_arg,
     TEST_EQUAL( psa_key_agreement( &generator,
                                    our_key,
                                    peer_key_data->x, peer_key_data->len,
-                                   alg ), expected_status_arg );
+                                   alg ),
+                expected_status_arg );
 
 exit:
     psa_generator_abort( &generator );
@@ -3946,18 +3945,16 @@ void key_agreement_output( int alg_arg,
                                    peer_key_data->x, peer_key_data->len,
                                    alg ) );
 
-    PSA_ASSERT(
-        psa_generator_read( &generator,
-                            actual_output,
-                            expected_output1->len ) );
+    PSA_ASSERT( psa_generator_read( &generator,
+                                    actual_output,
+                                    expected_output1->len ) );
     TEST_EQUAL( memcmp( actual_output, expected_output1->x,
                         expected_output1->len ), 0 );
     if( expected_output2->len != 0 )
     {
-        PSA_ASSERT(
-            psa_generator_read( &generator,
-                                actual_output,
-                                expected_output2->len ) );
+        PSA_ASSERT( psa_generator_read( &generator,
+                                        actual_output,
+                                        expected_output2->len ) );
         TEST_EQUAL( memcmp( actual_output, expected_output2->x,
                             expected_output2->len ), 0 );
     }
@@ -4047,13 +4044,12 @@ void generate_key( int type_arg,
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
     /* Generate a key */
-    TEST_EQUAL( psa_generate_key( handle, type, bits,
-                                  NULL, 0 ), expected_status );
+    TEST_EQUAL( psa_generate_key( handle, type, bits, NULL, 0 ),
+                expected_status );
 
     /* Test the key information */
-    TEST_EQUAL( psa_get_key_information( handle,
-                                         &got_type,
-                                         &got_bits ), expected_info_status );
+    TEST_EQUAL( psa_get_key_information( handle, &got_type, &got_bits ),
+                expected_info_status );
     if( expected_info_status != PSA_SUCCESS )
         goto exit;
     TEST_EQUAL( got_type, type );
@@ -4144,8 +4140,10 @@ void persistent_key_load_key_from_storage( data_t *data, int type_arg,
     }
 
     /* Export the key */
-    TEST_EQUAL( psa_export_key( handle, first_export, export_size,
-                                &first_exported_length ), export_status );
+    TEST_EQUAL( psa_export_key( handle,
+                                first_export, export_size,
+                                &first_exported_length ),
+                export_status );
 
     /* Shutdown and restart */
     mbedtls_psa_crypto_free();
@@ -4160,14 +4158,14 @@ void persistent_key_load_key_from_storage( data_t *data, int type_arg,
     TEST_EQUAL( bits_get, (size_t) bits );
 
     PSA_ASSERT( psa_get_key_policy( handle, &policy_get ) );
-    TEST_EQUAL( psa_key_policy_get_usage(
-                    &policy_get ), policy_usage );
-    TEST_EQUAL( psa_key_policy_get_algorithm(
-                    &policy_get ), policy_alg );
+    TEST_EQUAL( psa_key_policy_get_usage( &policy_get ), policy_usage );
+    TEST_EQUAL( psa_key_policy_get_algorithm( &policy_get ), policy_alg );
 
     /* Export the key again */
-    TEST_EQUAL( psa_export_key( handle, second_export, export_size,
-                                &second_exported_length ), export_status );
+    TEST_EQUAL( psa_export_key( handle,
+                                second_export, export_size,
+                                &second_exported_length ),
+                export_status );
 
     if( export_status == PSA_SUCCESS )
     {

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -1985,8 +1985,8 @@ void mac_sign( int key_type_arg,
                                      &mac_length ) );
 
     /* Compare with the expected value. */
-    TEST_EQUAL( mac_length, expected_mac->len );
-    TEST_EQUAL( memcmp( actual_mac, expected_mac->x, mac_length ), 0 );
+    ASSERT_COMPARE( expected_mac->x, expected_mac->len,
+                    actual_mac, mac_length );
 
     /* Verify that the end of the buffer is untouched. */
     TEST_ASSERT( mem_is_char( actual_mac + mac_length, '+',
@@ -3576,8 +3576,8 @@ void derive_output( int alg_arg,
         /* Success. Check the read data. */
         PSA_ASSERT( status );
         if( output_sizes[i] != 0 )
-            TEST_EQUAL( memcmp( output_buffer, expected_outputs[i],
-                                output_sizes[i] ), 0 );
+            ASSERT_COMPARE( output_buffer, output_sizes[i],
+                            expected_outputs[i], output_sizes[i] );
         /* Check the generator status. */
         expected_capacity -= output_sizes[i];
         PSA_ASSERT( psa_get_generator_capacity( &generator,
@@ -3805,7 +3805,8 @@ void derive_key_export( int alg_arg,
     TEST_EQUAL( length, bytes2 );
 
     /* Compare the outputs from the two runs. */
-    TEST_EQUAL( memcmp( output_buffer, export_buffer, capacity ), 0 );
+    ASSERT_COMPARE( output_buffer, bytes1 + bytes2,
+                    export_buffer, capacity );
 
 exit:
     mbedtls_free( output_buffer );
@@ -3948,15 +3949,15 @@ void key_agreement_output( int alg_arg,
     PSA_ASSERT( psa_generator_read( &generator,
                                     actual_output,
                                     expected_output1->len ) );
-    TEST_EQUAL( memcmp( actual_output, expected_output1->x,
-                        expected_output1->len ), 0 );
+    ASSERT_COMPARE( actual_output, expected_output1->len,
+                    expected_output1->x, expected_output1->len );
     if( expected_output2->len != 0 )
     {
         PSA_ASSERT( psa_generator_read( &generator,
                                         actual_output,
                                         expected_output2->len ) );
-        TEST_EQUAL( memcmp( actual_output, expected_output2->x,
-                            expected_output2->len ), 0 );
+        ASSERT_COMPARE( actual_output, expected_output2->len,
+                        expected_output2->x, expected_output2->len );
     }
 
 exit:
@@ -3993,7 +3994,8 @@ void generate_random( int bytes_arg )
         PSA_ASSERT( psa_generate_random( output, bytes ) );
 
         /* Check that no more than bytes have been overwritten */
-        TEST_EQUAL( memcmp( output + bytes, trail, sizeof( trail ) ), 0 );
+        ASSERT_COMPARE( output + bytes, sizeof( trail ),
+                        trail, sizeof( trail ) );
 
         for( i = 0; i < bytes; i++ )
         {

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -13,8 +13,6 @@
 
 #define MAX( x, y ) ( ( x ) > ( y ) ? ( x ) : ( y ) )
 
-#define ARRAY_LENGTH( array ) ( sizeof( array ) / sizeof( *( array ) ) )
-
 #if(UINT32_MAX > SIZE_MAX)
 #define PSA_CRYPTO_TEST_SIZE_T_RANGE( x ) ( ( x ) <= SIZE_MAX )
 #else

--- a/tests/suites/test_suite_psa_crypto_entropy.function
+++ b/tests/suites/test_suite_psa_crypto_entropy.function
@@ -55,9 +55,9 @@ void validate_entropy_seed_injection( int seed_length_a,
     TEST_ASSERT( status == expected_status_a );
     status = mbedtls_psa_inject_entropy( seed, seed_length_b );
     TEST_ASSERT( status == expected_status_b );
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_generate_random( output,
-                                      sizeof( output ) ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
+    PSA_ASSERT( psa_generate_random( output,
+                                     sizeof( output ) ) );
     TEST_ASSERT( memcmp( output, zeros, sizeof( output ) ) != 0 );
 exit:
     mbedtls_free( seed );
@@ -82,15 +82,15 @@ void run_entropy_inject_with_crypto_init( )
     TEST_ASSERT( ( its_status == PSA_ITS_SUCCESS ) ||
                  ( its_status == PSA_ITS_ERROR_KEY_NOT_FOUND ) );
     status = mbedtls_psa_inject_entropy( seed, sizeof( seed ) );
-    TEST_ASSERT( status == PSA_SUCCESS );
+    PSA_ASSERT( status );
     its_status =  psa_its_remove( PSA_CRYPTO_ITS_RANDOM_SEED_UID );
     TEST_ASSERT( its_status == PSA_ITS_SUCCESS );
     status = psa_crypto_init( );
     TEST_ASSERT( status == PSA_ERROR_INSUFFICIENT_ENTROPY );
     status = mbedtls_psa_inject_entropy( seed, sizeof( seed ) );
-    TEST_ASSERT( status == PSA_SUCCESS );
+    PSA_ASSERT( status );
     status = psa_crypto_init( );
-    TEST_ASSERT( status == PSA_SUCCESS );
+    PSA_ASSERT( status );
     mbedtls_psa_crypto_free( );
     /* The seed is written by nv_seed callback functions therefore the injection will fail */
     status = mbedtls_psa_inject_entropy( seed, sizeof( seed ) );

--- a/tests/suites/test_suite_psa_crypto_entropy.function
+++ b/tests/suites/test_suite_psa_crypto_entropy.function
@@ -52,9 +52,9 @@ void validate_entropy_seed_injection( int seed_length_a,
     TEST_ASSERT( ( its_status == PSA_ITS_SUCCESS ) ||
                  ( its_status == PSA_ITS_ERROR_KEY_NOT_FOUND ) );
     status = mbedtls_psa_inject_entropy( seed, seed_length_a );
-    TEST_ASSERT( status == expected_status_a );
+    TEST_EQUAL( status, expected_status_a );
     status = mbedtls_psa_inject_entropy( seed, seed_length_b );
-    TEST_ASSERT( status == expected_status_b );
+    TEST_EQUAL( status, expected_status_b );
     PSA_ASSERT( psa_crypto_init( ) );
     PSA_ASSERT( psa_generate_random( output,
                                      sizeof( output ) ) );
@@ -84,9 +84,9 @@ void run_entropy_inject_with_crypto_init( )
     status = mbedtls_psa_inject_entropy( seed, sizeof( seed ) );
     PSA_ASSERT( status );
     its_status =  psa_its_remove( PSA_CRYPTO_ITS_RANDOM_SEED_UID );
-    TEST_ASSERT( its_status == PSA_ITS_SUCCESS );
+    TEST_EQUAL( its_status, PSA_ITS_SUCCESS );
     status = psa_crypto_init( );
-    TEST_ASSERT( status == PSA_ERROR_INSUFFICIENT_ENTROPY );
+    TEST_EQUAL( status, PSA_ERROR_INSUFFICIENT_ENTROPY );
     status = mbedtls_psa_inject_entropy( seed, sizeof( seed ) );
     PSA_ASSERT( status );
     status = psa_crypto_init( );
@@ -94,7 +94,7 @@ void run_entropy_inject_with_crypto_init( )
     mbedtls_psa_crypto_free( );
     /* The seed is written by nv_seed callback functions therefore the injection will fail */
     status = mbedtls_psa_inject_entropy( seed, sizeof( seed ) );
-    TEST_ASSERT( status == PSA_ERROR_NOT_PERMITTED );
+    TEST_EQUAL( status, PSA_ERROR_NOT_PERMITTED );
 exit:
     psa_its_remove( PSA_CRYPTO_ITS_RANDOM_SEED_UID );
     mbedtls_psa_crypto_free( );

--- a/tests/suites/test_suite_psa_crypto_entropy.function
+++ b/tests/suites/test_suite_psa_crypto_entropy.function
@@ -6,11 +6,6 @@
 #include "mbedtls/entropy.h"
 #include "mbedtls/entropy_poll.h"
 
-/* MAX value support macro */
-#if !defined(MAX)
-#define MAX(a,b) (((a)>(b))?(a):(b))
-#endif
-
 /* Calculating the minimum allowed entropy size in bytes */
 #define MBEDTLS_PSA_INJECT_ENTROPY_MIN_SIZE MAX(MBEDTLS_ENTROPY_MIN_PLATFORM, MBEDTLS_ENTROPY_BLOCK_SIZE)
 

--- a/tests/suites/test_suite_psa_crypto_hash.function
+++ b/tests/suites/test_suite_psa_crypto_hash.function
@@ -23,14 +23,14 @@ void hash_finish( int alg_arg, data_t *input, data_t *expected_hash )
     size_t actual_hash_length;
     psa_hash_operation_t operation;
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_hash_setup( &operation, alg ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_hash_update( &operation,
-                                  input->x, input->len ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_hash_finish( &operation,
-                                  actual_hash, sizeof( actual_hash ),
-                                  &actual_hash_length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_hash_setup( &operation, alg ) );
+    PSA_ASSERT( psa_hash_update( &operation,
+                                 input->x, input->len ) );
+    PSA_ASSERT( psa_hash_finish( &operation,
+                                 actual_hash, sizeof( actual_hash ),
+                                 &actual_hash_length ) );
     ASSERT_COMPARE( expected_hash->x, expected_hash->len,
                     actual_hash, actual_hash_length );
 
@@ -45,15 +45,15 @@ void hash_verify( int alg_arg, data_t *input, data_t *expected_hash )
     psa_algorithm_t alg = alg_arg;
     psa_hash_operation_t operation;
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_hash_setup( &operation, alg ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_hash_update( &operation,
-                                  input->x,
-                                  input->len ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_hash_verify( &operation,
-                                  expected_hash->x,
-                                  expected_hash->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_hash_setup( &operation, alg ) );
+    PSA_ASSERT( psa_hash_update( &operation,
+                                 input->x,
+                                 input->len ) );
+    PSA_ASSERT( psa_hash_verify( &operation,
+                                 expected_hash->x,
+                                 expected_hash->len ) );
 
 exit:
     mbedtls_psa_crypto_free( );
@@ -69,22 +69,21 @@ void hash_multi_part( int alg_arg, data_t *input, data_t *expected_hash )
     psa_hash_operation_t operation;
     uint32_t len = 0;
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
     do
     {
         memset( actual_hash, 0, sizeof( actual_hash ) );
-        TEST_ASSERT( psa_hash_setup( &operation, alg ) == PSA_SUCCESS );
+        PSA_ASSERT( psa_hash_setup( &operation, alg ) );
 
-        TEST_ASSERT( psa_hash_update( &operation,
-                                      input->x, len ) == PSA_SUCCESS );
-        TEST_ASSERT( psa_hash_update( &operation,
-                                      input->x + len, input->len - len ) ==
-                     PSA_SUCCESS );
+        PSA_ASSERT( psa_hash_update( &operation,
+                                     input->x, len ) );
+        PSA_ASSERT( psa_hash_update( &operation,
+                                     input->x + len, input->len - len ) );
 
-        TEST_ASSERT( psa_hash_finish( &operation,
-                                      actual_hash, sizeof( actual_hash ),
-                                      &actual_hash_length ) == PSA_SUCCESS );
+        PSA_ASSERT( psa_hash_finish( &operation,
+                                     actual_hash, sizeof( actual_hash ),
+                                     &actual_hash_length ) );
 
         ASSERT_COMPARE( expected_hash->x, expected_hash->len,
                         actual_hash, actual_hash_length );

--- a/tests/suites/test_suite_psa_crypto_hash.function
+++ b/tests/suites/test_suite_psa_crypto_hash.function
@@ -15,7 +15,7 @@
  * END_DEPENDENCIES
  */
 
- /* BEGIN_CASE */
+/* BEGIN_CASE */
 void hash_finish( int alg_arg, data_t *input, data_t *expected_hash )
 {
     psa_algorithm_t alg = alg_arg;
@@ -80,7 +80,7 @@ void hash_multi_part( int alg_arg, data_t *input, data_t *expected_hash )
                                       input->x, len ) == PSA_SUCCESS );
         TEST_ASSERT( psa_hash_update( &operation,
                                       input->x + len, input->len - len ) ==
-                                      PSA_SUCCESS );
+                     PSA_SUCCESS );
 
         TEST_ASSERT( psa_hash_finish( &operation,
                                       actual_hash, sizeof( actual_hash ),

--- a/tests/suites/test_suite_psa_crypto_init.function
+++ b/tests/suites/test_suite_psa_crypto_init.function
@@ -12,9 +12,6 @@
 #include "mbedtls/entropy.h"
 #include "mbedtls/entropy_poll.h"
 
-#define MIN( x, y ) ( ( x ) < ( y ) ? ( x ) : ( y ) )
-#define MAX( x, y ) ( ( x ) > ( y ) ? ( x ) : ( y ) )
-
 #define ENTROPY_MIN_NV_SEED_SIZE                                        \
     MAX(MBEDTLS_ENTROPY_MIN_PLATFORM, MBEDTLS_ENTROPY_BLOCK_SIZE)
 

--- a/tests/suites/test_suite_psa_crypto_init.function
+++ b/tests/suites/test_suite_psa_crypto_init.function
@@ -176,7 +176,7 @@ void validate_module_init_generate_random( int count )
         mbedtls_psa_crypto_free( );
     }
     status = psa_generate_random( random, sizeof( random ) );
-    TEST_ASSERT( status == PSA_ERROR_BAD_STATE );
+    TEST_EQUAL( status, PSA_ERROR_BAD_STATE );
 }
 /* END_CASE */
 
@@ -193,7 +193,7 @@ void validate_module_init_key_based( int count )
         mbedtls_psa_crypto_free( );
     }
     status = psa_import_key( 1, PSA_KEY_TYPE_RAW_DATA, data, sizeof( data ) );
-    TEST_ASSERT( status == PSA_ERROR_BAD_STATE );
+    TEST_EQUAL( status, PSA_ERROR_BAD_STATE );
 }
 /* END_CASE */
 
@@ -207,7 +207,7 @@ void custom_entropy_sources( int sources_arg, int expected_init_status_arg )
     PSA_ASSERT( mbedtls_psa_crypto_configure_entropy_sources(
                     custom_entropy_init, mbedtls_entropy_free ) );
 
-    TEST_ASSERT( psa_crypto_init( ) == expected_init_status );
+    TEST_EQUAL( psa_crypto_init( ), expected_init_status );
     if( expected_init_status != PSA_SUCCESS )
         goto exit;
 
@@ -247,7 +247,7 @@ void fake_entropy_source( int threshold,
     PSA_ASSERT( mbedtls_psa_crypto_configure_entropy_sources(
                     custom_entropy_init, mbedtls_entropy_free ) );
 
-    TEST_ASSERT( psa_crypto_init( ) == expected_init_status );
+    TEST_EQUAL( psa_crypto_init( ), expected_init_status );
     if( expected_init_status != PSA_SUCCESS )
         goto exit;
 
@@ -274,7 +274,7 @@ void entropy_from_nv_seed( int seed_size_arg,
     PSA_ASSERT( mbedtls_psa_crypto_configure_entropy_sources(
                     custom_entropy_init, mbedtls_entropy_free ) );
 
-    TEST_ASSERT( psa_crypto_init( ) == expected_init_status );
+    TEST_EQUAL( psa_crypto_init( ), expected_init_status );
     if( expected_init_status != PSA_SUCCESS )
         goto exit;
 

--- a/tests/suites/test_suite_psa_crypto_init.function
+++ b/tests/suites/test_suite_psa_crypto_init.function
@@ -142,9 +142,9 @@ void init_deinit( int count )
     for( i = 0; i < count; i++ )
     {
         status = psa_crypto_init( );
-        TEST_ASSERT( status == PSA_SUCCESS );
+        PSA_ASSERT( status );
         status = psa_crypto_init( );
-        TEST_ASSERT( status == PSA_SUCCESS );
+        PSA_ASSERT( status );
         mbedtls_psa_crypto_free( );
     }
 }
@@ -156,7 +156,7 @@ void deinit_without_init( int count )
     int i;
     for( i = 0; i < count; i++ )
     {
-        TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+        PSA_ASSERT( psa_crypto_init( ) );
         mbedtls_psa_crypto_free( );
     }
     mbedtls_psa_crypto_free( );
@@ -172,7 +172,7 @@ void validate_module_init_generate_random( int count )
     for( i = 0; i < count; i++ )
     {
         status = psa_crypto_init( );
-        TEST_ASSERT( status == PSA_SUCCESS );
+        PSA_ASSERT( status );
         mbedtls_psa_crypto_free( );
     }
     status = psa_generate_random( random, sizeof( random ) );
@@ -189,7 +189,7 @@ void validate_module_init_key_based( int count )
     for( i = 0; i < count; i++ )
     {
         status = psa_crypto_init( );
-        TEST_ASSERT( status == PSA_SUCCESS );
+        PSA_ASSERT( status );
         mbedtls_psa_crypto_free( );
     }
     status = psa_import_key( 1, PSA_KEY_TYPE_RAW_DATA, data, sizeof( data ) );
@@ -204,16 +204,14 @@ void custom_entropy_sources( int sources_arg, int expected_init_status_arg )
     uint8_t random[10] = { 0 };
 
     custom_entropy_sources_mask = sources_arg;
-    TEST_ASSERT( mbedtls_psa_crypto_configure_entropy_sources(
-                     custom_entropy_init, mbedtls_entropy_free ) ==
-                 PSA_SUCCESS );
+    PSA_ASSERT( mbedtls_psa_crypto_configure_entropy_sources(
+                    custom_entropy_init, mbedtls_entropy_free ) );
 
     TEST_ASSERT( psa_crypto_init( ) == expected_init_status );
     if( expected_init_status != PSA_SUCCESS )
         goto exit;
 
-    TEST_ASSERT( psa_generate_random( random, sizeof( random ) ) ==
-                 PSA_SUCCESS );
+    PSA_ASSERT( psa_generate_random( random, sizeof( random ) ) );
 
 exit:
     mbedtls_psa_crypto_free( );
@@ -246,16 +244,14 @@ void fake_entropy_source( int threshold,
     fake_entropy_state.length_sequence = lengths;
 
     custom_entropy_sources_mask = ENTROPY_SOURCE_FAKE;
-    TEST_ASSERT( mbedtls_psa_crypto_configure_entropy_sources(
-                     custom_entropy_init, mbedtls_entropy_free ) ==
-                 PSA_SUCCESS );
+    PSA_ASSERT( mbedtls_psa_crypto_configure_entropy_sources(
+                    custom_entropy_init, mbedtls_entropy_free ) );
 
     TEST_ASSERT( psa_crypto_init( ) == expected_init_status );
     if( expected_init_status != PSA_SUCCESS )
         goto exit;
 
-    TEST_ASSERT( psa_generate_random( random, sizeof( random ) ) ==
-                 PSA_SUCCESS );
+    PSA_ASSERT( psa_generate_random( random, sizeof( random ) ) );
 
 exit:
     mbedtls_psa_crypto_free( );
@@ -275,16 +271,14 @@ void entropy_from_nv_seed( int seed_size_arg,
     TEST_ASSERT( mbedtls_nv_seed_write( seed, seed_size ) >= 0 );
 
     custom_entropy_sources_mask = ENTROPY_SOURCE_NV_SEED;
-    TEST_ASSERT( mbedtls_psa_crypto_configure_entropy_sources(
-                     custom_entropy_init, mbedtls_entropy_free ) ==
-                 PSA_SUCCESS );
+    PSA_ASSERT( mbedtls_psa_crypto_configure_entropy_sources(
+                    custom_entropy_init, mbedtls_entropy_free ) );
 
     TEST_ASSERT( psa_crypto_init( ) == expected_init_status );
     if( expected_init_status != PSA_SUCCESS )
         goto exit;
 
-    TEST_ASSERT( psa_generate_random( random, sizeof( random ) ) ==
-                 PSA_SUCCESS );
+    PSA_ASSERT( psa_generate_random( random, sizeof( random ) ) );
 
 exit:
     mbedtls_free( seed );

--- a/tests/suites/test_suite_psa_crypto_metadata.function
+++ b/tests/suites/test_suite_psa_crypto_metadata.function
@@ -287,20 +287,17 @@ void aead_algorithm( int alg_arg, int classification_flags,
     {
         psa_algorithm_t truncated_alg = PSA_ALG_AEAD_WITH_TAG_LENGTH( alg, n );
         aead_algorithm_core( truncated_alg, classification_flags, n );
-        TEST_EQUAL(
-            PSA_ALG_AEAD_WITH_DEFAULT_TAG_LENGTH( truncated_alg ), alg );
+        TEST_EQUAL( PSA_ALG_AEAD_WITH_DEFAULT_TAG_LENGTH( truncated_alg ),
+                    alg );
         /* Check that calling PSA_ALG_AEAD_WITH_DEFAULT_TAG_LENGTH twice gives
          * the length of the outer truncation (even if the outer length is
          * smaller than the inner length). */
-        TEST_EQUAL(
-            PSA_ALG_AEAD_WITH_TAG_LENGTH( truncated_alg, 1 ),
-            PSA_ALG_AEAD_WITH_TAG_LENGTH( alg, 1 ) );
-        TEST_EQUAL(
-            PSA_ALG_AEAD_WITH_TAG_LENGTH( truncated_alg, tag_length - 1 ),
-            PSA_ALG_AEAD_WITH_TAG_LENGTH( alg, tag_length - 1) );
-        TEST_EQUAL(
-            PSA_ALG_AEAD_WITH_TAG_LENGTH( truncated_alg, tag_length ),
-            PSA_ALG_AEAD_WITH_TAG_LENGTH( alg, tag_length ) );
+        TEST_EQUAL( PSA_ALG_AEAD_WITH_TAG_LENGTH( truncated_alg, 1 ),
+                    PSA_ALG_AEAD_WITH_TAG_LENGTH( alg, 1 ) );
+        TEST_EQUAL( PSA_ALG_AEAD_WITH_TAG_LENGTH( truncated_alg, tag_length - 1 ),
+                    PSA_ALG_AEAD_WITH_TAG_LENGTH( alg, tag_length - 1) );
+        TEST_EQUAL( PSA_ALG_AEAD_WITH_TAG_LENGTH( truncated_alg, tag_length ),
+                    PSA_ALG_AEAD_WITH_TAG_LENGTH( alg, tag_length ) );
     }
 }
 /* END_CASE */

--- a/tests/suites/test_suite_psa_crypto_metadata.function
+++ b/tests/suites/test_suite_psa_crypto_metadata.function
@@ -83,15 +83,15 @@ void key_type_classification( psa_key_type_t type, unsigned flags )
     TEST_CLASSIFICATION_MACRO( KEY_TYPE_IS_ECC, type, flags );
 
     /* Macros with derived semantics */
-    TEST_ASSERT( PSA_KEY_TYPE_IS_ASYMMETRIC( type ) ==
-                 ( PSA_KEY_TYPE_IS_PUBLIC_KEY( type ) ||
-                   PSA_KEY_TYPE_IS_KEYPAIR( type ) ) );
-    TEST_ASSERT( PSA_KEY_TYPE_IS_ECC_KEYPAIR( type ) ==
-                 ( PSA_KEY_TYPE_IS_ECC( type ) &&
-                   PSA_KEY_TYPE_IS_KEYPAIR( type ) ) );
-    TEST_ASSERT( PSA_KEY_TYPE_IS_ECC_PUBLIC_KEY( type ) ==
-                 ( PSA_KEY_TYPE_IS_ECC( type ) &&
-                   PSA_KEY_TYPE_IS_PUBLIC_KEY( type ) ) );
+    TEST_EQUAL( PSA_KEY_TYPE_IS_ASYMMETRIC( type ),
+                ( PSA_KEY_TYPE_IS_PUBLIC_KEY( type ) ||
+                  PSA_KEY_TYPE_IS_KEYPAIR( type ) ) );
+    TEST_EQUAL( PSA_KEY_TYPE_IS_ECC_KEYPAIR( type ),
+                ( PSA_KEY_TYPE_IS_ECC( type ) &&
+                  PSA_KEY_TYPE_IS_KEYPAIR( type ) ) );
+    TEST_EQUAL( PSA_KEY_TYPE_IS_ECC_PUBLIC_KEY( type ),
+                ( PSA_KEY_TYPE_IS_ECC( type ) &&
+                  PSA_KEY_TYPE_IS_PUBLIC_KEY( type ) ) );
 
 exit: ;
 }
@@ -113,7 +113,7 @@ void mac_algorithm_core( psa_algorithm_t alg, int classification_flags,
     algorithm_classification( alg, classification_flags );
 
     /* Length */
-    TEST_ASSERT( length == PSA_MAC_FINAL_SIZE( key_type, key_bits, alg ) );
+    TEST_EQUAL( length, PSA_MAC_FINAL_SIZE( key_type, key_bits, alg ) );
 
 exit: ;
 }
@@ -134,7 +134,7 @@ void aead_algorithm_core( psa_algorithm_t alg, int classification_flags,
     algorithm_classification( alg, classification_flags );
 
     /* Tag length */
-    TEST_ASSERT( tag_length == PSA_AEAD_TAG_LENGTH( alg ) );
+    TEST_EQUAL( tag_length, PSA_AEAD_TAG_LENGTH( alg ) );
 
 exit: ;
 }
@@ -174,18 +174,18 @@ void hash_algorithm( int alg_arg, int length_arg )
     algorithm_classification( alg, 0 );
 
     /* Dependent algorithms */
-    TEST_ASSERT( PSA_ALG_HMAC_GET_HASH( hmac_alg ) == alg );
-    TEST_ASSERT( PSA_ALG_SIGN_GET_HASH( rsa_pkcs1v15_sign_alg ) == alg );
-    TEST_ASSERT( PSA_ALG_SIGN_GET_HASH( rsa_pss_alg ) == alg );
-    TEST_ASSERT( PSA_ALG_SIGN_GET_HASH( dsa_alg ) == alg );
-    TEST_ASSERT( PSA_ALG_SIGN_GET_HASH( deterministic_dsa_alg ) == alg );
-    TEST_ASSERT( PSA_ALG_SIGN_GET_HASH( ecdsa_alg ) == alg );
-    TEST_ASSERT( PSA_ALG_SIGN_GET_HASH( deterministic_ecdsa_alg ) == alg );
-    TEST_ASSERT( PSA_ALG_RSA_OAEP_GET_HASH( rsa_oaep_alg ) == alg );
-    TEST_ASSERT( PSA_ALG_HKDF_GET_HASH( hkdf_alg ) == alg );
+    TEST_EQUAL( PSA_ALG_HMAC_GET_HASH( hmac_alg ), alg );
+    TEST_EQUAL( PSA_ALG_SIGN_GET_HASH( rsa_pkcs1v15_sign_alg ), alg );
+    TEST_EQUAL( PSA_ALG_SIGN_GET_HASH( rsa_pss_alg ), alg );
+    TEST_EQUAL( PSA_ALG_SIGN_GET_HASH( dsa_alg ), alg );
+    TEST_EQUAL( PSA_ALG_SIGN_GET_HASH( deterministic_dsa_alg ), alg );
+    TEST_EQUAL( PSA_ALG_SIGN_GET_HASH( ecdsa_alg ), alg );
+    TEST_EQUAL( PSA_ALG_SIGN_GET_HASH( deterministic_ecdsa_alg ), alg );
+    TEST_EQUAL( PSA_ALG_RSA_OAEP_GET_HASH( rsa_oaep_alg ), alg );
+    TEST_EQUAL( PSA_ALG_HKDF_GET_HASH( hkdf_alg ), alg );
 
     /* Hash length */
-    TEST_ASSERT( length == PSA_HASH_SIZE( alg ) );
+    TEST_EQUAL( length, PSA_HASH_SIZE( alg ) );
     TEST_ASSERT( length <= PSA_HASH_MAX_SIZE );
 }
 /* END_CASE */
@@ -203,7 +203,7 @@ void mac_algorithm( int alg_arg, int classification_flags,
 
     mac_algorithm_core( alg, classification_flags,
                         key_type, key_bits, length );
-    TEST_ASSERT( PSA_ALG_FULL_LENGTH_MAC( alg ) == alg );
+    TEST_EQUAL( PSA_ALG_FULL_LENGTH_MAC( alg ), alg );
     TEST_ASSERT( length <= PSA_MAC_MAX_SIZE );
 
     /* Truncated versions */
@@ -212,16 +212,16 @@ void mac_algorithm( int alg_arg, int classification_flags,
         psa_algorithm_t truncated_alg = PSA_ALG_TRUNCATED_MAC( alg, n );
         mac_algorithm_core( truncated_alg, classification_flags,
                             key_type, key_bits, n );
-        TEST_ASSERT( PSA_ALG_FULL_LENGTH_MAC( truncated_alg ) == alg );
+        TEST_EQUAL( PSA_ALG_FULL_LENGTH_MAC( truncated_alg ), alg );
         /* Check that calling PSA_ALG_TRUNCATED_MAC twice gives the length
          * of the outer truncation (even if the outer length is smaller than
          * the inner length). */
-        TEST_ASSERT( PSA_ALG_TRUNCATED_MAC( truncated_alg, 1 ) ==
-                     PSA_ALG_TRUNCATED_MAC( alg, 1 ) );
-        TEST_ASSERT( PSA_ALG_TRUNCATED_MAC( truncated_alg, length - 1 ) ==
-                     PSA_ALG_TRUNCATED_MAC( alg, length - 1) );
-        TEST_ASSERT( PSA_ALG_TRUNCATED_MAC( truncated_alg, length ) ==
-                     PSA_ALG_TRUNCATED_MAC( alg, length ) );
+        TEST_EQUAL( PSA_ALG_TRUNCATED_MAC( truncated_alg, 1 ),
+                    PSA_ALG_TRUNCATED_MAC( alg, 1 ) );
+        TEST_EQUAL( PSA_ALG_TRUNCATED_MAC( truncated_alg, length - 1 ),
+                    PSA_ALG_TRUNCATED_MAC( alg, length - 1) );
+        TEST_EQUAL( PSA_ALG_TRUNCATED_MAC( truncated_alg, length ),
+                    PSA_ALG_TRUNCATED_MAC( alg, length ) );
     }
 }
 /* END_CASE */
@@ -238,7 +238,7 @@ void hmac_algorithm( int alg_arg,
     size_t n;
 
     TEST_ASSERT( PSA_ALG_IS_HASH( hash_alg ) );
-    TEST_ASSERT( PSA_ALG_HMAC( hash_alg ) == alg );
+    TEST_EQUAL( PSA_ALG_HMAC( hash_alg ), alg );
 
     TEST_ASSERT( block_size <= PSA_HMAC_MAX_HASH_BLOCK_SIZE );
 
@@ -248,7 +248,7 @@ void hmac_algorithm( int alg_arg,
     for( n = 1; n <= length; n++ )
     {
         psa_algorithm_t truncated_alg = PSA_ALG_TRUNCATED_MAC( alg, n );
-        TEST_ASSERT( PSA_ALG_HMAC_GET_HASH( truncated_alg ) == hash_alg );
+        TEST_EQUAL( PSA_ALG_HMAC_GET_HASH( truncated_alg ), hash_alg );
     }
 }
 /* END_CASE */
@@ -287,19 +287,19 @@ void aead_algorithm( int alg_arg, int classification_flags,
     {
         psa_algorithm_t truncated_alg = PSA_ALG_AEAD_WITH_TAG_LENGTH( alg, n );
         aead_algorithm_core( truncated_alg, classification_flags, n );
-        TEST_ASSERT(
-            PSA_ALG_AEAD_WITH_DEFAULT_TAG_LENGTH( truncated_alg ) == alg );
+        TEST_EQUAL(
+            PSA_ALG_AEAD_WITH_DEFAULT_TAG_LENGTH( truncated_alg ), alg );
         /* Check that calling PSA_ALG_AEAD_WITH_DEFAULT_TAG_LENGTH twice gives
          * the length of the outer truncation (even if the outer length is
          * smaller than the inner length). */
-        TEST_ASSERT(
-            PSA_ALG_AEAD_WITH_TAG_LENGTH( truncated_alg, 1 ) ==
+        TEST_EQUAL(
+            PSA_ALG_AEAD_WITH_TAG_LENGTH( truncated_alg, 1 ),
             PSA_ALG_AEAD_WITH_TAG_LENGTH( alg, 1 ) );
-        TEST_ASSERT(
-            PSA_ALG_AEAD_WITH_TAG_LENGTH( truncated_alg, tag_length - 1 ) ==
+        TEST_EQUAL(
+            PSA_ALG_AEAD_WITH_TAG_LENGTH( truncated_alg, tag_length - 1 ),
             PSA_ALG_AEAD_WITH_TAG_LENGTH( alg, tag_length - 1) );
-        TEST_ASSERT(
-            PSA_ALG_AEAD_WITH_TAG_LENGTH( truncated_alg, tag_length ) ==
+        TEST_EQUAL(
+            PSA_ALG_AEAD_WITH_TAG_LENGTH( truncated_alg, tag_length ),
             PSA_ALG_AEAD_WITH_TAG_LENGTH( alg, tag_length ) );
     }
 }
@@ -363,8 +363,8 @@ void key_derivation_algorithm( int alg_arg, int classification_flags )
     /* Check combinations with key agreements */
     TEST_ASSERT( PSA_ALG_IS_KEY_AGREEMENT( PSA_ALG_FFDH( alg ) ) );
     TEST_ASSERT( PSA_ALG_IS_KEY_AGREEMENT( PSA_ALG_ECDH( alg ) ) );
-    TEST_ASSERT( PSA_ALG_KEY_AGREEMENT_GET_KDF( PSA_ALG_ECDH( alg ) ) == alg );
-    TEST_ASSERT( PSA_ALG_KEY_AGREEMENT_GET_KDF( PSA_ALG_FFDH( alg ) ) == alg );
+    TEST_EQUAL( PSA_ALG_KEY_AGREEMENT_GET_KDF( PSA_ALG_ECDH( alg ) ), alg );
+    TEST_EQUAL( PSA_ALG_KEY_AGREEMENT_GET_KDF( PSA_ALG_FFDH( alg ) ), alg );
 }
 /* END_CASE */
 
@@ -388,8 +388,8 @@ void key_selection_algorithm( int alg_arg, int classification_flags )
     /* Check combinations with key agreements */
     TEST_ASSERT( PSA_ALG_IS_KEY_AGREEMENT( PSA_ALG_FFDH( alg ) ) );
     TEST_ASSERT( PSA_ALG_IS_KEY_AGREEMENT( PSA_ALG_ECDH( alg ) ) );
-    TEST_ASSERT( PSA_ALG_KEY_AGREEMENT_GET_KDF( PSA_ALG_ECDH( alg ) ) == alg );
-    TEST_ASSERT( PSA_ALG_KEY_AGREEMENT_GET_KDF( PSA_ALG_FFDH( alg ) ) == alg );
+    TEST_EQUAL( PSA_ALG_KEY_AGREEMENT_GET_KDF( PSA_ALG_ECDH( alg ) ), alg );
+    TEST_EQUAL( PSA_ALG_KEY_AGREEMENT_GET_KDF( PSA_ALG_FFDH( alg ) ), alg );
 }
 /* END_CASE */
 
@@ -416,7 +416,7 @@ void key_agreement_algorithm( int alg_arg, int classification_flags,
     /* Shared secret derivation properties */
     TEST_ASSERT( PSA_ALG_IS_KEY_DERIVATION( actual_post_alg ) ||
                  PSA_ALG_IS_KEY_SELECTION( actual_post_alg ) );
-    TEST_ASSERT( actual_post_alg == expected_post_alg );
+    TEST_EQUAL( actual_post_alg, expected_post_alg );
 }
 /* END_CASE */
 
@@ -431,22 +431,22 @@ void key_type( int type_arg, int classification_flags )
     if( classification_flags & KEY_TYPE_IS_PUBLIC_KEY )
     {
         psa_key_type_t pair_type = PSA_KEY_TYPE_KEYPAIR_OF_PUBLIC_KEY( type );
-        TEST_ASSERT( PSA_KEY_TYPE_PUBLIC_KEY_OF_KEYPAIR( pair_type ) == type );
+        TEST_EQUAL( PSA_KEY_TYPE_PUBLIC_KEY_OF_KEYPAIR( pair_type ), type );
         key_type_classification( pair_type,
                                  ( classification_flags
                                    & ~KEY_TYPE_IS_PUBLIC_KEY )
                                  | KEY_TYPE_IS_KEYPAIR );
-        TEST_ASSERT( PSA_KEY_TYPE_PUBLIC_KEY_OF_KEYPAIR( type ) == type );
+        TEST_EQUAL( PSA_KEY_TYPE_PUBLIC_KEY_OF_KEYPAIR( type ), type );
     }
     if( classification_flags & KEY_TYPE_IS_KEYPAIR )
     {
         psa_key_type_t public_type = PSA_KEY_TYPE_PUBLIC_KEY_OF_KEYPAIR( type );
-        TEST_ASSERT( PSA_KEY_TYPE_KEYPAIR_OF_PUBLIC_KEY( public_type ) == type );
+        TEST_EQUAL( PSA_KEY_TYPE_KEYPAIR_OF_PUBLIC_KEY( public_type ), type );
         key_type_classification( public_type,
                                  ( classification_flags
                                    & ~KEY_TYPE_IS_KEYPAIR )
                                  | KEY_TYPE_IS_PUBLIC_KEY );
-        TEST_ASSERT( PSA_KEY_TYPE_KEYPAIR_OF_PUBLIC_KEY( type ) == type );
+        TEST_EQUAL( PSA_KEY_TYPE_KEYPAIR_OF_PUBLIC_KEY( type ), type );
     }
 }
 /* END_CASE */
@@ -462,8 +462,8 @@ void ecc_key_types( int curve_arg, int curve_bits_arg )
     test_key_type( public_type, KEY_TYPE_IS_ECC | KEY_TYPE_IS_PUBLIC_KEY );
     test_key_type( pair_type, KEY_TYPE_IS_ECC | KEY_TYPE_IS_KEYPAIR );
 
-    TEST_ASSERT( PSA_KEY_TYPE_GET_CURVE( public_type ) == curve );
-    TEST_ASSERT( PSA_KEY_TYPE_GET_CURVE( pair_type ) == curve );
+    TEST_EQUAL( PSA_KEY_TYPE_GET_CURVE( public_type ), curve );
+    TEST_EQUAL( PSA_KEY_TYPE_GET_CURVE( pair_type ), curve );
 
     /* Validate that the bit size is less than the maximum ECC bit size
      * in this implementation. There's no parameter that should be equal

--- a/tests/suites/test_suite_psa_crypto_metadata.function
+++ b/tests/suites/test_suite_psa_crypto_metadata.function
@@ -46,7 +46,7 @@
 #define KEY_TYPE_IS_DSA                 ( 1u << 5 )
 #define KEY_TYPE_IS_ECC                 ( 1u << 6 )
 
-#define TEST_CLASSIFICATION_MACRO( flag, alg, flags )            \
+#define TEST_CLASSIFICATION_MACRO( flag, alg, flags )           \
     TEST_ASSERT( PSA_##flag( alg ) == !! ( ( flags ) & flag ) )
 
 void algorithm_classification( psa_algorithm_t alg, unsigned flags )

--- a/tests/suites/test_suite_psa_crypto_persistent_key.function
+++ b/tests/suites/test_suite_psa_crypto_persistent_key.function
@@ -102,7 +102,8 @@ void save_large_persistent_key( int data_too_large, int expected_status )
                                 &handle ) );
 
     TEST_EQUAL( psa_import_key( handle, PSA_KEY_TYPE_RAW_DATA,
-                                data, data_length ), expected_status );
+                                data, data_length ),
+                expected_status );
 
 exit:
     mbedtls_free( data );
@@ -143,8 +144,8 @@ void persistent_key_destroy( int key_id_arg, int should_store,
 
     /* Check key slot storage is removed */
     TEST_EQUAL( psa_is_key_present_in_storage( key_id ), 0 );
-    TEST_EQUAL( psa_open_key( PSA_KEY_LIFETIME_PERSISTENT, key_id,
-                              &handle ), PSA_ERROR_EMPTY_SLOT );
+    TEST_EQUAL( psa_open_key( PSA_KEY_LIFETIME_PERSISTENT, key_id, &handle ),
+                PSA_ERROR_EMPTY_SLOT );
     TEST_EQUAL( handle, 0 );
 
     /* Shutdown and restart */
@@ -183,8 +184,8 @@ void persistent_key_import( int key_id_arg, int type_arg, data_t *data,
                                 PSA_BYTES_TO_BITS( data->len ),
                                 &handle ) );
     psa_key_policy_init( &policy );
-    TEST_EQUAL( psa_import_key( handle, type,
-                                data->x, data->len ), expected_status );
+    TEST_EQUAL( psa_import_key( handle, type, data->x, data->len ),
+                expected_status );
 
     if( expected_status != PSA_SUCCESS )
     {

--- a/tests/suites/test_suite_psa_crypto_persistent_key.function
+++ b/tests/suites/test_suite_psa_crypto_persistent_key.function
@@ -66,13 +66,13 @@ void parse_storage_data_check( data_t *file_data,
                                               &key_data, &key_data_length,
                                               &key_type, &key_policy );
 
-    TEST_ASSERT( status == expected_status );
+    TEST_EQUAL( status, expected_status );
     if( status != PSA_SUCCESS )
         goto exit;
 
-    TEST_ASSERT( key_type == (psa_key_type_t) expected_key_type );
-    TEST_ASSERT( key_policy.usage == (uint32_t) expected_key_usage );
-    TEST_ASSERT( key_policy.alg == (uint32_t) expected_key_alg );
+    TEST_EQUAL( key_type, (psa_key_type_t) expected_key_type );
+    TEST_EQUAL( key_policy.usage, (uint32_t) expected_key_usage );
+    TEST_EQUAL( key_policy.alg, (uint32_t) expected_key_alg );
     ASSERT_COMPARE( expected_key_data->x, expected_key_data->len,
                     key_data, key_data_length );
 
@@ -101,8 +101,8 @@ void save_large_persistent_key( int data_too_large, int expected_status )
                                 PSA_BYTES_TO_BITS( data_length ),
                                 &handle ) );
 
-    TEST_ASSERT( psa_import_key( handle, PSA_KEY_TYPE_RAW_DATA,
-                                 data, data_length ) == expected_status );
+    TEST_EQUAL( psa_import_key( handle, PSA_KEY_TYPE_RAW_DATA,
+                                data, data_length ), expected_status );
 
 exit:
     mbedtls_free( data );
@@ -142,10 +142,10 @@ void persistent_key_destroy( int key_id_arg, int should_store,
     PSA_ASSERT( psa_destroy_key( handle ) );
 
     /* Check key slot storage is removed */
-    TEST_ASSERT( psa_is_key_present_in_storage( key_id ) == 0 );
-    TEST_ASSERT( psa_open_key( PSA_KEY_LIFETIME_PERSISTENT, key_id,
-                               &handle ) == PSA_ERROR_EMPTY_SLOT );
-    TEST_ASSERT( handle == 0 );
+    TEST_EQUAL( psa_is_key_present_in_storage( key_id ), 0 );
+    TEST_EQUAL( psa_open_key( PSA_KEY_LIFETIME_PERSISTENT, key_id,
+                              &handle ), PSA_ERROR_EMPTY_SLOT );
+    TEST_EQUAL( handle, 0 );
 
     /* Shutdown and restart */
     mbedtls_psa_crypto_free();
@@ -183,17 +183,17 @@ void persistent_key_import( int key_id_arg, int type_arg, data_t *data,
                                 PSA_BYTES_TO_BITS( data->len ),
                                 &handle ) );
     psa_key_policy_init( &policy );
-    TEST_ASSERT( psa_import_key( handle, type,
-                                 data->x, data->len ) == expected_status );
+    TEST_EQUAL( psa_import_key( handle, type,
+                                data->x, data->len ), expected_status );
 
     if( expected_status != PSA_SUCCESS )
     {
-        TEST_ASSERT( psa_is_key_present_in_storage( key_id ) == 0 );
+        TEST_EQUAL( psa_is_key_present_in_storage( key_id ), 0 );
         goto exit;
     }
 
     PSA_ASSERT( psa_get_key_lifetime( handle, &lifetime ) );
-    TEST_ASSERT( lifetime == PSA_KEY_LIFETIME_PERSISTENT );
+    TEST_EQUAL( lifetime, PSA_KEY_LIFETIME_PERSISTENT );
 
 exit:
     psa_destroy_persistent_key( key_id );
@@ -235,15 +235,15 @@ void import_export_persistent_key( data_t *data, int type_arg,
                                 data->x, data->len ) );
 
     PSA_ASSERT( psa_get_key_lifetime( handle, &lifetime_get ) );
-    TEST_ASSERT( lifetime_get == PSA_KEY_LIFETIME_PERSISTENT );
+    TEST_EQUAL( lifetime_get, PSA_KEY_LIFETIME_PERSISTENT );
 
     /* Test the key information */
     PSA_ASSERT( psa_get_key_information(
                     handle, &got_type, &got_bits ) );
-    TEST_ASSERT( got_type == type );
-    TEST_ASSERT( got_bits == (size_t) expected_bits );
+    TEST_EQUAL( got_type, type );
+    TEST_EQUAL( got_bits, (size_t) expected_bits );
 
-    TEST_ASSERT( psa_is_key_present_in_storage( key_id ) == 1 );
+    TEST_EQUAL( psa_is_key_present_in_storage( key_id ), 1 );
 
     if( key_not_exist )
     {
@@ -257,7 +257,7 @@ void import_export_persistent_key( data_t *data, int type_arg,
 
     /* Destroy the key */
     PSA_ASSERT( psa_destroy_key( handle ) );
-    TEST_ASSERT( psa_is_key_present_in_storage( key_id ) == 0 );
+    TEST_EQUAL( psa_is_key_present_in_storage( key_id ), 0 );
 
 exit:
     mbedtls_free( exported );

--- a/tests/suites/test_suite_psa_crypto_persistent_key.function
+++ b/tests/suites/test_suite_psa_crypto_persistent_key.function
@@ -81,7 +81,6 @@ exit:
 }
 /* END_CASE */
 
-
 /* BEGIN_CASE */
 void save_large_persistent_key( int data_too_large, int expected_status )
 {
@@ -95,12 +94,12 @@ void save_large_persistent_key( int data_too_large, int expected_status )
 
     ASSERT_ALLOC( data, data_length );
 
-    TEST_ASSERT( psa_crypto_init() == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init() );
 
-    TEST_ASSERT( psa_create_key( PSA_KEY_LIFETIME_PERSISTENT, key_id,
-                                 PSA_KEY_TYPE_RAW_DATA,
-                                 PSA_BYTES_TO_BITS( data_length ),
-                                 &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_create_key( PSA_KEY_LIFETIME_PERSISTENT, key_id,
+                                PSA_KEY_TYPE_RAW_DATA,
+                                PSA_BYTES_TO_BITS( data_length ),
+                                &handle ) );
 
     TEST_ASSERT( psa_import_key( handle, PSA_KEY_TYPE_RAW_DATA,
                                  data, data_length ) == expected_status );
@@ -123,24 +122,24 @@ void persistent_key_destroy( int key_id_arg, int should_store,
     psa_key_type_t first_type = (psa_key_type_t) first_type_arg;
     psa_key_type_t second_type = (psa_key_type_t) second_type_arg;
 
-    TEST_ASSERT( psa_crypto_init() == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init() );
 
     psa_key_policy_init( &policy );
 
-    TEST_ASSERT( psa_create_key( PSA_KEY_LIFETIME_PERSISTENT, key_id,
-                                 first_type,
-                                 PSA_BYTES_TO_BITS( first_data->len ),
-                                 &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_create_key( PSA_KEY_LIFETIME_PERSISTENT, key_id,
+                                first_type,
+                                PSA_BYTES_TO_BITS( first_data->len ),
+                                &handle ) );
 
     if( should_store == 1 )
     {
-        TEST_ASSERT( psa_import_key(
-                         handle, first_type,
-                         first_data->x, first_data->len ) == PSA_SUCCESS );
+        PSA_ASSERT( psa_import_key(
+                        handle, first_type,
+                        first_data->x, first_data->len ) );
     }
 
     /* Destroy the key */
-    TEST_ASSERT( psa_destroy_key( handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_destroy_key( handle ) );
 
     /* Check key slot storage is removed */
     TEST_ASSERT( psa_is_key_present_in_storage( key_id ) == 0 );
@@ -150,16 +149,16 @@ void persistent_key_destroy( int key_id_arg, int should_store,
 
     /* Shutdown and restart */
     mbedtls_psa_crypto_free();
-    TEST_ASSERT( psa_crypto_init() == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init() );
 
     /* Create another key in the same slot */
-    TEST_ASSERT( psa_create_key( PSA_KEY_LIFETIME_PERSISTENT, key_id,
-                                 second_type,
-                                 PSA_BYTES_TO_BITS( second_data->len ),
-                                 &handle ) == PSA_SUCCESS );
-    TEST_ASSERT( psa_import_key(
-                     handle, second_type,
-                     second_data->x, second_data->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_create_key( PSA_KEY_LIFETIME_PERSISTENT, key_id,
+                                second_type,
+                                PSA_BYTES_TO_BITS( second_data->len ),
+                                &handle ) );
+    PSA_ASSERT( psa_import_key(
+                    handle, second_type,
+                    second_data->x, second_data->len ) );
 
 exit:
     mbedtls_psa_crypto_free();
@@ -177,12 +176,12 @@ void persistent_key_import( int key_id_arg, int type_arg, data_t *data,
     psa_key_type_t type = (psa_key_type_t) type_arg;
     psa_key_handle_t handle = 0;
 
-    TEST_ASSERT( psa_crypto_init() == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init() );
 
-    TEST_ASSERT( psa_create_key( PSA_KEY_LIFETIME_PERSISTENT, key_id,
-                                 type,
-                                 PSA_BYTES_TO_BITS( data->len ),
-                                 &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_create_key( PSA_KEY_LIFETIME_PERSISTENT, key_id,
+                                type,
+                                PSA_BYTES_TO_BITS( data->len ),
+                                &handle ) );
     psa_key_policy_init( &policy );
     TEST_ASSERT( psa_import_key( handle, type,
                                  data->x, data->len ) == expected_status );
@@ -193,7 +192,7 @@ void persistent_key_import( int key_id_arg, int type_arg, data_t *data,
         goto exit;
     }
 
-    TEST_ASSERT( psa_get_key_lifetime( handle, &lifetime ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_get_key_lifetime( handle, &lifetime ) );
     TEST_ASSERT( lifetime == PSA_KEY_LIFETIME_PERSISTENT );
 
 exit:
@@ -219,28 +218,28 @@ void import_export_persistent_key( data_t *data, int type_arg,
 
     ASSERT_ALLOC( exported, export_size );
 
-    TEST_ASSERT( psa_crypto_init( ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_create_key( PSA_KEY_LIFETIME_PERSISTENT, key_id,
-                                 type,
-                                 PSA_BYTES_TO_BITS( data->len ),
-                                 &handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_create_key( PSA_KEY_LIFETIME_PERSISTENT, key_id,
+                                type,
+                                PSA_BYTES_TO_BITS( data->len ),
+                                &handle ) );
 
     psa_key_policy_init( &policy );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_EXPORT,
                               PSA_ALG_VENDOR_FLAG );
-    TEST_ASSERT( psa_set_key_policy( handle, &policy ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
     /* Import the key */
-    TEST_ASSERT( psa_import_key( handle, type,
-                                 data->x, data->len ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_import_key( handle, type,
+                                data->x, data->len ) );
 
-    TEST_ASSERT( psa_get_key_lifetime( handle, &lifetime_get ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_get_key_lifetime( handle, &lifetime_get ) );
     TEST_ASSERT( lifetime_get == PSA_KEY_LIFETIME_PERSISTENT );
 
     /* Test the key information */
-    TEST_ASSERT( psa_get_key_information(
-                     handle, &got_type, &got_bits ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_get_key_information(
+                    handle, &got_type, &got_bits ) );
     TEST_ASSERT( got_type == type );
     TEST_ASSERT( got_bits == (size_t) expected_bits );
 
@@ -251,13 +250,13 @@ void import_export_persistent_key( data_t *data, int type_arg,
         psa_destroy_persistent_key( key_id );
     }
     /* Export the key */
-    TEST_ASSERT( psa_export_key( handle, exported, export_size,
-                                 &exported_length ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_export_key( handle, exported, export_size,
+                                &exported_length ) );
 
     ASSERT_COMPARE( data->x, data->len, exported, exported_length );
 
     /* Destroy the key */
-    TEST_ASSERT( psa_destroy_key( handle ) == PSA_SUCCESS );
+    PSA_ASSERT( psa_destroy_key( handle ) );
     TEST_ASSERT( psa_is_key_present_in_storage( key_id ) == 0 );
 
 exit:

--- a/tests/suites/test_suite_psa_crypto_persistent_key.function
+++ b/tests/suites/test_suite_psa_crypto_persistent_key.function
@@ -103,7 +103,7 @@ void save_large_persistent_key( int data_too_large, int expected_status )
                                  &handle ) == PSA_SUCCESS );
 
     TEST_ASSERT( psa_import_key( handle, PSA_KEY_TYPE_RAW_DATA,
-        data, data_length ) == expected_status );
+                                 data, data_length ) == expected_status );
 
 exit:
     mbedtls_free( data );
@@ -135,8 +135,8 @@ void persistent_key_destroy( int key_id_arg, int should_store,
     if( should_store == 1 )
     {
         TEST_ASSERT( psa_import_key(
-            handle, first_type,
-            first_data->x, first_data->len ) == PSA_SUCCESS );
+                         handle, first_type,
+                         first_data->x, first_data->len ) == PSA_SUCCESS );
     }
 
     /* Destroy the key */
@@ -158,8 +158,8 @@ void persistent_key_destroy( int key_id_arg, int should_store,
                                  PSA_BYTES_TO_BITS( second_data->len ),
                                  &handle ) == PSA_SUCCESS );
     TEST_ASSERT( psa_import_key(
-        handle, second_type,
-        second_data->x, second_data->len ) == PSA_SUCCESS );
+                     handle, second_type,
+                     second_data->x, second_data->len ) == PSA_SUCCESS );
 
 exit:
     mbedtls_psa_crypto_free();
@@ -240,7 +240,7 @@ void import_export_persistent_key( data_t *data, int type_arg,
 
     /* Test the key information */
     TEST_ASSERT( psa_get_key_information(
-        handle, &got_type, &got_bits ) == PSA_SUCCESS );
+                     handle, &got_type, &got_bits ) == PSA_SUCCESS );
     TEST_ASSERT( got_type == type );
     TEST_ASSERT( got_bits == (size_t) expected_bits );
 

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -89,7 +89,7 @@ void transient_slot_lifecycle( int type_arg, int max_bits_arg,
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
     PSA_ASSERT( psa_import_key( handle, type, key_data->x, key_data->len ) );
     PSA_ASSERT( psa_get_key_information( handle, &read_type, NULL ) );
-    TEST_ASSERT( read_type == type );
+    TEST_EQUAL( read_type, type );
 
     /* Do something that invalidates the handle. */
     switch( close_method )
@@ -106,9 +106,9 @@ void transient_slot_lifecycle( int type_arg, int max_bits_arg,
             break;
     }
     /* Test that the handle is now invalid. */
-    TEST_ASSERT( psa_get_key_information( handle, &read_type, NULL ) ==
-                 PSA_ERROR_INVALID_HANDLE );
-    TEST_ASSERT( psa_close_key( handle ) == PSA_ERROR_INVALID_HANDLE );
+    TEST_EQUAL( psa_get_key_information( handle, &read_type, NULL ),
+                PSA_ERROR_INVALID_HANDLE );
+    TEST_EQUAL( psa_close_key( handle ), PSA_ERROR_INVALID_HANDLE );
 
 exit:
     mbedtls_psa_crypto_free( );
@@ -145,13 +145,13 @@ void persistent_slot_lifecycle( int lifetime_arg, int id_arg,
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
     PSA_ASSERT( psa_import_key( handle, type, key_data->x, key_data->len ) );
     PSA_ASSERT( psa_get_key_information( handle, &read_type, NULL ) );
-    TEST_ASSERT( read_type == type );
+    TEST_EQUAL( read_type, type );
 
     /* Close the key and reopen it. */
     PSA_ASSERT( psa_close_key( handle ) );
     PSA_ASSERT( psa_open_key( lifetime, id, &handle ) );
     PSA_ASSERT( psa_get_key_information( handle, &read_type, NULL ) );
-    TEST_ASSERT( read_type == type );
+    TEST_EQUAL( read_type, type );
 
     /* Do something that invalidates the handle. */
     switch( close_method )
@@ -168,9 +168,9 @@ void persistent_slot_lifecycle( int lifetime_arg, int id_arg,
             break;
     }
     /* Test that the handle is now invalid. */
-    TEST_ASSERT( psa_get_key_information( handle, &read_type, NULL ) ==
-                 PSA_ERROR_INVALID_HANDLE );
-    TEST_ASSERT( psa_close_key( handle ) == PSA_ERROR_INVALID_HANDLE );
+    TEST_EQUAL( psa_get_key_information( handle, &read_type, NULL ),
+                PSA_ERROR_INVALID_HANDLE );
+    TEST_EQUAL( psa_close_key( handle ), PSA_ERROR_INVALID_HANDLE );
 
     /* Try to reopen the key. If we destroyed it, check that it doesn't
      * exist, otherwise check that it still exists. */
@@ -180,11 +180,11 @@ void persistent_slot_lifecycle( int lifetime_arg, int id_arg,
         case CLOSE_BY_SHUTDOWN:
             PSA_ASSERT( psa_open_key( lifetime, id, &handle ) );
             PSA_ASSERT( psa_get_key_information( handle, &read_type, NULL ) );
-            TEST_ASSERT( read_type == type );
+            TEST_EQUAL( read_type, type );
             break;
         case CLOSE_BY_DESTROY:
-            TEST_ASSERT( psa_open_key( lifetime, id, &handle ) ==
-                         PSA_ERROR_EMPTY_SLOT );
+            TEST_EQUAL( psa_open_key( lifetime, id, &handle ),
+                        PSA_ERROR_EMPTY_SLOT );
             break;
     }
 
@@ -230,9 +230,9 @@ void create_existent( int lifetime_arg, int id_arg,
         PSA_ASSERT( psa_close_key( handle1 ) );
 
     /* Attempt to create a new key in the same slot. */
-    TEST_ASSERT( psa_create_key( lifetime, id, type2, bits1, &handle2 ) ==
-                 PSA_ERROR_OCCUPIED_SLOT );
-    TEST_ASSERT( handle2 == 0 );
+    TEST_EQUAL( psa_create_key( lifetime, id, type2, bits1, &handle2 ),
+                PSA_ERROR_OCCUPIED_SLOT );
+    TEST_EQUAL( handle2, 0 );
 
     if( reopen_policy == CLOSE_AFTER )
         PSA_ASSERT( psa_close_key( handle1 ) );
@@ -243,8 +243,8 @@ void create_existent( int lifetime_arg, int id_arg,
     PSA_ASSERT( psa_get_key_policy( handle1, &read_policy ) );
     TEST_ASSERT( psa_key_policy_equal( &read_policy, &policy1 ) );
     PSA_ASSERT( psa_get_key_information( handle1, &read_type, &read_bits ) );
-    TEST_ASSERT( read_type == type1 );
-    TEST_ASSERT( read_bits == bits1 );
+    TEST_EQUAL( read_type, type1 );
+    TEST_EQUAL( read_bits, bits1 );
     PSA_ASSERT( psa_export_key( handle1,
                                 reexported, sizeof( reexported ),
                                 &reexported_length ) );
@@ -268,8 +268,8 @@ void open_fail( int lifetime_arg, int id_arg,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_open_key( lifetime, id, &handle ) == expected_status );
-    TEST_ASSERT( handle == 0 );
+    TEST_EQUAL( psa_open_key( lifetime, id, &handle ), expected_status );
+    TEST_EQUAL( handle, 0 );
 
 exit:
     mbedtls_psa_crypto_free( );
@@ -292,10 +292,10 @@ void create_fail( int lifetime_arg, int id_arg,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_ASSERT( psa_create_key( lifetime, id,
-                                 type, max_bits,
-                                 &handle ) == expected_status );
-    TEST_ASSERT( handle == 0 );
+    TEST_EQUAL( psa_create_key( lifetime, id,
+                                type, max_bits,
+                                &handle ), expected_status );
+    TEST_EQUAL( handle, 0 );
 
 exit:
     mbedtls_psa_crypto_free( );
@@ -326,17 +326,17 @@ void invalid_handle( )
                                 material, sizeof( material ) ) );
 
     /* Attempt to close and destroy some invalid handles. */
-    TEST_ASSERT( psa_close_key( 0 ) == PSA_ERROR_INVALID_HANDLE );
-    TEST_ASSERT( psa_close_key( handle1 - 1 ) == PSA_ERROR_INVALID_HANDLE );
-    TEST_ASSERT( psa_close_key( handle1 + 1 ) == PSA_ERROR_INVALID_HANDLE );
-    TEST_ASSERT( psa_destroy_key( 0 ) == PSA_ERROR_INVALID_HANDLE );
-    TEST_ASSERT( psa_destroy_key( handle1 - 1 ) == PSA_ERROR_INVALID_HANDLE );
-    TEST_ASSERT( psa_destroy_key( handle1 + 1 ) == PSA_ERROR_INVALID_HANDLE );
+    TEST_EQUAL( psa_close_key( 0 ), PSA_ERROR_INVALID_HANDLE );
+    TEST_EQUAL( psa_close_key( handle1 - 1 ), PSA_ERROR_INVALID_HANDLE );
+    TEST_EQUAL( psa_close_key( handle1 + 1 ), PSA_ERROR_INVALID_HANDLE );
+    TEST_EQUAL( psa_destroy_key( 0 ), PSA_ERROR_INVALID_HANDLE );
+    TEST_EQUAL( psa_destroy_key( handle1 - 1 ), PSA_ERROR_INVALID_HANDLE );
+    TEST_EQUAL( psa_destroy_key( handle1 + 1 ), PSA_ERROR_INVALID_HANDLE );
 
     /* After all this, check that the original handle is intact. */
     PSA_ASSERT( psa_get_key_information( handle1, &read_type, &read_bits ) );
-    TEST_ASSERT( read_type == PSA_KEY_TYPE_RAW_DATA );
-    TEST_ASSERT( read_bits == PSA_BYTES_TO_BITS( sizeof( material ) ) );
+    TEST_EQUAL( read_type, PSA_KEY_TYPE_RAW_DATA );
+    TEST_EQUAL( read_bits, PSA_BYTES_TO_BITS( sizeof( material ) ) );
     PSA_ASSERT( psa_close_key( handle1 ) );
 
 exit:

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -292,9 +292,8 @@ void create_fail( int lifetime_arg, int id_arg,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_EQUAL( psa_create_key( lifetime, id,
-                                type, max_bits,
-                                &handle ), expected_status );
+    TEST_EQUAL( psa_create_key( lifetime, id, type, max_bits, &handle ),
+                expected_status );
     TEST_EQUAL( handle, 0 );
 
 exit:

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -8,8 +8,6 @@
 
 #include "psa_crypto_storage.h"
 
-#define PSA_ASSERT( expr ) TEST_ASSERT( ( expr ) == PSA_SUCCESS )
-
 typedef enum
 {
     CLOSE_BY_CLOSE,

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -367,7 +367,7 @@ void many_transient_handles( int max_handles_arg )
                                    &handles[i] );
         if( status == PSA_ERROR_INSUFFICIENT_MEMORY )
             break;
-        TEST_ASSERT( status == PSA_SUCCESS );
+        PSA_ASSERT( status );
         TEST_ASSERT( handles[i] != 0 );
         for( j = 0; j < i; j++ )
             TEST_ASSERT( handles[i] != handles[j] );

--- a/tests/suites/test_suite_psa_crypto_storage_file.function
+++ b/tests/suites/test_suite_psa_crypto_storage_file.function
@@ -97,7 +97,6 @@ exit:
 }
 /* END_CASE */
 
-
 /* BEGIN_CASE */
 void get_file_size( data_t *data, int expected_data_length,
                     int expected_status, int should_make_file )

--- a/tests/suites/test_suite_psa_crypto_storage_file.function
+++ b/tests/suites/test_suite_psa_crypto_storage_file.function
@@ -30,9 +30,9 @@ void load_data_from_file( int id_to_load_arg,
         file = fopen( slot_location, "wb+" );
         TEST_ASSERT( file != NULL );
         file_size = fwrite( data->x, 1, data->len, file );
-        TEST_ASSERT( file_size == data->len );
+        TEST_EQUAL( file_size, data->len );
         ret = fclose( file );
-        TEST_ASSERT( ret == 0 );
+        TEST_EQUAL( ret, 0 );
     }
 
     /* Read from the file with psa_crypto_storage_load. */
@@ -41,7 +41,7 @@ void load_data_from_file( int id_to_load_arg,
     status = psa_crypto_storage_load( id_to_load, loaded_data, file_size );
 
     /* Check we get the expected status. */
-    TEST_ASSERT( status == expected_status );
+    TEST_EQUAL( status, expected_status );
     if( status != PSA_SUCCESS )
         goto exit;
 
@@ -69,7 +69,7 @@ void write_data_to_file( data_t *data, int expected_status )
     status = psa_crypto_storage_store( 1, data->x, data->len );
 
     /* Check that we got the expected status. */
-    TEST_ASSERT( status == expected_status );
+    TEST_EQUAL( status, expected_status );
     if( status != PSA_SUCCESS )
         goto exit;
 
@@ -79,17 +79,17 @@ void write_data_to_file( data_t *data, int expected_status )
     fseek( file, 0, SEEK_END );
     file_size = (size_t) ftell( file );
     fseek( file, 0, SEEK_SET );
-    TEST_ASSERT( file_size == data->len );
+    TEST_EQUAL( file_size, data->len );
 
     /* Check that the file contents are what we expect */
     loaded_data = mbedtls_calloc( 1, data->len );
     TEST_ASSERT( loaded_data != NULL );
 
     num_read = fread( loaded_data, 1, file_size, file );
-    TEST_ASSERT( num_read == file_size );
+    TEST_EQUAL( num_read, file_size );
     ASSERT_COMPARE( data->x, data->len, loaded_data, file_size );
     ret = fclose( file );
-    TEST_ASSERT( ret == 0 );
+    TEST_EQUAL( ret, 0 );
 
 exit:
     mbedtls_free( loaded_data );
@@ -113,16 +113,16 @@ void get_file_size( data_t *data, int expected_data_length,
         file = fopen( slot_location, "wb+" );
         TEST_ASSERT( file != NULL );
         file_size = fwrite( data->x, 1, data->len, file );
-        TEST_ASSERT( file_size == data->len );
+        TEST_EQUAL( file_size, data->len );
         ret = fclose( file );
-        TEST_ASSERT( ret == 0 );
+        TEST_EQUAL( ret, 0 );
     }
 
     /* Check get data size is what we expect */
     status = psa_crypto_storage_get_data_length( 1, &file_size );
-    TEST_ASSERT( status == expected_status );
+    TEST_EQUAL( status, expected_status );
     if( expected_status == PSA_SUCCESS )
-        TEST_ASSERT( file_size == (size_t)expected_data_length );
+        TEST_EQUAL( file_size, (size_t)expected_data_length );
 
 exit:
     remove( slot_location );
@@ -142,13 +142,13 @@ void write_data_to_prexisting_file( char *preexist_file_location,
     file = fopen( preexist_file_location, "wb" );
     TEST_ASSERT( file != NULL );
     ret = fclose( file );
-    TEST_ASSERT( ret == 0 );
+    TEST_EQUAL( ret, 0 );
 
     /* Write data to file. */
     status = psa_crypto_storage_store( 1, data->x, data->len );
 
     /* Check that we got the expected status. */
-    TEST_ASSERT( status == expected_status );
+    TEST_EQUAL( status, expected_status );
     if( status != PSA_SUCCESS )
         goto exit;
 

--- a/tests/suites/test_suite_psa_crypto_storage_file.function
+++ b/tests/suites/test_suite_psa_crypto_storage_file.function
@@ -36,8 +36,7 @@ void load_data_from_file( int id_to_load_arg,
     }
 
     /* Read from the file with psa_crypto_storage_load. */
-    loaded_data = mbedtls_calloc( 1, capacity );
-    TEST_ASSERT( loaded_data != NULL );
+    ASSERT_ALLOC( loaded_data, capacity );
     status = psa_crypto_storage_load( id_to_load, loaded_data, file_size );
 
     /* Check we get the expected status. */
@@ -82,8 +81,7 @@ void write_data_to_file( data_t *data, int expected_status )
     TEST_EQUAL( file_size, data->len );
 
     /* Check that the file contents are what we expect */
-    loaded_data = mbedtls_calloc( 1, data->len );
-    TEST_ASSERT( loaded_data != NULL );
+    ASSERT_ALLOC( loaded_data, data->len );
 
     num_read = fread( loaded_data, 1, file_size, file );
     TEST_EQUAL( num_read, file_size );


### PR DESCRIPTION
Declare a few macros in `helpers.function` and use them in the PSA tests. I haven't touched non-PSA tests.

* `TEST_EQUAL` (slightly more readable than `TEST_ASSERT(a==b)`, but the real payoff will come later when we instrument it to print the values on failure)
* `PSA_ASSERT` (`TEST_ASSERT(…==PSA_SUCCESS)`)
* `ARRAY_LENGTH` (with protection against usage on a pointer when compiling with GCC)
* `MIN`, `MAX`

There's some refactoring going on, so I recommend reviewing commit by commit.
