### PR TITLE
Fix double return statement in cipher.c

### DIFF
--- a/library/cipher.c
+++ b/library/cipher.c
@@ -1100,8 +1100,6 @@ int mbedtls_cipher_write_tag( mbedtls_cipher_context_t *ctx,
          * operations, we currently don't make it
          * accessible through the cipher layer. */
         return( MBEDTLS_ERR_CIPHER_FEATURE_UNAVAILABLE );
-
-        return( 0 );
     }
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 


### PR DESCRIPTION
This was introduced in ce1ddee13a171

It was caught by the IAR compiler in the Mbed TLS CI in one of our PRs. Not sure why it wasn't caught by other compilers earlier.