### PR TITLE
all.sh: Enable verbose failure messages for CMake

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -137,6 +137,9 @@ pre_initialize_variables () {
         export MAKEFLAGS="-j"
     fi
 
+    # Include more verbose output for failing tests run by CMake
+    export CTEST_OUTPUT_ON_FAILURE=1
+
     # Gather the list of available components. These are the functions
     # defined in this script whose name starts with "component_".
     # Parse the script with sed, because in sh there is no way to list


### PR DESCRIPTION
Set the CMake-observed variable `CTEST_OUTPUT_ON_FAILURE`, so that when
a "make test" run by CMake fails, verbose test output about the detail
of failure is available.