### PR TITLE
Don't require a type and size when creating a key slot

### DIFF
--- a/include/psa/crypto.h
+++ b/include/psa/crypto.h
@@ -124,14 +124,6 @@ psa_status_t psa_get_key_lifetime(psa_key_handle_t handle,
  * application calls psa_close_key() or psa_destroy_key() or until the
  * application terminates.
  *
- * This function takes a key type and maximum size as arguments so that
- * the implementation can reserve a corresponding amount of memory.
- * Implementations are not required to enforce this limit: if the application
- * later tries to create a larger key or a key of a different type, it
- * is implementation-defined whether this may succeed.
- *
- * \param type          The type of key that the slot will contain.
- * \param max_bits      The maximum key size that the slot will contain.
  * \param[out] handle   On success, a handle to a volatile key slot.
  *
  * \retval #PSA_SUCCESS
@@ -140,13 +132,8 @@ psa_status_t psa_get_key_lifetime(psa_key_handle_t handle,
  * \retval #PSA_ERROR_INSUFFICIENT_MEMORY
  *         There was not enough memory, or the maximum number of key slots
  *         has been reached.
- * \retval #PSA_ERROR_INVALID_ARGUMENT
- *         This implementation does not support this key type.
  */
-
-psa_status_t psa_allocate_key(psa_key_type_t type,
-                              size_t max_bits,
-                              psa_key_handle_t *handle);
+psa_status_t psa_allocate_key(psa_key_handle_t *handle);
 
 /** Open a handle to an existing persistent key.
  *
@@ -192,8 +179,6 @@ psa_status_t psa_open_key(psa_key_lifetime_t lifetime,
  *                      area where the key material is stored. This must not
  *                      be #PSA_KEY_LIFETIME_VOLATILE.
  * \param id            The persistent identifier of the key.
- * \param type          The type of key that the slot will contain.
- * \param max_bits      The maximum key size that the slot will contain.
  * \param[out] handle   On success, a handle to the newly created key slot.
  *                      When key material is later created in this key slot,
  *                      it will be saved to the specified persistent location.
@@ -218,8 +203,6 @@ psa_status_t psa_open_key(psa_key_lifetime_t lifetime,
  */
 psa_status_t psa_create_key(psa_key_lifetime_t lifetime,
                             psa_key_id_t id,
-                            psa_key_type_t type,
-                            size_t max_bits,
                             psa_key_handle_t *handle);
 
 /** Close a key handle.
@@ -261,11 +244,9 @@ psa_status_t psa_close_key(psa_key_handle_t handle);
  * according to a different format.
  *
  * \param handle      Handle to the slot where the key will be stored.
- *                    This must be a valid slot for a key of the chosen
- *                    type: it must have been obtained by calling
- *                    psa_allocate_key() or psa_create_key() with the
- *                    correct \p type and with a maximum size that is
- *                    compatible with \p data.
+ *                    It must have been obtained by calling
+ *                    psa_allocate_key() or psa_create_key() and must
+ *                    not contain key material yet.
  * \param type        Key type (a \c PSA_KEY_TYPE_XXX value). On a successful
  *                    import, the key slot will contain a key of this type.
  * \param[in] data    Buffer containing the key data. The content of this
@@ -2005,12 +1986,9 @@ psa_status_t psa_generator_read(psa_crypto_generator_t *generator,
  * the key material is not exposed outside the isolation boundary.
  *
  * \param handle            Handle to the slot where the key will be stored.
- *                          This must be a valid slot for a key of the chosen
- *                          type: it must have been obtained by calling
- *                          psa_allocate_key() or psa_create_key() with the
- *                          correct \p type and with a maximum size that is
- *                          compatible with \p bits.
- *                          It must not contain any key material yet.
+ *                          It must have been obtained by calling
+ *                          psa_allocate_key() or psa_create_key() and must
+ *                          not contain key material yet.
  * \param type              Key type (a \c PSA_KEY_TYPE_XXX value).
  *                          This must be a symmetric key type.
  * \param bits              Key size in bits.
@@ -2232,12 +2210,9 @@ typedef struct {
  * \brief Generate a key or key pair.
  *
  * \param handle            Handle to the slot where the key will be stored.
- *                          This must be a valid slot for a key of the chosen
- *                          type: it must have been obtained by calling
- *                          psa_allocate_key() or psa_create_key() with the
- *                          correct \p type and with a maximum size that is
- *                          compatible with \p bits.
- *                          It must not contain any key material yet.
+ *                          It must have been obtained by calling
+ *                          psa_allocate_key() or psa_create_key() and must
+ *                          not contain key material yet.
  * \param type              Key type (a \c PSA_KEY_TYPE_XXX value).
  * \param bits              Key size in bits.
  * \param[in] extra         Extra parameters for key generation. The

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -142,13 +142,8 @@ static psa_status_t psa_internal_release_key_slot( psa_key_handle_t handle )
     return( psa_wipe_key_slot( slot ) );
 }
 
-psa_status_t psa_allocate_key( psa_key_type_t type,
-                               size_t max_bits,
-                               psa_key_handle_t *handle )
+psa_status_t psa_allocate_key( psa_key_handle_t *handle )
 {
-    /* This implementation doesn't reserve memory for the keys. */
-    (void) type;
-    (void) max_bits;
     *handle = 0;
     return( psa_internal_allocate_key_slot( handle ) );
 }
@@ -259,15 +254,9 @@ psa_status_t psa_open_key( psa_key_lifetime_t lifetime,
 
 psa_status_t psa_create_key( psa_key_lifetime_t lifetime,
                              psa_key_id_t id,
-                             psa_key_type_t type,
-                             size_t max_bits,
                              psa_key_handle_t *handle )
 {
     psa_status_t status;
-
-    /* This implementation doesn't reserve memory for the keys. */
-    (void) type;
-    (void) max_bits;
 
     status = persistent_key_setup( lifetime, id, handle,
                                    PSA_ERROR_EMPTY_SLOT );

--- a/programs/psa/crypto_examples.c
+++ b/programs/psa/crypto_examples.c
@@ -176,7 +176,7 @@ cipher_example_encrypt_decrypt_aes_cbc_nopad_1_block( void )
     status = psa_generate_random( input, sizeof( input ) );
     ASSERT_STATUS( status, PSA_SUCCESS );
 
-    status = psa_allocate_key( PSA_KEY_TYPE_AES, key_bits, &key_handle );
+    status = psa_allocate_key( &key_handle );
     ASSERT_STATUS( status, PSA_SUCCESS );
 
     status = set_key_policy( key_handle,
@@ -226,7 +226,7 @@ static psa_status_t cipher_example_encrypt_decrypt_aes_cbc_pkcs7_multi( void )
     status = psa_generate_random( input, sizeof( input ) );
     ASSERT_STATUS( status, PSA_SUCCESS );
 
-    status = psa_allocate_key( PSA_KEY_TYPE_AES, key_bits, &key_handle );
+    status = psa_allocate_key( &key_handle );
     ASSERT_STATUS( status, PSA_SUCCESS );
 
     status = set_key_policy( key_handle,
@@ -275,7 +275,7 @@ static psa_status_t cipher_example_encrypt_decrypt_aes_ctr_multi( void )
     status = psa_generate_random( input, sizeof( input ) );
     ASSERT_STATUS( status, PSA_SUCCESS );
 
-    status = psa_allocate_key( PSA_KEY_TYPE_AES, key_bits, &key_handle );
+    status = psa_allocate_key( &key_handle );
     ASSERT_STATUS( status, PSA_SUCCESS );
     status = set_key_policy( key_handle,
                              PSA_KEY_USAGE_ENCRYPT | PSA_KEY_USAGE_DECRYPT,

--- a/programs/psa/key_ladder_demo.c
+++ b/programs/psa/key_ladder_demo.c
@@ -211,9 +211,7 @@ static psa_status_t generate( const char *key_file_name )
     psa_key_handle_t key_handle = 0;
     psa_key_policy_t policy = PSA_KEY_POLICY_INIT;
 
-    PSA_CHECK( psa_allocate_key( PSA_KEY_TYPE_DERIVE,
-                                 PSA_BYTES_TO_BITS( KEY_SIZE_BYTES ),
-                                 &key_handle ) );
+    PSA_CHECK( psa_allocate_key( &key_handle ) );
     psa_key_policy_set_usage( &policy,
                               PSA_KEY_USAGE_DERIVE | PSA_KEY_USAGE_EXPORT,
                               KDF_ALG );
@@ -263,9 +261,7 @@ static psa_status_t import_key_from_file( psa_key_usage_t usage,
     SYS_CHECK( fclose( key_file ) == 0 );
     key_file = NULL;
 
-    PSA_CHECK( psa_allocate_key( PSA_KEY_TYPE_DERIVE,
-                                 PSA_BYTES_TO_BITS( key_size ),
-                                 master_key_handle ) );
+    PSA_CHECK( psa_allocate_key( master_key_handle ) );
     psa_key_policy_set_usage( &policy, usage, alg );
     PSA_CHECK( psa_set_key_policy( *master_key_handle, &policy ) );
     PSA_CHECK( psa_import_key( *master_key_handle,
@@ -318,9 +314,7 @@ static psa_status_t derive_key_ladder( const char *ladder[],
          * since it is no longer needed. */
         PSA_CHECK( psa_close_key( *key_handle ) );
         *key_handle = 0;
-        PSA_CHECK( psa_allocate_key( PSA_KEY_TYPE_DERIVE,
-                                     PSA_BYTES_TO_BITS( KEY_SIZE_BYTES ),
-                                     key_handle ) );
+        PSA_CHECK( psa_allocate_key( key_handle ) );
         PSA_CHECK( psa_set_key_policy( *key_handle, &policy ) );
         /* Use the generator obtained from the parent key to create
          * the next intermediate key. */
@@ -352,8 +346,7 @@ static psa_status_t derive_wrapping_key( psa_key_usage_t usage,
     psa_crypto_generator_t generator = PSA_CRYPTO_GENERATOR_INIT;
 
     *wrapping_key_handle = 0;
-    PSA_CHECK( psa_allocate_key( PSA_KEY_TYPE_AES, WRAPPING_KEY_BITS,
-                                 wrapping_key_handle ) );
+    PSA_CHECK( psa_allocate_key( wrapping_key_handle ) );
     psa_key_policy_set_usage( &policy, usage, WRAPPING_ALG );
     PSA_CHECK( psa_set_key_policy( *wrapping_key_handle, &policy ) );
 

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -876,8 +876,7 @@ void import( data_t *data, int type, int expected_status_arg )
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( type, KEY_BITS_FROM_DATA( type, data ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     status = psa_import_key( handle, type, data->x, data->len );
     TEST_EQUAL( status, expected_status );
     if( status == PSA_SUCCESS )
@@ -907,10 +906,7 @@ void import_twice( int alg_arg, int usage_arg,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( type1,
-                                  MAX( KEY_BITS_FROM_DATA( type1, data1 ),
-                                       KEY_BITS_FROM_DATA( type2, data2 ) ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, usage, alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -954,7 +950,7 @@ void import_rsa_made_up( int bits_arg, int keypair, int expected_status_arg )
     length = ret;
 
     /* Try importing the key */
-    PSA_ASSERT( psa_allocate_key( type, bits, &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     status = psa_import_key( handle, type, p, length );
     TEST_EQUAL( status, expected_status );
     if( status == PSA_SUCCESS )
@@ -996,7 +992,7 @@ void import_export( data_t *data,
         ASSERT_ALLOC( reexported, export_size );
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( type, expected_bits, &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, usage_arg, alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -1042,7 +1038,7 @@ void import_export( data_t *data,
     else
     {
         psa_key_handle_t handle2;
-        PSA_ASSERT( psa_allocate_key( type, expected_bits, &handle2 ) );
+        PSA_ASSERT( psa_allocate_key( &handle2 ) );
         PSA_ASSERT( psa_set_key_policy( handle2, &policy ) );
 
         PSA_ASSERT( psa_import_key( handle2, type,
@@ -1080,8 +1076,7 @@ void import_key_nonempty_slot( )
     const uint8_t data[] = { 0x1, 0x2, 0x3, 0x4, 0x5 };
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( type, PSA_BYTES_TO_BITS( sizeof( data ) ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
 
     /* Import the key */
     PSA_ASSERT( psa_import_key( handle, type,
@@ -1131,8 +1126,7 @@ void export_with_no_key_activity( )
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( PSA_KEY_TYPE_RAW_DATA, 0,
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_EXPORT, alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -1158,8 +1152,7 @@ void cipher_with_no_key_activity( )
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( PSA_KEY_TYPE_RAW_DATA, 0,
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_ENCRYPT, exercise_alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -1186,8 +1179,7 @@ void export_after_import_failure( data_t *data, int type_arg,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( type, KEY_BITS_FROM_DATA( type, data ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
 
     /* Import the key - expect failure */
     status = psa_import_key( handle, type,
@@ -1218,8 +1210,7 @@ void cipher_after_import_failure( data_t *data, int type_arg,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( type, KEY_BITS_FROM_DATA( type, data ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
 
     /* Import the key - expect failure */
     status = psa_import_key( handle, type,
@@ -1249,8 +1240,7 @@ void export_after_destroy_key( data_t *data, int type_arg )
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( type, KEY_BITS_FROM_DATA( type, data ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_EXPORT, alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
     export_size = (ptrdiff_t) data->len;
@@ -1297,8 +1287,7 @@ void import_export_public_key( data_t *data,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( type, KEY_BITS_FROM_DATA( type, data ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_EXPORT, alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -1348,8 +1337,7 @@ void import_and_exercise_key( data_t *data,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( type, KEY_BITS_FROM_DATA( type, data ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, usage, alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -1389,8 +1377,7 @@ void key_policy( int usage_arg, int alg_arg )
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( sizeof( key ) ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy_set, usage, alg );
 
     TEST_EQUAL( psa_key_policy_get_usage( &policy_set ), usage );
@@ -1451,9 +1438,7 @@ void mac_key_policy( int policy_usage,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( key_type,
-                                  KEY_BITS_FROM_DATA( key_type, key_data ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, policy_usage, policy_alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -1497,9 +1482,7 @@ void cipher_key_policy( int policy_usage,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( key_type,
-                                  KEY_BITS_FROM_DATA( key_type, key_data ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, policy_usage, policy_alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -1551,9 +1534,7 @@ void aead_key_policy( int policy_usage,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( key_type,
-                                  KEY_BITS_FROM_DATA( key_type, key_data ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, policy_usage, policy_alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -1608,9 +1589,7 @@ void asymmetric_encryption_key_policy( int policy_usage,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( key_type,
-                                  KEY_BITS_FROM_DATA( key_type, key_data ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, policy_usage, policy_alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -1672,9 +1651,7 @@ void asymmetric_signature_key_policy( int policy_usage,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( key_type,
-                                  KEY_BITS_FROM_DATA( key_type, key_data ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, policy_usage, policy_alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -1721,9 +1698,7 @@ void derive_key_policy( int policy_usage,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( key_type,
-                                  KEY_BITS_FROM_DATA( key_type, key_data ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, policy_usage, policy_alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -1763,9 +1738,7 @@ void agreement_key_policy( int policy_usage,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( key_type,
-                                  KEY_BITS_FROM_DATA( key_type, key_data ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, policy_usage, policy_alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -1965,8 +1938,7 @@ void mac_setup( int key_type_arg,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key->len ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy,
                               PSA_KEY_USAGE_SIGN | PSA_KEY_USAGE_VERIFY,
                               alg );
@@ -2011,8 +1983,7 @@ void mac_sign( int key_type_arg,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key->len ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_SIGN, alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -2059,8 +2030,7 @@ void mac_verify( int key_type_arg,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key->len ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_VERIFY, alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -2123,8 +2093,7 @@ void cipher_setup( int key_type_arg,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key->len ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_ENCRYPT, alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -2166,8 +2135,7 @@ void cipher_encrypt( int alg_arg, int key_type_arg,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key->len ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_ENCRYPT, alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -2233,8 +2201,7 @@ void cipher_encrypt_multipart( int alg_arg, int key_type_arg,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key->len ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_ENCRYPT, alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -2303,8 +2270,7 @@ void cipher_decrypt_multipart( int alg_arg, int key_type_arg,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key->len ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_DECRYPT, alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -2375,8 +2341,7 @@ void cipher_decrypt( int alg_arg, int key_type_arg,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key->len ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_DECRYPT, alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -2443,8 +2408,7 @@ void cipher_verify_output( int alg_arg, int key_type_arg,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key->len ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_ENCRYPT | PSA_KEY_USAGE_DECRYPT, alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -2528,8 +2492,7 @@ void cipher_verify_output_multipart( int alg_arg,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key->len ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_ENCRYPT | PSA_KEY_USAGE_DECRYPT, alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -2631,8 +2594,7 @@ void aead_encrypt_decrypt( int key_type_arg, data_t *key_data,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key_data->len ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy,
                               PSA_KEY_USAGE_ENCRYPT | PSA_KEY_USAGE_DECRYPT,
                               alg );
@@ -2697,8 +2659,7 @@ void aead_encrypt( int key_type_arg, data_t *key_data,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key_data->len ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_ENCRYPT , alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -2747,8 +2708,7 @@ void aead_decrypt( int key_type_arg, data_t *key_data,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key_data->len ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_DECRYPT , alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -2807,9 +2767,7 @@ void sign_deterministic( int key_type_arg, data_t *key_data,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( key_type,
-                                  KEY_BITS_FROM_DATA( key_type, key_data ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_SIGN, alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -2863,9 +2821,7 @@ void sign_fail( int key_type_arg, data_t *key_data,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( key_type,
-                                  KEY_BITS_FROM_DATA( key_type, key_data ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_SIGN, alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -2906,9 +2862,7 @@ void sign_verify( int key_type_arg, data_t *key_data,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( key_type,
-                                  KEY_BITS_FROM_DATA( key_type, key_data ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy,
                               PSA_KEY_USAGE_SIGN | PSA_KEY_USAGE_VERIFY,
                               alg );
@@ -2977,9 +2931,7 @@ void asymmetric_verify( int key_type_arg, data_t *key_data,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( key_type,
-                                  KEY_BITS_FROM_DATA( key_type, key_data ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_VERIFY, alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -3012,9 +2964,7 @@ void asymmetric_verify_fail( int key_type_arg, data_t *key_data,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( key_type,
-                                  KEY_BITS_FROM_DATA( key_type, key_data ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_VERIFY, alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -3059,9 +3009,7 @@ void asymmetric_encrypt( int key_type_arg,
     PSA_ASSERT( psa_crypto_init( ) );
 
     /* Import the key */
-    PSA_ASSERT( psa_allocate_key( key_type,
-                                  KEY_BITS_FROM_DATA( key_type, key_data ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_ENCRYPT, alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
     PSA_ASSERT( psa_import_key( handle, key_type,
@@ -3128,9 +3076,7 @@ void asymmetric_encrypt_decrypt( int key_type_arg,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( key_type,
-                                  KEY_BITS_FROM_DATA( key_type, key_data ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy,
                               PSA_KEY_USAGE_ENCRYPT | PSA_KEY_USAGE_DECRYPT,
                               alg );
@@ -3198,9 +3144,7 @@ void asymmetric_decrypt( int key_type_arg,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( key_type,
-                                  KEY_BITS_FROM_DATA( key_type, key_data ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_DECRYPT, alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -3264,9 +3208,7 @@ void asymmetric_decrypt_fail( int key_type_arg,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( key_type,
-                                  KEY_BITS_FROM_DATA( key_type, key_data ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_DECRYPT, alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -3349,8 +3291,7 @@ void derive_setup( int key_type_arg,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( key_type, PSA_BYTES_TO_BITS( key_data->len ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_DERIVE, alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -3387,9 +3328,7 @@ void test_derive_invalid_generator_state( )
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( key_type,
-                                  PSA_BYTES_TO_BITS( sizeof( key_data ) ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_DERIVE, alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -3484,9 +3423,7 @@ void derive_output( int alg_arg,
     ASSERT_ALLOC( output_buffer, output_buffer_size );
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( PSA_KEY_TYPE_DERIVE,
-                                  PSA_BYTES_TO_BITS( key_data->len ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_DERIVE, alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -3564,9 +3501,7 @@ void derive_full( int alg_arg,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( PSA_KEY_TYPE_DERIVE,
-                                  PSA_BYTES_TO_BITS( key_data->len ),
-                                  &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_DERIVE, alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -3636,9 +3571,7 @@ void derive_key_exercise( int alg_arg,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( PSA_KEY_TYPE_DERIVE,
-                                  PSA_BYTES_TO_BITS( key_data->len ),
-                                  &base_handle ) );
+    PSA_ASSERT( psa_allocate_key( &base_handle ) );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_DERIVE, alg );
     PSA_ASSERT( psa_set_key_policy( base_handle, &policy ) );
     PSA_ASSERT( psa_import_key( base_handle, PSA_KEY_TYPE_DERIVE,
@@ -3650,8 +3583,7 @@ void derive_key_exercise( int alg_arg,
                                     salt->x, salt->len,
                                     label->x, label->len,
                                     capacity ) );
-    PSA_ASSERT( psa_allocate_key( derived_type, derived_bits,
-                                  &derived_handle ) );
+    PSA_ASSERT( psa_allocate_key( &derived_handle ) );
     psa_key_policy_set_usage( &policy, derived_usage, derived_alg );
     PSA_ASSERT( psa_set_key_policy( derived_handle, &policy ) );
     PSA_ASSERT( psa_generator_import_key( derived_handle,
@@ -3703,9 +3635,7 @@ void derive_key_export( int alg_arg,
     ASSERT_ALLOC( export_buffer, capacity );
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( PSA_KEY_TYPE_DERIVE,
-                                  PSA_BYTES_TO_BITS( key_data->len ),
-                                  &base_handle ) );
+    PSA_ASSERT( psa_allocate_key( &base_handle ) );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_DERIVE, alg );
     PSA_ASSERT( psa_set_key_policy( base_handle, &policy ) );
     PSA_ASSERT( psa_import_key( base_handle, PSA_KEY_TYPE_DERIVE,
@@ -3727,8 +3657,7 @@ void derive_key_export( int alg_arg,
                                     salt->x, salt->len,
                                     label->x, label->len,
                                     capacity ) );
-    PSA_ASSERT( psa_allocate_key( PSA_KEY_TYPE_RAW_DATA, derived_bits,
-                                  &derived_handle ) );
+    PSA_ASSERT( psa_allocate_key( &derived_handle ) );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_EXPORT, 0 );
     PSA_ASSERT( psa_set_key_policy( derived_handle, &policy ) );
     PSA_ASSERT( psa_generator_import_key( derived_handle,
@@ -3740,9 +3669,7 @@ void derive_key_export( int alg_arg,
                                 &length ) );
     TEST_EQUAL( length, bytes1 );
     PSA_ASSERT( psa_destroy_key( derived_handle ) );
-    PSA_ASSERT( psa_allocate_key( PSA_KEY_TYPE_RAW_DATA,
-                                  PSA_BYTES_TO_BITS( bytes2 ),
-                                  &derived_handle ) );
+    PSA_ASSERT( psa_allocate_key( &derived_handle ) );
     PSA_ASSERT( psa_set_key_policy( derived_handle, &policy ) );
     PSA_ASSERT( psa_generator_import_key( derived_handle,
                                           PSA_KEY_TYPE_RAW_DATA,
@@ -3781,10 +3708,7 @@ void key_agreement_setup( int alg_arg,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( our_key_type,
-                                  KEY_BITS_FROM_DATA( our_key_type,
-                                                      our_key_data ),
-                                  &our_key ) );
+    PSA_ASSERT( psa_allocate_key( &our_key ) );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_DERIVE, alg );
     PSA_ASSERT( psa_set_key_policy( our_key, &policy ) );
     PSA_ASSERT( psa_import_key( our_key, our_key_type,
@@ -3820,10 +3744,7 @@ void key_agreement_capacity( int alg_arg,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( our_key_type,
-                                  KEY_BITS_FROM_DATA( our_key_type,
-                                                      our_key_data ),
-                                  &our_key ) );
+    PSA_ASSERT( psa_allocate_key( &our_key ) );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_DERIVE, alg );
     PSA_ASSERT( psa_set_key_policy( our_key, &policy ) );
     PSA_ASSERT( psa_import_key( our_key, our_key_type,
@@ -3877,10 +3798,7 @@ void key_agreement_output( int alg_arg,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( our_key_type,
-                                  KEY_BITS_FROM_DATA( our_key_type,
-                                                      our_key_data ),
-                                  &our_key ) );
+    PSA_ASSERT( psa_allocate_key( &our_key ) );
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_DERIVE, alg );
     PSA_ASSERT( psa_set_key_policy( our_key, &policy ) );
     PSA_ASSERT( psa_import_key( our_key, our_key_type,
@@ -3986,7 +3904,7 @@ void generate_key( int type_arg,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    PSA_ASSERT( psa_allocate_key( type, bits, &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     psa_key_policy_set_usage( &policy, usage, alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
 
@@ -4042,7 +3960,6 @@ void persistent_key_load_key_from_storage( data_t *data, int type_arg,
     PSA_ASSERT( psa_crypto_init() );
 
     PSA_ASSERT( psa_create_key( PSA_KEY_LIFETIME_PERSISTENT, 1,
-                                type, bits,
                                 &handle ) );
     psa_key_policy_set_usage( &policy_set, policy_usage,
                               policy_alg );
@@ -4064,9 +3981,7 @@ void persistent_key_load_key_from_storage( data_t *data, int type_arg,
 
         case DERIVE_KEY:
             /* Create base key */
-            PSA_ASSERT( psa_allocate_key( PSA_KEY_TYPE_DERIVE,
-                                          PSA_BYTES_TO_BITS( data->len ),
-                                          &base_key ) );
+            PSA_ASSERT( psa_allocate_key( &base_key ) );
             psa_key_policy_set_usage( &base_policy_set, PSA_KEY_USAGE_DERIVE,
                                       base_policy_alg );
             PSA_ASSERT( psa_set_key_policy(

--- a/tests/suites/test_suite_psa_crypto_persistent_key.function
+++ b/tests/suites/test_suite_psa_crypto_persistent_key.function
@@ -97,8 +97,6 @@ void save_large_persistent_key( int data_too_large, int expected_status )
     PSA_ASSERT( psa_crypto_init() );
 
     PSA_ASSERT( psa_create_key( PSA_KEY_LIFETIME_PERSISTENT, key_id,
-                                PSA_KEY_TYPE_RAW_DATA,
-                                PSA_BYTES_TO_BITS( data_length ),
                                 &handle ) );
 
     TEST_EQUAL( psa_import_key( handle, PSA_KEY_TYPE_RAW_DATA,
@@ -125,8 +123,6 @@ void persistent_key_destroy( int key_id_arg, int should_store,
     PSA_ASSERT( psa_crypto_init() );
 
     PSA_ASSERT( psa_create_key( PSA_KEY_LIFETIME_PERSISTENT, key_id,
-                                first_type,
-                                PSA_BYTES_TO_BITS( first_data->len ),
                                 &handle ) );
 
     if( should_store == 1 )
@@ -151,8 +147,6 @@ void persistent_key_destroy( int key_id_arg, int should_store,
 
     /* Create another key in the same slot */
     PSA_ASSERT( psa_create_key( PSA_KEY_LIFETIME_PERSISTENT, key_id,
-                                second_type,
-                                PSA_BYTES_TO_BITS( second_data->len ),
                                 &handle ) );
     PSA_ASSERT( psa_import_key(
                     handle, second_type,
@@ -176,8 +170,6 @@ void persistent_key_import( int key_id_arg, int type_arg, data_t *data,
     PSA_ASSERT( psa_crypto_init() );
 
     PSA_ASSERT( psa_create_key( PSA_KEY_LIFETIME_PERSISTENT, key_id,
-                                type,
-                                PSA_BYTES_TO_BITS( data->len ),
                                 &handle ) );
     TEST_EQUAL( psa_import_key( handle, type, data->x, data->len ),
                 expected_status );
@@ -217,8 +209,6 @@ void import_export_persistent_key( data_t *data, int type_arg,
     PSA_ASSERT( psa_crypto_init( ) );
 
     PSA_ASSERT( psa_create_key( PSA_KEY_LIFETIME_PERSISTENT, key_id,
-                                type,
-                                PSA_BYTES_TO_BITS( data->len ),
                                 &handle ) );
 
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_EXPORT,

--- a/tests/suites/test_suite_psa_crypto_slot_management.data
+++ b/tests/suites/test_suite_psa_crypto_slot_management.data
@@ -1,41 +1,29 @@
 Transient slot, check after closing
-transient_slot_lifecycle:PSA_KEY_TYPE_RAW_DATA:128:0:0:"0123456789abcdef0123456789abcdef":CLOSE_BY_CLOSE
+transient_slot_lifecycle:0:0:PSA_KEY_TYPE_RAW_DATA:"0123456789abcdef0123456789abcdef":CLOSE_BY_CLOSE
 
 Transient slot, check after destroying
-transient_slot_lifecycle:PSA_KEY_TYPE_RAW_DATA:128:0:0:"0123456789abcdef0123456789abcdef":CLOSE_BY_DESTROY
+transient_slot_lifecycle:0:0:PSA_KEY_TYPE_RAW_DATA:"0123456789abcdef0123456789abcdef":CLOSE_BY_DESTROY
 
 Transient slot, check after restart
-transient_slot_lifecycle:PSA_KEY_TYPE_RAW_DATA:128:0:0:"0123456789abcdef0123456789abcdef":CLOSE_BY_SHUTDOWN
+transient_slot_lifecycle:0:0:PSA_KEY_TYPE_RAW_DATA:"0123456789abcdef0123456789abcdef":CLOSE_BY_SHUTDOWN
 
 Persistent slot, check after closing
-persistent_slot_lifecycle:PSA_KEY_LIFETIME_PERSISTENT:1:PSA_KEY_TYPE_RAW_DATA:128:0:0:"0123456789abcdef0123456789abcdef":CLOSE_BY_CLOSE
+persistent_slot_lifecycle:PSA_KEY_LIFETIME_PERSISTENT:1:0:0:PSA_KEY_TYPE_RAW_DATA:"0123456789abcdef0123456789abcdef":CLOSE_BY_CLOSE
 
 Persistent slot, check after destroying
-persistent_slot_lifecycle:PSA_KEY_LIFETIME_PERSISTENT:1:PSA_KEY_TYPE_RAW_DATA:128:0:0:"0123456789abcdef0123456789abcdef":CLOSE_BY_DESTROY
+persistent_slot_lifecycle:PSA_KEY_LIFETIME_PERSISTENT:1:0:0:PSA_KEY_TYPE_RAW_DATA:"0123456789abcdef0123456789abcdef":CLOSE_BY_DESTROY
 
 Persistent slot, check after restart
-persistent_slot_lifecycle:PSA_KEY_LIFETIME_PERSISTENT:1:PSA_KEY_TYPE_RAW_DATA:128:0:0:"0123456789abcdef0123456789abcdef":CLOSE_BY_SHUTDOWN
+persistent_slot_lifecycle:PSA_KEY_LIFETIME_PERSISTENT:1:0:0:PSA_KEY_TYPE_RAW_DATA:"0123456789abcdef0123456789abcdef":CLOSE_BY_SHUTDOWN
 
-Attempt to overwrite: close before, same type
-create_existent:PSA_KEY_LIFETIME_PERSISTENT:1:PSA_KEY_TYPE_RAW_DATA:CLOSE_BEFORE
+Attempt to overwrite: close before
+create_existent:PSA_KEY_LIFETIME_PERSISTENT:1:CLOSE_BEFORE
 
-Attempt to overwrite: close before, different type
-depends_on:MBEDTLS_AES_C
-create_existent:PSA_KEY_LIFETIME_PERSISTENT:1:PSA_KEY_TYPE_AES:CLOSE_BEFORE
+Attempt to overwrite: close after
+create_existent:PSA_KEY_LIFETIME_PERSISTENT:1:CLOSE_AFTER
 
-Attempt to overwrite: close after, same type
-create_existent:PSA_KEY_LIFETIME_PERSISTENT:1:PSA_KEY_TYPE_RAW_DATA:CLOSE_AFTER
-
-Attempt to overwrite: close after, different type
-depends_on:MBEDTLS_AES_C
-create_existent:PSA_KEY_LIFETIME_PERSISTENT:1:PSA_KEY_TYPE_AES:CLOSE_AFTER
-
-Attempt to overwrite: keep open, same type
-create_existent:PSA_KEY_LIFETIME_PERSISTENT:1:PSA_KEY_TYPE_RAW_DATA:KEEP_OPEN
-
-Attempt to overwrite: keep open, different type
-depends_on:MBEDTLS_AES_C
-create_existent:PSA_KEY_LIFETIME_PERSISTENT:1:PSA_KEY_TYPE_AES:KEEP_OPEN
+Attempt to overwrite: keep open
+create_existent:PSA_KEY_LIFETIME_PERSISTENT:1:KEEP_OPEN
 
 Open failure: invalid identifier (0)
 depends_on:MBEDTLS_PSA_CRYPTO_STORAGE_C
@@ -56,18 +44,18 @@ Open failure: invalid lifetime
 open_fail:0x7fffffff:0:PSA_ERROR_INVALID_ARGUMENT
 
 Create failure: volatile lifetime
-create_fail:PSA_KEY_LIFETIME_VOLATILE:1:PSA_KEY_TYPE_RAW_DATA:8:PSA_ERROR_INVALID_ARGUMENT
+create_fail:PSA_KEY_LIFETIME_VOLATILE:1:PSA_ERROR_INVALID_ARGUMENT
 
 Create failure: invalid lifetime
-create_fail:0x7fffffff:0:PSA_KEY_TYPE_RAW_DATA:8:PSA_ERROR_INVALID_ARGUMENT
+create_fail:0x7fffffff:0:PSA_ERROR_INVALID_ARGUMENT
 
 Create failure: invalid key id (0)
 depends_on:MBEDTLS_PSA_CRYPTO_STORAGE_C
-create_fail:PSA_KEY_LIFETIME_PERSISTENT:0:PSA_KEY_TYPE_RAW_DATA:8:PSA_ERROR_INVALID_ARGUMENT
+create_fail:PSA_KEY_LIFETIME_PERSISTENT:0:PSA_ERROR_INVALID_ARGUMENT
 
 Create failure: invalid key id (random seed UID)
 depends_on:MBEDTLS_PSA_CRYPTO_STORAGE_C
-create_fail:PSA_KEY_LIFETIME_PERSISTENT:PSA_CRYPTO_ITS_RANDOM_SEED_UID:PSA_KEY_TYPE_RAW_DATA:8:PSA_ERROR_INVALID_ARGUMENT
+create_fail:PSA_KEY_LIFETIME_PERSISTENT:PSA_CRYPTO_ITS_RANDOM_SEED_UID:PSA_ERROR_INVALID_ARGUMENT
 
 Open not supported
 depends_on:!MBEDTLS_PSA_CRYPTO_STORAGE_C
@@ -75,7 +63,7 @@ open_fail:PSA_KEY_LIFETIME_PERSISTENT:1:PSA_ERROR_NOT_SUPPORTED
 
 Create not supported
 depends_on:!MBEDTLS_PSA_CRYPTO_STORAGE_C
-create_fail:PSA_KEY_LIFETIME_PERSISTENT:1:PSA_KEY_TYPE_RAW_DATA:8:PSA_ERROR_NOT_SUPPORTED
+create_fail:PSA_KEY_LIFETIME_PERSISTENT:1:PSA_ERROR_NOT_SUPPORTED
 
 Close/destroy invalid handle
 invalid_handle:

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -65,15 +65,13 @@ static int psa_key_policy_equal( psa_key_policy_t *p1,
  */
 
 /* BEGIN_CASE */
-void transient_slot_lifecycle( int type_arg, int max_bits_arg,
-                               int alg_arg, int usage_arg,
-                               data_t *key_data,
+void transient_slot_lifecycle( int alg_arg, int usage_arg,
+                               int type_arg, data_t *key_data,
                                int close_method_arg )
 {
-    psa_key_type_t type = type_arg;
-    size_t max_bits = max_bits_arg;
     psa_algorithm_t alg = alg_arg;
     psa_key_usage_t usage_flags = usage_arg;
+    psa_key_type_t type = type_arg;
     close_method_t close_method = close_method_arg;
     psa_key_type_t read_type;
     psa_key_handle_t handle = 0;
@@ -82,7 +80,7 @@ void transient_slot_lifecycle( int type_arg, int max_bits_arg,
     PSA_ASSERT( psa_crypto_init( ) );
 
     /* Get a handle and import a key. */
-    PSA_ASSERT( psa_allocate_key( type, max_bits, &handle ) );
+    PSA_ASSERT( psa_allocate_key( &handle ) );
     TEST_ASSERT( handle != 0 );
     psa_key_policy_set_usage( &policy, usage_flags, alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
@@ -116,17 +114,15 @@ exit:
 
 /* BEGIN_CASE depends_on:MBEDTLS_PSA_CRYPTO_STORAGE_C */
 void persistent_slot_lifecycle( int lifetime_arg, int id_arg,
-                                int type_arg, int max_bits_arg,
                                 int alg_arg, int usage_arg,
-                                data_t *key_data,
+                                int type_arg, data_t *key_data,
                                 int close_method_arg )
 {
     psa_key_lifetime_t lifetime = lifetime_arg;
     psa_key_id_t id = id_arg;
-    psa_key_type_t type = type_arg;
-    size_t max_bits = max_bits_arg;
     psa_algorithm_t alg = alg_arg;
     psa_key_usage_t usage_flags = usage_arg;
+    psa_key_type_t type = type_arg;
     close_method_t close_method = close_method_arg;
     psa_key_type_t read_type;
     psa_key_handle_t handle = 0;
@@ -137,7 +133,7 @@ void persistent_slot_lifecycle( int lifetime_arg, int id_arg,
     PSA_ASSERT( psa_crypto_init( ) );
 
     /* Get a handle and import a key. */
-    PSA_ASSERT( psa_create_key( lifetime, id, type, max_bits, &handle ) );
+    PSA_ASSERT( psa_create_key( lifetime, id, &handle ) );
     TEST_ASSERT( handle != 0 );
     psa_key_policy_set_usage( &policy, usage_flags, alg );
     PSA_ASSERT( psa_set_key_policy( handle, &policy ) );
@@ -194,7 +190,6 @@ exit:
 
 /* BEGIN_CASE depends_on:MBEDTLS_PSA_CRYPTO_STORAGE_C */
 void create_existent( int lifetime_arg, int id_arg,
-                      int new_type_arg,
                       int reopen_policy_arg )
 {
     psa_key_lifetime_t lifetime = lifetime_arg;
@@ -203,7 +198,6 @@ void create_existent( int lifetime_arg, int id_arg,
     psa_key_policy_t policy1 = PSA_KEY_POLICY_INIT;
     psa_key_policy_t read_policy = PSA_KEY_POLICY_INIT;
     psa_key_type_t type1 = PSA_KEY_TYPE_RAW_DATA;
-    psa_key_type_t type2 = new_type_arg;
     psa_key_type_t read_type;
     const uint8_t material1[16] = "test material #1";
     size_t bits1 = PSA_BYTES_TO_BITS( sizeof( material1 ) );
@@ -217,7 +211,7 @@ void create_existent( int lifetime_arg, int id_arg,
     PSA_ASSERT( psa_crypto_init( ) );
 
     /* Create a key. */
-    PSA_ASSERT( psa_create_key( lifetime, id, type1, bits1, &handle1 ) );
+    PSA_ASSERT( psa_create_key( lifetime, id, &handle1 ) );
     TEST_ASSERT( handle1 != 0 );
     psa_key_policy_set_usage( &policy1, PSA_KEY_USAGE_EXPORT, 0 );
     PSA_ASSERT( psa_set_key_policy( handle1, &policy1 ) );
@@ -228,7 +222,7 @@ void create_existent( int lifetime_arg, int id_arg,
         PSA_ASSERT( psa_close_key( handle1 ) );
 
     /* Attempt to create a new key in the same slot. */
-    TEST_EQUAL( psa_create_key( lifetime, id, type2, bits1, &handle2 ),
+    TEST_EQUAL( psa_create_key( lifetime, id, &handle2 ),
                 PSA_ERROR_OCCUPIED_SLOT );
     TEST_EQUAL( handle2, 0 );
 
@@ -276,13 +270,10 @@ exit:
 
 /* BEGIN_CASE */
 void create_fail( int lifetime_arg, int id_arg,
-                  int type_arg, int max_bits_arg,
                   int expected_status_arg )
 {
     psa_key_lifetime_t lifetime = lifetime_arg;
     psa_key_id_t id = id_arg;
-    psa_key_type_t type = type_arg;
-    size_t max_bits = max_bits_arg;
     psa_status_t expected_status = expected_status_arg;
     psa_key_handle_t handle = 0xdead;
 
@@ -290,7 +281,7 @@ void create_fail( int lifetime_arg, int id_arg,
 
     PSA_ASSERT( psa_crypto_init( ) );
 
-    TEST_EQUAL( psa_create_key( lifetime, id, type, max_bits, &handle ),
+    TEST_EQUAL( psa_create_key( lifetime, id, &handle ),
                 expected_status );
     TEST_EQUAL( handle, 0 );
 
@@ -314,7 +305,7 @@ void invalid_handle( )
     PSA_ASSERT( psa_crypto_init( ) );
 
     /* Allocate a handle and store a key in it. */
-    PSA_ASSERT( psa_allocate_key( PSA_KEY_TYPE_RAW_DATA, 1, &handle1 ) );
+    PSA_ASSERT( psa_allocate_key( &handle1 ) );
     TEST_ASSERT( handle1 != 0 );
     psa_key_policy_set_usage( &policy, 0, 0 );
     PSA_ASSERT( psa_set_key_policy( handle1, &policy ) );
@@ -350,7 +341,6 @@ void many_transient_handles( int max_handles_arg )
     psa_key_policy_t policy = PSA_KEY_POLICY_INIT;
     uint8_t exported[sizeof( size_t )];
     size_t exported_length;
-    size_t max_bits = PSA_BITS_TO_BYTES( sizeof( exported ) );
 
     ASSERT_ALLOC( handles, max_handles );
     PSA_ASSERT( psa_crypto_init( ) );
@@ -358,8 +348,7 @@ void many_transient_handles( int max_handles_arg )
 
     for( i = 0; i < max_handles; i++ )
     {
-        status = psa_allocate_key( PSA_KEY_TYPE_RAW_DATA, max_bits,
-                                   &handles[i] );
+        status = psa_allocate_key( &handles[i] );
         if( status == PSA_ERROR_INSUFFICIENT_MEMORY )
             break;
         PSA_ASSERT( status );


### PR DESCRIPTION
Remove the type and bits arguments to psa_allocate_key() and
psa_create_key(). They can be useful if the implementation wants to
know exactly how much space to allocate for the slot, but many
implementations (including ours) don't care, and it's possible to work
around their lack by deferring size-dependent actions to the time when
the key material is created. They are a burden to applications and
make the API more complex, and the benefits aren't worth it.

Change the API and adapt the implementation, the units test and the
sample code accordingly.