### PR TITLE
psa: Explicitly include platform_util.h

### DIFF
--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -30,6 +30,8 @@
 #ifndef PSA_CRYPTO_EXTRA_H
 #define PSA_CRYPTO_EXTRA_H
 
+#include "mbedtls/platform_util.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
crypto_extra.h has a dependency on platform_util.h for
MBEDTLS_DEPRECATED_NUMERIC_CONSTANT. Make the dependency explicit by
including platform_util.h. Although in most use cases the header should
already be included by something else, it doesn't hurt to include it
again and helps to clarify dependencies.