### PR TITLE
Prepare support for 64 bit key ids under SPM

### DIFF
--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -26,22 +26,8 @@
 #endif
 
 #if defined(MBEDTLS_PSA_CRYPTO_C)
-/*
- * When MBEDTLS_PSA_CRYPTO_SPM is defined, the code is being built for SPM
- * (Secure Partition Manager) integration which separates the code into two
- * parts: NSPE (Non-Secure Processing Environment) and SPE (Secure Processing
- * Environment). When building for the SPE, an additional header file should be
- * included.
- */
-#if defined(MBEDTLS_PSA_CRYPTO_SPM)
-/*
- * PSA_CRYPTO_SECURE means that this file is compiled for the SPE.
- * Some headers will be affected by this flag.
- */
-#define PSA_CRYPTO_SECURE 1
-#include "crypto_spe.h"
-#endif
 
+#include "psa_crypto_service_integration.h"
 #include "psa/crypto.h"
 
 #include "psa_crypto_core.h"

--- a/library/psa_crypto_service_integration.h
+++ b/library/psa_crypto_service_integration.h
@@ -1,0 +1,40 @@
+/*  Copyright (C) 2019, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+
+#ifndef PSA_CRYPTO_SERVICE_INTEGRATION_H
+#define PSA_CRYPTO_SERVICE_INTEGRATION_H
+
+/*
+ * When MBEDTLS_PSA_CRYPTO_SPM is defined, the code is being built for SPM
+ * (Secure Partition Manager) integration which separates the code into two
+ * parts: NSPE (Non-Secure Processing Environment) and SPE (Secure Processing
+ * Environment). When building for the SPE, an additional header file should be
+ * included.
+ */
+#if defined(MBEDTLS_PSA_CRYPTO_SPM)
+/*
+ * PSA_CRYPTO_SECURE means that the file which included this file is being
+ * compiled for SPE. The files crypto_structs.h and crypto_types.h have
+ * different implementations for NSPE and SPE and are compiled according to this
+ * flag.
+ */
+#define PSA_CRYPTO_SECURE 1
+#include "crypto_spe.h"
+#endif // MBEDTLS_PSA_CRYPTO_SPM
+
+#endif // PSA_CRYPTO_SERVICE_INTEGRATION_H

--- a/library/psa_crypto_slot_management.c
+++ b/library/psa_crypto_slot_management.c
@@ -26,22 +26,8 @@
 #endif
 
 #if defined(MBEDTLS_PSA_CRYPTO_C)
-/*
- * When MBEDTLS_PSA_CRYPTO_SPM is defined, the code is being built for SPM
- * (Secure Partition Manager) integration which separates the code into two
- * parts: NSPE (Non-Secure Processing Environment) and SPE (Secure Processing
- * Environment). When building for the SPE, an additional header file should be
- * included.
- */
-#if defined(MBEDTLS_PSA_CRYPTO_SPM)
-/*
- * PSA_CRYPTO_SECURE means that this file is compiled for the SPE.
- * Some headers will be affected by this flag.
- */
-#define PSA_CRYPTO_SECURE 1
-#include "crypto_spe.h"
-#endif
 
+#include "psa_crypto_service_integration.h"
 #include "psa/crypto.h"
 
 #include "psa_crypto_core.h"

--- a/library/psa_crypto_storage.c
+++ b/library/psa_crypto_storage.c
@@ -29,6 +29,20 @@
 
 #include <stdlib.h>
 #include <string.h>
+/*
+ * When MBEDTLS_PSA_CRYPTO_SPM is defined, the code is being built for SPM
+ * (Secure Partition Manager) integration which separates the code into two
+ * parts: NSPE (Non-Secure Processing Environment) and SPE (Secure Processing
+ * Environment). When building for the SPE, an additional header file should be
+ * included.
+ */
+#if defined(MBEDTLS_PSA_CRYPTO_SPM)
+/*
+ * PSA_CRYPTO_SECURE means that this file is compiled for the SPE.
+ * Some headers will be affected by this flag.
+ */
+#define PSA_CRYPTO_SECURE 1
+#endif
 
 #include "psa/crypto.h"
 #include "psa_crypto_storage.h"

--- a/library/psa_crypto_storage.c
+++ b/library/psa_crypto_storage.c
@@ -29,21 +29,8 @@
 
 #include <stdlib.h>
 #include <string.h>
-/*
- * When MBEDTLS_PSA_CRYPTO_SPM is defined, the code is being built for SPM
- * (Secure Partition Manager) integration which separates the code into two
- * parts: NSPE (Non-Secure Processing Environment) and SPE (Secure Processing
- * Environment). When building for the SPE, an additional header file should be
- * included.
- */
-#if defined(MBEDTLS_PSA_CRYPTO_SPM)
-/*
- * PSA_CRYPTO_SECURE means that this file is compiled for the SPE.
- * Some headers will be affected by this flag.
- */
-#define PSA_CRYPTO_SECURE 1
-#endif
 
+#include "psa_crypto_service_integration.h"
 #include "psa/crypto.h"
 #include "psa_crypto_storage.h"
 #include "psa_crypto_storage_backend.h"

--- a/library/psa_crypto_storage_its.c
+++ b/library/psa_crypto_storage_its.c
@@ -26,22 +26,9 @@
 #endif
 
 #if defined(MBEDTLS_PSA_CRYPTO_STORAGE_ITS_C)
-/*
- * When MBEDTLS_PSA_CRYPTO_SPM is defined, the code is being built for SPM
- * (Secure Partition Manager) integration which separates the code into two
- * parts: NSPE (Non-Secure Processing Environment) and SPE (Secure Processing
- * Environment). When building for the SPE, an additional header file should be
- * included.
- */
-#if defined(MBEDTLS_PSA_CRYPTO_SPM)
-/*
- * PSA_CRYPTO_SECURE means that this file is compiled for the SPE.
- * Some headers will be affected by this flag.
- */
-#define PSA_CRYPTO_SECURE 1
-#endif
 
 #include "psa/error.h"
+#include "psa_crypto_service_integration.h"
 #include "psa/crypto.h"
 #include "psa_crypto_storage_backend.h"
 #include "psa/internal_trusted_storage.h"

--- a/library/psa_crypto_storage_its.c
+++ b/library/psa_crypto_storage_its.c
@@ -26,6 +26,20 @@
 #endif
 
 #if defined(MBEDTLS_PSA_CRYPTO_STORAGE_ITS_C)
+/*
+ * When MBEDTLS_PSA_CRYPTO_SPM is defined, the code is being built for SPM
+ * (Secure Partition Manager) integration which separates the code into two
+ * parts: NSPE (Non-Secure Processing Environment) and SPE (Secure Processing
+ * Environment). When building for the SPE, an additional header file should be
+ * included.
+ */
+#if defined(MBEDTLS_PSA_CRYPTO_SPM)
+/*
+ * PSA_CRYPTO_SECURE means that this file is compiled for the SPE.
+ * Some headers will be affected by this flag.
+ */
+#define PSA_CRYPTO_SECURE 1
+#endif
 
 #include "psa/error.h"
 #include "psa/crypto.h"

--- a/visualc/VS2010/mbedTLS.vcxproj
+++ b/visualc/VS2010/mbedTLS.vcxproj
@@ -238,6 +238,7 @@
     <ClInclude Include="..\..\include\psa\crypto_values.h" />
     <ClInclude Include="..\..\library/psa_crypto_core.h" />
     <ClInclude Include="..\..\library/psa_crypto_invasive.h" />
+    <ClInclude Include="..\..\library/psa_crypto_service_integration.h" />
     <ClInclude Include="..\..\library/psa_crypto_slot_management.h" />
     <ClInclude Include="..\..\library/psa_crypto_storage.h" />
     <ClInclude Include="..\..\library/psa_crypto_storage_backend.h" />


### PR DESCRIPTION
Preparation for type separation between SPE and NSPE.

This PR is the setup required for moving from 32 bit key ids to 64 bit key ids in Mbed OS in a system where SPM is present. When compiling as a library (in a system where there's no SPM) the changes in this PR are irrelevant and should not affect anything.

The file `crypto_types.h` will be handled differently in Mbed OS when SPM is present. There will be 2 different implementation of the file, one for the client and one for the server. Much like `crypto_structs.h` is separated between client and server. Specifically, the type `psa_key_id_t` will be 32 bits on the client and 64 bits on the server. This work is being done as part of https://github.com/ARMmbed/mbed-os/pull/9575.