### PR TITLE
The specification document is now a single PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,7 @@ There are currently a few deviations where the library does not yet implement th
 
 ### PSA Cryptography API
 
-The PSA cryptography API specification consists of the following documents:
-
-* The [PSA Cryptography API overview](https://github.com/ARMmbed/mbed-crypto/blob/psa-crypto-api/docs/PSA_Cryptography_API_Specification.pdf).
-* The [PSA Cryptography API detailed function reference](https://github.com/ARMmbed/mbed-crypto/blob/psa-crypto-api/docs/PSA_Cryptography_API_Reference.pdf), which you can also browse in [HTML format](https://htmlpreview.github.io/?https://github.com/ARMmbed/mbed-crypto/blob/psa-crypto-api/docs/html/modules.html).
+You can read the [complete PSA cryptography API specification as a PDF document](https://github.com/ARMmbed/mbed-crypto/blob/psa-crypto-api/docs/PSA_Cryptography_API_Specification.pdf). The API reference is also available in [HTML format](https://htmlpreview.github.io/?https://github.com/ARMmbed/mbed-crypto/blob/psa-crypto-api/docs/html/modules.html).
 
 ### Browsable library documentation
 


### PR DESCRIPTION
Since version 1.0 beta2 of the PSA Crypto API specification, the PDF output consists of a single file. Update `README.md` accordingly.

Objective of the review: check that the links in `README.md` are properly updated for beta2. Since beta2 has been published, any content changes will need to go into beta3.

To be merged as close as possible to the merge of https://github.com/ARMmbed/mbed-crypto/pull/81 into the `psa-crypto-api` branch, since `README.md` points to that branch.
