### PR TITLE
PSA integration sibling: Update crypto submodule (Hash clone, Key Policy Init, Key slot alloc)

### DIFF
--- a/library/cipher.c
+++ b/library/cipher.c
@@ -308,7 +308,7 @@ int mbedtls_cipher_setkey( mbedtls_cipher_context_t *ctx,
             return( MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE );
 
         /* Allocate a key slot to use. */
-        status = psa_allocate_key( key_type, key_bitlen, &cipher_psa->slot );
+        status = psa_allocate_key( &cipher_psa->slot );
         if( status != PSA_SUCCESS )
             return( MBEDTLS_ERR_CIPHER_HW_ACCEL_FAILED );
 

--- a/library/cipher.c
+++ b/library/cipher.c
@@ -322,7 +322,7 @@ int mbedtls_cipher_setkey( mbedtls_cipher_context_t *ctx,
          * mbedtls_cipher_free() needs to be called in any case. */
 
         /* Setup policy for the new key slot. */
-        psa_key_policy_init( &key_policy );
+        policy = psa_key_policy_init();
 
         /* Mbed TLS' cipher layer doesn't enforce the mode of operation
          * (encrypt vs. decrypt): it is possible to setup a key for encryption

--- a/library/pk.c
+++ b/library/pk.c
@@ -576,7 +576,7 @@ int mbedtls_pk_wrap_as_opaque( mbedtls_pk_context *pk,
                                  mbedtls_psa_parse_tls_ecc_group ( curve_id ) );
 
     /* allocate a key slot */
-    if( PSA_SUCCESS != psa_allocate_key( key_type, d_len * 8, &key ) )
+    if( PSA_SUCCESS != psa_allocate_key( &key ) )
         return( MBEDTLS_ERR_PK_HW_ACCEL_FAILED );
 
     /* set policy */

--- a/library/pk.c
+++ b/library/pk.c
@@ -580,7 +580,7 @@ int mbedtls_pk_wrap_as_opaque( mbedtls_pk_context *pk,
         return( MBEDTLS_ERR_PK_HW_ACCEL_FAILED );
 
     /* set policy */
-    psa_key_policy_init( &policy );
+    policy = psa_key_policy_init();
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_SIGN,
                                        PSA_ALG_ECDSA(hash_alg) );
     if( PSA_SUCCESS != psa_set_key_policy( key, &policy ) )

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -577,9 +577,7 @@ static int ecdsa_verify_wrap( void *ctx, mbedtls_md_type_t md_alg,
     psa_sig_md = PSA_ALG_ECDSA( psa_md );
     psa_type = PSA_KEY_TYPE_ECC_PUBLIC_KEY( curve );
 
-    if( ( ret = psa_allocate_key( psa_type,
-                                  MBEDTLS_PSA_ECC_KEY_BITS_OF_CURVE(curve),
-                                  &key_slot ) ) != PSA_SUCCESS )
+    if( ( ret = psa_allocate_key( &key_slot ) ) != PSA_SUCCESS )
           return( mbedtls_psa_err_translate_pk( ret ) );
 
     psa_key_policy_init( &policy );

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -580,7 +580,7 @@ static int ecdsa_verify_wrap( void *ctx, mbedtls_md_type_t md_alg,
     if( ( ret = psa_allocate_key( &key_slot ) ) != PSA_SUCCESS )
           return( mbedtls_psa_err_translate_pk( ret ) );
 
-    psa_key_policy_init( &policy );
+    policy = psa_key_policy_init();
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_VERIFY, psa_sig_md );
     if( ( ret = psa_set_key_policy( key_slot, &policy ) ) != PSA_SUCCESS )
     {

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -1594,7 +1594,7 @@ int main( int argc, char *argv[] )
     if( opt.psk_opaque != 0 )
     {
         /* The algorithm has already been determined earlier. */
-        status = psa_allocate_key( PSA_KEY_TYPE_DERIVE, psk_len * 8, &slot );
+        status = psa_allocate_key( &slot );
         if( status != PSA_SUCCESS )
         {
             ret = MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -1601,7 +1601,7 @@ int main( int argc, char *argv[] )
             goto exit;
         }
 
-        psa_key_policy_init( &policy );
+        policy = psa_key_policy_init();
         psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_DERIVE, alg );
 
         status = psa_set_key_policy( slot, &policy );

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -1239,7 +1239,7 @@ static psa_status_t psa_setup_psk_key_slot( psa_key_handle_t slot,
     psa_status_t status;
     psa_key_policy_t policy;
 
-    psa_key_policy_init( &policy );
+    policy = psa_key_policy_init();
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_DERIVE, alg );
 
     status = psa_set_key_policy( slot, &policy );

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -2667,7 +2667,7 @@ int main( int argc, char *argv[] )
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
         if( opt.psk_opaque != 0 )
         {
-            status = psa_allocate_key( PSA_KEY_TYPE_DERIVE, psk_len * 8, &psk_slot );
+            status = psa_allocate_key( &psk_slot );
             if( status != PSA_SUCCESS )
             {
                 fprintf( stderr, "ALLOC FAIL\n" );
@@ -2711,7 +2711,7 @@ int main( int argc, char *argv[] )
             psk_entry *cur_psk;
             for( cur_psk = psk_info; cur_psk != NULL; cur_psk = cur_psk->next )
             {
-                status = psa_allocate_key( PSA_KEY_TYPE_DERIVE, cur_psk->key_len * 8, &cur_psk->slot );
+                status = psa_allocate_key( &cur_psk->slot );
                 if( status != PSA_SUCCESS )
                 {
                     ret = MBEDTLS_ERR_SSL_HW_ACCEL_FAILED;

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -84,7 +84,7 @@ psa_key_handle_t pk_psa_genkey( void )
     psa_key_policy_t policy;
 
     /* Allocate a key slot */
-    if( PSA_SUCCESS != psa_allocate_key( type, bits, &key ) )
+    if( PSA_SUCCESS != psa_allocate_key( &key ) )
         return( PK_PSA_INVALID_SLOT );
 
     /* set up policy on key slot */

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -88,7 +88,7 @@ psa_key_handle_t pk_psa_genkey( void )
         return( PK_PSA_INVALID_SLOT );
 
     /* set up policy on key slot */
-    psa_key_policy_init( &policy );
+    policy = psa_key_policy_init();
     psa_key_policy_set_usage( &policy, PSA_KEY_USAGE_SIGN,
                                       PSA_ALG_ECDSA(PSA_ALG_SHA_256) );
     if( PSA_SUCCESS != psa_set_key_policy( key, &policy ) )


### PR DESCRIPTION
__Summary:__ This is the sibling of ARMmbed/mbedtls#2376. It is based on the merge 0b6b871 of #22 with development, it adapts crypto and TLS files to the changes that have been made to the key policy initialization and key slot allocation APIs in the same way as ARMmbed/mbedtls#2376 does.