### PR TITLE
modify check-names.sh and list-macros.sh to work with PSA constants

### DIFF
--- a/tests/scripts/check-names.sh
+++ b/tests/scripts/check-names.sh
@@ -40,7 +40,7 @@ diff macros identifiers | sed -n -e 's/< //p' > actual-macros
 for THING in actual-macros enum-consts; do
     printf "Names of $THING: "
     test -r $THING
-    BAD=$( grep -v '^MBEDTLS_[0-9A-Z_]*[0-9A-Z]$' $THING || true )
+    BAD=$( grep -E -v '^(MBEDTLS|PSA)_[0-9A-Z_]*[0-9A-Z]$' $THING || true )
     if [ "x$BAD" = "x" ]; then
         echo "PASS"
     else
@@ -65,12 +65,14 @@ done
 
 printf "Likely typos: "
 sort -u actual-macros enum-consts > _caps
-HEADERS=$( ls include/mbedtls/*.h | egrep -v 'compat-1\.3\.h' )
+HEADERS=$( ls include/mbedtls/*.h include/psa/*.h | egrep -v 'compat-1\.3\.h' )
 NL='
 '
 sed -n 's/MBED..._[A-Z0-9_]*/\'"$NL"'&\'"$NL"/gp \
     $HEADERS library/*.c \
     | grep MBEDTLS | sort -u > _MBEDTLS_XXX
+
+
 TYPOS=$( diff _caps _MBEDTLS_XXX | sed -n 's/^> //p' \
             | egrep -v 'XXX|__|_$|^MBEDTLS_.*CONFIG_FILE$' || true )
 rm _MBEDTLS_XXX _caps

--- a/tests/scripts/check-names.sh
+++ b/tests/scripts/check-names.sh
@@ -71,8 +71,6 @@ NL='
 sed -n 's/MBED..._[A-Z0-9_]*/\'"$NL"'&\'"$NL"/gp \
     $HEADERS library/*.c \
     | grep MBEDTLS | sort -u > _MBEDTLS_XXX
-
-
 TYPOS=$( diff _caps _MBEDTLS_XXX | sed -n 's/^> //p' \
             | egrep -v 'XXX|__|_$|^MBEDTLS_.*CONFIG_FILE$' || true )
 rm _MBEDTLS_XXX _caps

--- a/tests/scripts/list-macros.sh
+++ b/tests/scripts/list-macros.sh
@@ -7,7 +7,7 @@ if [ -d include/mbedtls ]; then :; else
     exit 1
 fi
 
-HEADERS=$( ls include/mbedtls/*.h | egrep -v 'compat-1\.3\.h' )
+HEADERS=$( ls include/mbedtls/*.h include/psa/*.h | egrep -v 'compat-1\.3\.h' )
 
 sed -n -e 's/.*#define \([a-zA-Z0-9_]*\).*/\1/p' $HEADERS \
     | egrep -v '^(asm|inline|EMIT|_CRT_SECURE_NO_DEPRECATE)$|^MULADDC_' \


### PR DESCRIPTION
fixed processing of PSA macros in check names script.
This required changes in:
    list-macros.sh to scan the PSA headers
    check-names to scan PSA files and allow PSA_* macro names