### PR TITLE
travis: Use seed 4 when running ssl-opt.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
 - make test
 - programs/test/selftest
 - OSSL_NO_DTLS=1 tests/compat.sh
-- tests/ssl-opt.sh -e '\(DTLS\|SCSV\).*openssl'
+- tests/ssl-opt.sh -e '\(DTLS\|SCSV\).*openssl' --seed 4
 - tests/scripts/test-ref-configs.pl
 - tests/scripts/curves.pl
 - tests/scripts/key-exchanges.pl


### PR DESCRIPTION
Seed 4 has been shown to result in a DTLS proxy that works more often
than not. This should help reduce the flakiness we observe from Travis
CI runs.