### PR TITLE
Make number of key slots externally configurable

### DIFF
--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -122,7 +122,9 @@ psa_status_t mbedtls_psa_inject_entropy(const unsigned char *seed,
 
 
 /* The Number of key slots (plus one because 0 is not used).
- * The value is a compile-time constant for now, for simplicity. */
+ * The value is a compile-time constant for now, for simplicity.
+ * Note: this configuration flag is an implementation detail that may change
+ * or be removed in future versions */
 #if !defined(MBEDTLS_PSA_KEY_SLOT_COUNT)
     #define MBEDTLS_PSA_KEY_SLOT_COUNT 32
 #endif /* !defined(MBEDTLS_PSA_KEY_SLOT_COUNT) */

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -123,10 +123,9 @@ psa_status_t mbedtls_psa_inject_entropy(const unsigned char *seed,
 
 /* The Number of key slots (plus one because 0 is not used).
  * The value is a compile-time constant for now, for simplicity. */
-#if defined(MBEDTLS_PSA_KEY_SLOT_COUNT)
-#else
+#if !defined(MBEDTLS_PSA_KEY_SLOT_COUNT)
     #define MBEDTLS_PSA_KEY_SLOT_COUNT 32
-#endif /*MBEDTLS_PSA_KEY_SLOT_COUNT*/
+#endif /* !defined(MBEDTLS_PSA_KEY_SLOT_COUNT) */
 
 
 #ifdef __cplusplus

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -121,6 +121,14 @@ psa_status_t mbedtls_psa_inject_entropy(const unsigned char *seed,
                                         size_t seed_size);
 
 
+/* The Number of key slots (plus one because 0 is not used).
+ * The value is a compile-time constant for now, for simplicity. */
+#if defined(MBEDTLS_PSA_KEY_SLOT_COUNT)
+#else
+    #define MBEDTLS_PSA_KEY_SLOT_COUNT 32
+#endif /*MBEDTLS_PSA_KEY_SLOT_COUNT*/
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -46,7 +46,7 @@
 
 typedef struct
 {
-    psa_key_slot_t key_slots[PSA_KEY_SLOT_COUNT];
+    psa_key_slot_t key_slots[MBEDTLS_PSA_KEY_SLOT_COUNT];
     unsigned key_slots_initialized : 1;
 } psa_global_data_t;
 
@@ -90,7 +90,7 @@ psa_status_t psa_initialize_key_slots( void )
 void psa_wipe_all_key_slots( void )
 {
     psa_key_handle_t key;
-    for( key = 1; key <= PSA_KEY_SLOT_COUNT; key++ )
+    for( key = 1; key <= MBEDTLS_PSA_KEY_SLOT_COUNT; key++ )
     {
         psa_key_slot_t *slot = &global_data.key_slots[key - 1];
         (void) psa_wipe_key_slot( slot );
@@ -108,7 +108,7 @@ void psa_wipe_all_key_slots( void )
  */
 static psa_status_t psa_internal_allocate_key_slot( psa_key_handle_t *handle )
 {
-    for( *handle = PSA_KEY_SLOT_COUNT; *handle != 0; --( *handle ) )
+    for( *handle = MBEDTLS_PSA_KEY_SLOT_COUNT; *handle != 0; --( *handle ) )
     {
         psa_key_slot_t *slot = &global_data.key_slots[*handle - 1];
         if( ! slot->allocated )

--- a/library/psa_crypto_slot_management.h
+++ b/library/psa_crypto_slot_management.h
@@ -22,10 +22,6 @@
 #ifndef PSA_CRYPTO_SLOT_MANAGEMENT_H
 #define PSA_CRYPTO_SLOT_MANAGEMENT_H
 
-/* Number of key slots (plus one because 0 is not used).
- * The value is a compile-time constant for now, for simplicity. */
-#define PSA_KEY_SLOT_COUNT 32
-
 /** Access a key slot at the given handle.
  *
  * \param handle        Key handle to query.

--- a/library/psa_crypto_storage.h
+++ b/library/psa_crypto_storage.h
@@ -51,7 +51,7 @@ extern "C" {
  * - Using the ITS backend, all key ids are ok except 0xFFFFFF52
  *   (#PSA_CRYPTO_ITS_RANDOM_SEED_UID) for which the file contains the
  *   device's random seed (if this feature is enabled).
- * - Only key ids from 1 to #PSA_KEY_SLOT_COUNT are actually used.
+ * - Only key ids from 1 to #MBEDTLS_PSA_KEY_SLOT_COUNT are actually used.
  *
  * Since we need to preserve the random seed, avoid using that key slot.
  * Reserve a whole range of key slots just in case something else comes up.

--- a/tests/scripts/check-names.sh
+++ b/tests/scripts/check-names.sh
@@ -40,7 +40,7 @@ diff macros identifiers | sed -n -e 's/< //p' > actual-macros
 for THING in actual-macros enum-consts; do
     printf "Names of $THING: "
     test -r $THING
-    BAD=$( grep -v '^MBEDTLS_[0-9A-Z_]*[0-9A-Z]$' $THING || true )
+    BAD=$( grep -E -v '^(MBEDTLS|PSA)_[0-9A-Z_]*[0-9A-Z]$' $THING || true )
     if [ "x$BAD" = "x" ]; then
         echo "PASS"
     else
@@ -65,12 +65,14 @@ done
 
 printf "Likely typos: "
 sort -u actual-macros enum-consts > _caps
-HEADERS=$( ls include/mbedtls/*.h | egrep -v 'compat-1\.3\.h' )
+HEADERS=$( ls include/mbedtls/*.h include/psa/*.h | egrep -v 'compat-1\.3\.h' )
 NL='
 '
 sed -n 's/MBED..._[A-Z0-9_]*/\'"$NL"'&\'"$NL"/gp \
     $HEADERS library/*.c \
     | grep MBEDTLS | sort -u > _MBEDTLS_XXX
+
+
 TYPOS=$( diff _caps _MBEDTLS_XXX | sed -n 's/^> //p' \
             | egrep -v 'XXX|__|_$|^MBEDTLS_.*CONFIG_FILE$' || true )
 rm _MBEDTLS_XXX _caps

--- a/tests/scripts/list-macros.sh
+++ b/tests/scripts/list-macros.sh
@@ -7,7 +7,7 @@ if [ -d include/mbedtls ]; then :; else
     exit 1
 fi
 
-HEADERS=$( ls include/mbedtls/*.h | egrep -v 'compat-1\.3\.h' )
+HEADERS=$( ls include/mbedtls/*.h include/psa/*.h | egrep -v 'compat-1\.3\.h' )
 
 sed -n -e 's/.*#define \([a-zA-Z0-9_]*\).*/\1/p' $HEADERS \
     | egrep -v '^(asm|inline|EMIT|_CRT_SECURE_NO_DEPRECATE)$|^MULADDC_' \


### PR DESCRIPTION
changes to make number of key slots externally configurable

changed define name from PSA_KEY_SLOT_COUNT to MBEDTLS_PSA_KEY_SLOT_COUNT
moved define to crypto_extra.h and made it possible to externally override

depends on fixes from (and is rebased on) : https://github.com/ARMmbed/mbed-crypto/pull/8 
