### PR TITLE
Unified tests/scripts/depends.py

### DIFF
--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -118,6 +118,10 @@
 #error "MBEDTLS_ECP_RESTARTABLE defined, but it cannot coexist with an alternative ECP implementation"
 #endif
 
+#if defined(MBEDTLS_ECP_RESTARTABLE) && !defined(MBEDTLS_ECP_C)
+#error "MBEDTLS_ECP_RESTARTABLE defined, but not all prerequisites"
+#endif
+
 #if defined(MBEDTLS_ECDSA_DETERMINISTIC) && !defined(MBEDTLS_HMAC_DRBG_C)
 #error "MBEDTLS_ECDSA_DETERMINISTIC defined, but not all prerequisites"
 #endif

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -759,8 +759,12 @@ int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl )
 #if defined(MBEDTLS_SSL_EXTENDED_MASTER_SECRET)
         const mbedtls_ssl_ciphersuite_t *ciphersuite_info =
             ssl->transform_negotiate->ciphersuite_info;
+#if defined(MBEDTLS_SHA512_C)
         mbedtls_md_type_t const md_type = ciphersuite_info->mac;
+#endif
 #endif /* MBEDTLS_SSL_EXTENDED_MASTER_SECRET */
+
+        (void) ciphersuite_info;
 
 #if defined(MBEDTLS_SSL_EXTENDED_MASTER_SECRET)
         if( ssl->handshake->extended_ms == MBEDTLS_SSL_EXTENDED_MS_ENABLED )
@@ -806,9 +810,11 @@ int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl )
             if( ssl->handshake->psk_opaque != 0 )
                 psk = ssl->handshake->psk_opaque;
 
+#if defined(MBEDTLS_SHA512_C)
             if( md_type == MBEDTLS_MD_SHA384 )
                 alg = PSA_ALG_TLS12_PSK_TO_MS(PSA_ALG_SHA_384);
             else
+#endif /* MBEDTLS_SHA512_C */
                 alg = PSA_ALG_TLS12_PSK_TO_MS(PSA_ALG_SHA_256);
 
             status = psa_key_derivation( &generator, psk, alg,

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -764,9 +764,9 @@ int mbedtls_ssl_derive_keys( mbedtls_ssl_context *ssl )
 #endif
 #endif /* MBEDTLS_SSL_EXTENDED_MASTER_SECRET */
 
-        (void) ciphersuite_info;
 
 #if defined(MBEDTLS_SSL_EXTENDED_MASTER_SECRET)
+        (void) ciphersuite_info;
         if( ssl->handshake->extended_ms == MBEDTLS_SSL_EXTENDED_MS_ENABLED )
         {
             MBEDTLS_SSL_DEBUG_MSG( 3, ( "using extended master secret" ) );

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -456,7 +456,7 @@ static int my_send( void *ctx, const unsigned char *buf, size_t len )
     return( ret );
 }
 
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED)
 /*
  * Enabled if debug_level > 1 in code below
  */
@@ -496,7 +496,7 @@ static int ssl_sig_hashes_for_test[] = {
 #endif
     MBEDTLS_MD_NONE
 };
-#endif /* MBEDTLS_X509_CRT_PARSE_C */
+#endif /* MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED */
 
 /*
  * Wait for an event from the underlying transport or the timer
@@ -577,7 +577,7 @@ int main( int argc, char *argv[] )
     psa_status_t status;
 #endif
 
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED)
     mbedtls_x509_crt_profile crt_profile_for_test = mbedtls_x509_crt_profile_default;
 #endif
     mbedtls_entropy_context entropy;
@@ -1468,7 +1468,7 @@ int main( int argc, char *argv[] )
         goto exit;
     }
 
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED)
     /* The default algorithms profile disables SHA-1, but our tests still
        rely on it heavily. */
     if( opt.allow_sha1 > 0 )
@@ -1480,7 +1480,7 @@ int main( int argc, char *argv[] )
 
     if( opt.debug_level > 0 )
         mbedtls_ssl_conf_verify( &conf, my_verify, NULL );
-#endif /* MBEDTLS_X509_CRT_PARSE_C */
+#endif /* MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED */
 
     if( opt.auth_mode != DFL_AUTH_MODE )
         mbedtls_ssl_conf_authmode( &conf, opt.auth_mode );

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -924,7 +924,7 @@ void term_handler( int sig )
 }
 #endif
 
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED)
 static int ssl_sig_hashes_for_test[] = {
 #if defined(MBEDTLS_SHA512_C)
     MBEDTLS_MD_SHA512,
@@ -940,7 +940,7 @@ static int ssl_sig_hashes_for_test[] = {
 #endif
     MBEDTLS_MD_NONE
 };
-#endif /* MBEDTLS_X509_CRT_PARSE_C */
+#endif /* MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED */
 
 /** Return true if \p ret is a status code indicating that there is an
  * operation in progress on an SSL connection, and false if it indicates
@@ -1281,7 +1281,7 @@ int main( int argc, char *argv[] )
     mbedtls_ssl_cookie_ctx cookie_ctx;
 #endif
 
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED)
     mbedtls_x509_crt_profile crt_profile_for_test = mbedtls_x509_crt_profile_default;
 #endif
     mbedtls_entropy_context entropy;
@@ -2368,7 +2368,7 @@ int main( int argc, char *argv[] )
         goto exit;
     }
 
-#if defined(MBEDTLS_X509_CRT_PARSE_C)
+#if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED)
     /* The default algorithms profile disables SHA-1, but our tests still
        rely on it heavily. Hence we allow it here. A real-world server
        should use the default profile unless there is a good reason not to. */
@@ -2378,7 +2378,7 @@ int main( int argc, char *argv[] )
         mbedtls_ssl_conf_cert_profile( &conf, &crt_profile_for_test );
         mbedtls_ssl_conf_sig_hashes( &conf, ssl_sig_hashes_for_test );
     }
-#endif /* MBEDTLS_X509_CRT_PARSE_C */
+#endif /* MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED */
 
     if( opt.auth_mode != DFL_AUTH_MODE )
         mbedtls_ssl_conf_authmode( &conf, opt.auth_mode );

--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -684,7 +684,10 @@ int main( int argc, char *argv[] )
     }
 #endif
 
-#if defined(MBEDTLS_HMAC_DRBG_C)
+#if defined(MBEDTLS_HMAC_DRBG_C) &&             \
+    ( defined(MBEDTLS_SHA1_C) ||                \
+      defined(MBEDTLS_SHA256_C) ||              \
+      defined(MBEDTLS_SHA512_C) )
     if( todo.hmac_drbg )
     {
         mbedtls_hmac_drbg_context hmac_drbg;
@@ -725,6 +728,24 @@ int main( int argc, char *argv[] )
         TIME_AND_TSC( "HMAC_DRBG SHA-256 (PR)",
                 mbedtls_hmac_drbg_random( &hmac_drbg, buf, BUFSIZE ) );
 #endif
+
+#if defined(MBEDTLS_SHA512_C)
+        if( ( md_info = mbedtls_md_info_from_type( MBEDTLS_MD_SHA512 ) ) == NULL )
+            mbedtls_exit(1);
+
+        if( mbedtls_hmac_drbg_seed( &hmac_drbg, md_info, myrand, NULL, NULL, 0 ) != 0 )
+            mbedtls_exit(1);
+        TIME_AND_TSC( "HMAC_DRBG SHA-512 (NOPR)",
+                mbedtls_hmac_drbg_random( &hmac_drbg, buf, BUFSIZE ) );
+
+        if( mbedtls_hmac_drbg_seed( &hmac_drbg, md_info, myrand, NULL, NULL, 0 ) != 0 )
+            mbedtls_exit(1);
+        mbedtls_hmac_drbg_set_prediction_resistance( &hmac_drbg,
+                                             MBEDTLS_HMAC_DRBG_PR_ON );
+        TIME_AND_TSC( "HMAC_DRBG SHA-512 (PR)",
+                mbedtls_hmac_drbg_random( &hmac_drbg, buf, BUFSIZE ) );
+#endif
+
         mbedtls_hmac_drbg_free( &hmac_drbg );
     }
 #endif

--- a/tests/scripts/depends.py
+++ b/tests/scripts/depends.py
@@ -176,16 +176,22 @@ ssl_pre_1_2_dependencies = ['MBEDTLS_SSL_CBC_RECORD_SPLITTING',
 
 # If the configuration option A requires B, make sure that
 # B in reverse_dependencies[A].
+# All the information here should be contained in check_config.h. This
+# file includes a copy because it changes rarely and it would be a pain
+# to extract automatically.
 reverse_dependencies = {
     'MBEDTLS_ECDSA_C': ['MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED'],
     'MBEDTLS_ECP_C': ['MBEDTLS_ECDSA_C',
                       'MBEDTLS_ECDH_C',
                       'MBEDTLS_ECJPAKE_C',
+                      'MBEDTLS_ECP_RESTARTABLE',
+                      'MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED',
                       'MBEDTLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED',
                       'MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED',
                       'MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED',
                       'MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED',
                       'MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED'],
+    'MBEDTLS_ECP_DP_SECP256R1_ENABLED': ['MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED'],
     'MBEDTLS_MD5_C': ssl_pre_1_2_dependencies,
     'MBEDTLS_PKCS1_V21': ['MBEDTLS_X509_RSASSA_PSS_SUPPORT'],
     'MBEDTLS_PKCS1_V15': ['MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED',
@@ -198,6 +204,8 @@ reverse_dependencies = {
                       'MBEDTLS_KEY_EXCHANGE_RSA_PSK_ENABLED',
                       'MBEDTLS_KEY_EXCHANGE_RSA_ENABLED'],
     'MBEDTLS_SHA1_C': ssl_pre_1_2_dependencies,
+    'MBEDTLS_SHA256_C': ['MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED',
+                         'MBEDTLS_ENTROPY_FORCE_SHA256'],
     'MBEDTLS_X509_RSASSA_PSS_SUPPORT': [],
 }
 

--- a/tests/scripts/depends.py
+++ b/tests/scripts/depends.py
@@ -301,9 +301,11 @@ Return them in a generator."""
             # hash which is obsolete. Run the test suites.
             'hashes': ExclusiveDomain(hash_symbols, build_and_test,
                                       exclude=r'MBEDTLS_(MD|RIPEMD|SHA1_)'),
-            # Key exchange types. Just check the build.
-            'kex': ExclusiveDomain(key_exchange_symbols, [build_command]),
-            # Public-key algorithms. Run the test suites.
+            # Key exchange types. Only build the library and the sample
+            # programs.
+            'kex': ExclusiveDomain(key_exchange_symbols,
+                                   [build_command + ['lib'],
+                                    build_command + ['-C', 'programs']]),
             'pkalgs': ComplementaryDomain(['MBEDTLS_ECDSA_C',
                                            'MBEDTLS_ECP_C',
                                            'MBEDTLS_PKCS1_V21',

--- a/tests/scripts/depends.py
+++ b/tests/scripts/depends.py
@@ -31,6 +31,7 @@ import traceback
 def log_line(text, prefix='depends.py'):
     """Print a status message."""
     sys.stderr.write(prefix + ' ' + text + '\n')
+    sys.stderr.flush()
 
 def backup_config(options):
     """Back up the library configuration file (config.h)."""

--- a/tests/scripts/depends.py
+++ b/tests/scripts/depends.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2018, Arm Limited, All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This file is part of Mbed TLS (https://tls.mbed.org)
+
+"""Test Mbed TLS with a subset of algorithms.
+"""
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+import traceback
+
+def log_line(text, prefix='depends.py'):
+    """Print a status message."""
+    sys.stderr.write(prefix + ' ' + text + '\n')
+
+def backup_config(options):
+    """Back up the library configuration file (config.h)."""
+    shutil.copy(options.config, options.config_backup)
+
+def restore_config(options, done=False):
+    """Restore the library configuration file (config.h).
+If done is true, remove the backup file."""
+    if done:
+        shutil.move(options.config_backup, options.config)
+    else:
+        shutil.copy(options.config_backup, options.config)
+
+class Job:
+    """A job builds the library in a specific configuration and runs some tests."""
+    def __init__(self, name, config_settings, commands):
+        """Build a job object.
+The job uses the configuration described by config_settings. This is a
+dictionary where the keys are preprocessor symbols and the values are
+booleans or strings. A boolean indicates whether or not to #define the
+symbol. With a string, the symbol is #define'd to that value.
+After setting the configuration, the job runs the programs specified by
+commands. This is a list of lists of strings; each list of string is a
+command name and its arguments and is passed to subprocess.call with
+shell=False."""
+        self.name = name
+        self.config_settings = config_settings
+        self.commands = commands
+
+    def announce(self, what):
+        '''Announce the start or completion of a job.
+If what is None, announce the start of the job.
+If what is True, announce that the job has passed.
+If what is False, announce that the job has failed.'''
+        if what is True:
+            log_line(self.name + ' PASSED')
+        elif what is False:
+            log_line(self.name + ' FAILED')
+        else:
+            log_line('starting ' + self.name)
+
+    def trace_command(self, cmd):
+        '''Print a trace of the specified command.
+cmd is a list of strings: a command name and its arguments.'''
+        log_line(' '.join(cmd), prefix='+')
+
+    def configure(self, config_file_name):
+        '''Set library configuration options as required for the job.
+config_file_name indicates which file to modify.'''
+        for key, value in sorted(self.config_settings.items()):
+            if value is True:
+                args = ['set', key]
+            elif value is False:
+                args = ['unset', key]
+            else:
+                args = ['set', key, value]
+            cmd = ['scripts/config.pl']
+            if config_file_name != 'include/mbedtls/config.h':
+                cmd += ['--file', config_file_name]
+            cmd += args
+            self.trace_command(cmd)
+            subprocess.check_call(cmd)
+
+    def test(self, options):
+        '''Run the job's build and test commands.
+Return True if all the commands succeed and False otherwise.
+If options.keep_going is false, stop as soon as one command fails. Otherwise
+run all the commands, except that if the first command fails, none of the
+other commands are run (typically, the first command is a build command
+and subsequent commands are tests that cannot run if the build failed).'''
+        built = False
+        success = True
+        for command in self.commands:
+            self.trace_command(command)
+            ret = subprocess.call(command)
+            if ret != 0:
+                if command[0] not in ['make', options.make_command]:
+                    log_line('*** [{}] Error {}'.format(' '.join(command), ret))
+                if not options.keep_going or not built:
+                    return False
+                success = False
+            built = True
+        return success
+
+# SSL/TLS versions up to 1.1 and corresponding options. These require
+# both MD5 and SHA-1.
+ssl_pre_1_2_dependencies = ['MBEDTLS_SSL_CBC_RECORD_SPLITTING',
+                            'MBEDTLS_SSL_PROTO_SSL3',
+                            'MBEDTLS_SSL_PROTO_TLS1',
+                            'MBEDTLS_SSL_PROTO_TLS1_1']
+
+# If the configuration option A requires B, make sure that
+# B in reverse_dependencies[A].
+reverse_dependencies = {
+    'MBEDTLS_ECDSA_C': ['MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED'],
+    'MBEDTLS_ECP_C': ['MBEDTLS_ECDSA_C',
+                      'MBEDTLS_ECDH_C',
+                      'MBEDTLS_ECJPAKE_C',
+                      'MBEDTLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED',
+                      'MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED',
+                      'MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED',
+                      'MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED',
+                      'MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED'],
+    'MBEDTLS_MD5_C': ssl_pre_1_2_dependencies,
+    'MBEDTLS_PKCS1_V21': ['MBEDTLS_X509_RSASSA_PSS_SUPPORT'],
+    'MBEDTLS_PKCS1_V15': ['MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED',
+                          'MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED',
+                          'MBEDTLS_KEY_EXCHANGE_RSA_PSK_ENABLED',
+                          'MBEDTLS_KEY_EXCHANGE_RSA_ENABLED'],
+    'MBEDTLS_RSA_C': ['MBEDTLS_X509_RSASSA_PSS_SUPPORT',
+                      'MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED',
+                      'MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED',
+                      'MBEDTLS_KEY_EXCHANGE_RSA_PSK_ENABLED',
+                      'MBEDTLS_KEY_EXCHANGE_RSA_ENABLED'],
+    'MBEDTLS_SHA1_C': ssl_pre_1_2_dependencies,
+    'MBEDTLS_X509_RSASSA_PSS_SUPPORT': [],
+}
+
+def turn_off_dependencies(config_settings):
+    """For every option turned off config_settings, also turn off what depends on it.
+An option O is turned off if config_settings[O] is False."""
+    for key, value in sorted(config_settings.items()):
+        if value is not False:
+            continue
+        for dep in reverse_dependencies.get(key, []):
+            config_settings[dep] = False
+
+class Domain:
+    """A domain is a set of jobs that all relate to a particular configuration aspect."""
+    pass
+
+class ExclusiveDomain(Domain):
+    """A domain consisting of a set of conceptually-equivalent settings.
+Establish a list of configuration symbols. For each symbol, run a test job
+with this symbol set and the others unset, and a test job with this symbol
+unset and the others set."""
+    def __init__(self, symbols, commands):
+        self.jobs = []
+        for invert in [False, True]:
+            base_config_settings = {}
+            for symbol in symbols:
+                base_config_settings[symbol] = invert
+            for symbol in symbols:
+                description = '!' + symbol if invert else symbol
+                config_settings = base_config_settings.copy()
+                config_settings[symbol] = not invert
+                turn_off_dependencies(config_settings)
+                job = Job(description, config_settings, commands)
+                self.jobs.append(job)
+
+class ComplementaryDomain:
+    """A domain consisting of a set of loosely-related settings.
+Establish a list of configuration symbols. For each symbol, run a test job
+with this symbol unset."""
+    def __init__(self, symbols, commands):
+        self.jobs = []
+        for symbol in symbols:
+            description = '!' + symbol
+            config_settings = {symbol: False}
+            turn_off_dependencies(config_settings)
+            job = Job(description, config_settings, commands)
+            self.jobs.append(job)
+
+class DomainData:
+    """Collect data about the library."""
+    def collect_config_symbols(self, options):
+        """Read the list of settings from config.h.
+Return them in a generator."""
+        with open(options.config) as config_file:
+            rx = re.compile(r'\s*(?://\s*)?#define\s+(\w+)\s*(?:$|/[/*])')
+            for line in config_file:
+                m = re.match(rx, line)
+                if m:
+                    yield m.group(1)
+
+    def config_symbols_matching(self, regexp):
+        """List the config.h settings matching regexp."""
+        return [symbol for symbol in self.all_config_symbols
+                if re.match(regexp, symbol)]
+
+    def __init__(self, options):
+        """Gather data about the library and establish a list of domains to test."""
+        build_command = [options.make_command, 'CFLAGS=-Werror']
+        build_and_test = [build_command, [options.make_command, 'test']]
+        self.all_config_symbols = set(self.collect_config_symbols(options))
+        # Find hash modules by name.
+        hash_symbols = self.config_symbols_matching(r'MBEDTLS_(MD|RIPEMD|SHA)[0-9]+_C\Z')
+        # Find elliptic curve enabling macros by name.
+        curve_symbols = self.config_symbols_matching(r'MBEDTLS_ECP_DP_\w+_ENABLED\Z')
+        # Find key exchange enabling macros by name.
+        key_exchange_symbols = self.config_symbols_matching(r'MBEDTLS_KEY_EXCHANGE_\w+_ENABLED\Z')
+        self.domains = {
+            # Elliptic curves. Run the test suites.
+            'curves': ExclusiveDomain(curve_symbols, build_and_test),
+            # Hash algorithms. Exclude configurations with only one
+            # hash which is obsolete. Run the test suites.
+            'hashes': ExclusiveDomain(hash_symbols, build_and_test),
+            # Key exchange types. Just check the build.
+            'kex': ExclusiveDomain(key_exchange_symbols, [build_command]),
+            # Public-key algorithms. Run the test suites.
+            'pkalgs': ComplementaryDomain(['MBEDTLS_ECDSA_C',
+                                           'MBEDTLS_ECP_C',
+                                           'MBEDTLS_PKCS1_V21',
+                                           'MBEDTLS_PKCS1_V15',
+                                           'MBEDTLS_RSA_C',
+                                           'MBEDTLS_X509_RSASSA_PSS_SUPPORT'],
+                                          build_and_test),
+        }
+        self.jobs = {}
+        for domain in self.domains.values():
+            for job in domain.jobs:
+                self.jobs[job.name] = job
+
+    def get_jobs(self, name):
+        """Return the list of jobs identified by the given name.
+A name can either be the name of a domain or the name of one specific job."""
+        if name in self.domains:
+            return sorted(self.domains[name].jobs, key=lambda job: job.name)
+        else:
+            return [self.jobs[name]]
+
+def run(options, job):
+    """Run the specified job (a Job instance)."""
+    subprocess.check_call([options.make_command, 'clean'])
+    job.announce(None)
+    job.configure(options.config)
+    success = job.test(options)
+    job.announce(success)
+    return success
+
+def main(options, domain_data):
+    """Run the desired jobs.
+domain_data should be a DomainData instance that describes the available
+domains and jobs.
+Run the jobs listed in options.domains."""
+    if not hasattr(options, 'config_backup'):
+        options.config_backup = options.config + '.bak'
+    jobs = []
+    failures = []
+    successes = []
+    for name in options.domains:
+        jobs += domain_data.get_jobs(name)
+    backup_config(options)
+    try:
+        for job in jobs:
+            success = run(options, job)
+            if not success:
+                if options.keep_going:
+                    failures.append(job.name)
+                else:
+                    return False
+            else:
+                successes.append(job.name)
+            restore_config(options)
+    finally:
+        if options.keep_going:
+            restore_config(options, True)
+    if failures:
+        if successes:
+            log_line('{} passed; {} FAILED'.format(' '.join(successes),
+                                                   ' '.join(failures)))
+        else:
+            log_line('{} FAILED'.format(' '.join(failures)))
+        return False
+    else:
+        log_line('{} passed'.format(' '.join(successes)))
+        return True
+
+
+if __name__ == '__main__':
+    try:
+        parser = argparse.ArgumentParser(description=__doc__)
+        parser.add_argument('-c', '--config', metavar='FILE',
+                            help='Configuration file to modify',
+                            default='include/mbedtls/config.h')
+        parser.add_argument('-C', '--directory', metavar='DIR',
+                            help='Change to this directory before anything else',
+                            default='.')
+        parser.add_argument('-k', '--keep-going',
+                            help='Try all configurations even if some fail (default)',
+                            action='store_true', dest='keep_going', default=True)
+        parser.add_argument('-e', '--no-keep-going',
+                            help='Stop as soon as a configuration fails',
+                            action='store_false', dest='keep_going')
+        parser.add_argument('--list-jobs',
+                            help='List supported jobs and exit',
+                            action='append_const', dest='list', const='jobs')
+        parser.add_argument('--list-domains',
+                            help='List supported domains and exit',
+                            action='append_const', dest='list', const='domains')
+        parser.add_argument('--make-command', metavar='CMD',
+                            help='Command to run instead of make (e.g. gmake)',
+                            action='store', default='make')
+        parser.add_argument('domains', metavar='DOMAIN', nargs='*',
+                            help='The domain(s) to test (default: all)',
+                            default=True)
+        options = parser.parse_args()
+        os.chdir(options.directory)
+        domain_data = DomainData(options)
+        if options.domains == True:
+            options.domains = sorted(domain_data.domains.keys())
+        if options.list:
+            for what in options.list:
+                for key in sorted(getattr(domain_data, what).keys()):
+                    print(key)
+            exit(0)
+        else:
+            sys.exit(0 if main(options, domain_data) else 1)
+    except SystemExit:
+        raise
+    except:
+        traceback.print_exc()
+        exit(3)

--- a/tests/scripts/depends.py
+++ b/tests/scripts/depends.py
@@ -323,15 +323,12 @@ Run the jobs listed in options.domains."""
     finally:
         if options.keep_going:
             restore_config(options, True)
+    if successes:
+        log_line('{} passed'.format(' '.join(successes)), color=colors.bold_green)
     if failures:
-        if successes:
-            log_line('{} passed; {} FAILED'.format(' '.join(successes),
-                                                   ' '.join(failures)))
-        else:
-            log_line('{} FAILED'.format(' '.join(failures)))
+        log_line('{} FAILED'.format(' '.join(failures)), color=colors.bold_red)
         return False
     else:
-        log_line('{} passed'.format(' '.join(successes)))
         return True
 
 

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -564,7 +564,7 @@ static int exported_key_sanity_check( psa_key_type_t type, size_t bits,
     else
 #endif
 
-#if defined(MBEDTLS_RSA_C) && defined(MBEDTLS_PK_PARSE_C)
+#if defined(MBEDTLS_RSA_C)
     if( type == PSA_KEY_TYPE_RSA_KEYPAIR )
     {
         uint8_t *p = exported;
@@ -622,12 +622,12 @@ static int exported_key_sanity_check( psa_key_type_t type, size_t bits,
 
     if( PSA_KEY_TYPE_IS_PUBLIC_KEY( type ) )
     {
-        uint8_t *p = exported;
-        uint8_t *end = exported + exported_length;
-        size_t len;
 #if defined(MBEDTLS_RSA_C)
         if( type == PSA_KEY_TYPE_RSA_PUBLIC_KEY )
         {
+            uint8_t *end = exported + exported_length;
+            uint8_t *p = exported;
+            size_t len;
             /*   RSAPublicKey ::= SEQUENCE {
              *      modulus            INTEGER,    -- n
              *      publicExponent     INTEGER  }  -- e
@@ -654,8 +654,8 @@ static int exported_key_sanity_check( psa_key_type_t type, size_t bits,
              *      - `y_P` as a `ceiling(m/8)`-byte string, big-endian;
              *      - where m is the bit size associated with the curve.
              */
-            TEST_EQUAL( p + 1 + 2 * PSA_BITS_TO_BYTES( bits ), end );
-            TEST_EQUAL( p[0], 4 );
+            TEST_EQUAL( exported_length, 1 + 2 * PSA_BITS_TO_BYTES( bits ) );
+            TEST_EQUAL( exported[0], 4 );
         }
         else
 #endif /* MBEDTLS_ECP_C */

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -608,6 +608,26 @@ static int exported_key_sanity_check( psa_key_type_t type, size_t bits,
             goto exit;
         TEST_EQUAL( p, end );
     }
+    else if( type == PSA_KEY_TYPE_RSA_PUBLIC_KEY )
+    {
+        uint8_t *end = exported + exported_length;
+        uint8_t *p = exported;
+        size_t len;
+        /*   RSAPublicKey ::= SEQUENCE {
+         *      modulus            INTEGER,    -- n
+         *      publicExponent     INTEGER  }  -- e
+         */
+        TEST_EQUAL( mbedtls_asn1_get_tag( &p, end, &len,
+                                          MBEDTLS_ASN1_SEQUENCE |
+                                          MBEDTLS_ASN1_CONSTRUCTED ),
+                    0 );
+        TEST_EQUAL( p + len, end );
+        if( ! asn1_skip_integer( &p, end, bits, bits, 1 ) )
+            goto exit;
+        if( ! asn1_skip_integer( &p, end, 2, bits, 1 ) )
+            goto exit;
+        TEST_EQUAL( p, end );
+    }
     else
 #endif /* MBEDTLS_RSA_C */
 
@@ -617,61 +637,32 @@ static int exported_key_sanity_check( psa_key_type_t type, size_t bits,
         /* Just the secret value */
         TEST_EQUAL( exported_length, PSA_BITS_TO_BYTES( bits ) );
     }
-    else
-#endif /* MBEDTLS_ECP_C */
-
-    if( PSA_KEY_TYPE_IS_PUBLIC_KEY( type ) )
+    else if( PSA_KEY_TYPE_IS_ECC_PUBLIC_KEY( type ) )
     {
-#if defined(MBEDTLS_RSA_C)
-        if( type == PSA_KEY_TYPE_RSA_PUBLIC_KEY )
-        {
-            uint8_t *end = exported + exported_length;
-            uint8_t *p = exported;
-            size_t len;
-            /*   RSAPublicKey ::= SEQUENCE {
-             *      modulus            INTEGER,    -- n
-             *      publicExponent     INTEGER  }  -- e
-             */
-            TEST_EQUAL( mbedtls_asn1_get_tag( &p, end, &len,
-                                              MBEDTLS_ASN1_SEQUENCE |
-                                              MBEDTLS_ASN1_CONSTRUCTED ),
-                        0 );
-            TEST_EQUAL( p + len, end );
-            if( ! asn1_skip_integer( &p, end, bits, bits, 1 ) )
-                goto exit;
-            if( ! asn1_skip_integer( &p, end, 2, bits, 1 ) )
-                goto exit;
-            TEST_EQUAL( p, end );
-        }
-        else
-#endif /* MBEDTLS_RSA_C */
-#if defined(MBEDTLS_ECP_C)
-        if( PSA_KEY_TYPE_IS_ECC_PUBLIC_KEY( type ) )
-        {
-            /* The representation of an ECC public key is:
-             *      - The byte 0x04;
-             *      - `x_P` as a `ceiling(m/8)`-byte string, big-endian;
-             *      - `y_P` as a `ceiling(m/8)`-byte string, big-endian;
-             *      - where m is the bit size associated with the curve.
-             */
-            TEST_EQUAL( exported_length, 1 + 2 * PSA_BITS_TO_BYTES( bits ) );
-            TEST_EQUAL( exported[0], 4 );
-        }
-        else
-#endif /* MBEDTLS_ECP_C */
-        {
-            char message[47];
-            mbedtls_snprintf( message, sizeof( message ),
-                              "No sanity check for public key type=0x%08lx",
-                              (unsigned long) type );
-            test_fail( message, __LINE__, __FILE__ );
-            return( 0 );
-        }
+        /* The representation of an ECC public key is:
+         *      - The byte 0x04;
+         *      - `x_P` as a `ceiling(m/8)`-byte string, big-endian;
+         *      - `y_P` as a `ceiling(m/8)`-byte string, big-endian;
+         *      - where m is the bit size associated with the curve.
+         */
+        TEST_EQUAL( exported_length, 1 + 2 * PSA_BITS_TO_BYTES( bits ) );
+        TEST_EQUAL( exported[0], 4 );
     }
     else
+#endif /* MBEDTLS_ECP_C */
 
+    if( PSA_KEY_TYPE_IS_ASYMMETRIC( type ) )
     {
-        /* No sanity checks for other types */
+        char message[47];
+        mbedtls_snprintf( message, sizeof( message ),
+                          "No sanity check for asymmetric key type=0x%08lx",
+                          (unsigned long) type );
+        test_fail( message, __LINE__, __FILE__ );
+        return( 0 );
+    }
+    else
+    {
+        /* No sanity checks for other symmetric types */
     }
 
     return( 1 );

--- a/tests/suites/test_suite_x509parse.data
+++ b/tests/suites/test_suite_x509parse.data
@@ -131,7 +131,7 @@ depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_MD2_C:MBEDTLS_RSA_C
 mbedtls_x509_crl_info:"data_files/crl_md2.pem":"CRL version   \: 1\nissuer name   \: C=NL, O=PolarSSL, CN=PolarSSL Test CA\nthis update   \: 2009-07-19 19\:56\:37\nnext update   \: 2009-09-17 19\:56\:37\nRevoked certificates\:\nserial number\: 01 revocation date\: 2009-02-09 21\:12\:36\nserial number\: 03 revocation date\: 2009-02-09 21\:12\:36\nsigned using  \: RSA with MD2\n"
 
 X509 CRL Information MD4 Digest
-depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_MD4_C
+depends_on:MBEDTLS_PEM_PARSE_C:MBEDTLS_MD4_C:MBEDTLS_RSA_C
 mbedtls_x509_crl_info:"data_files/crl_md4.pem":"CRL version   \: 1\nissuer name   \: C=NL, O=PolarSSL, CN=PolarSSL Test CA\nthis update   \: 2011-02-12 14\:44\:07\nnext update   \: 2011-04-13 14\:44\:07\nRevoked certificates\:\nserial number\: 01 revocation date\: 2011-02-12 14\:44\:07\nserial number\: 03 revocation date\: 2011-02-12 14\:44\:07\nsigned using  \: RSA with MD4\n"
 
 X509 CRL Information MD5 Digest


### PR DESCRIPTION
Unify `curves.pl`, `key-exchanges.pl`, `depends-pkalgs.pl`, `depends-hashes.pl`, and [`depends-ciphers.pl`](https://github.com/ARMmbed/mbedtls/pull/1919) into a single, newly-written script. This isn't meant to be an identical replacement, but to provide at least the same amount of coverage.

For curves, key exchanges, ciphers and hashes, in addition to testing all-but-one settings in the group like the old scripts, also run the tests with a single option in the group.

The new script is unified (so less code to maintain), runs more tests (only-one in addition to all-but-one), and offers better tools to investigate failures.

The new script always starts from the `full` config (minus unimportant memory management options).

This is work in progress. Still to do:

* Fix all the builds.
    * Include patches from https://github.com/ARMmbed/mbedtls/pull/2019 for the only-one-curve jobs.
    * Include patches from https://github.com/ARMmbed/mbedtls/pull/1919 for the all-but-one-cipher-id jobs.
* Tutorial-type documentation to complement the reference documentation.

Fix https://github.com/ARMmbed/mbedtls/issues/1892

Obsoletes https://github.com/ARMmbed/mbedtls/pull/1919 and https://github.com/ARMmbed/mbedtls/pull/2019 (when fully done). Needs sideport/backport to mbedtls/development, 2.16 and 2.7.
