### PR TITLE
tests: Add library to include path when used as submodule

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,7 +52,8 @@ function(add_test_suite suite_name)
     target_link_libraries(${exe_name} ${libs})
     target_include_directories(${exe_name}
         PUBLIC ${CMAKE_SOURCE_DIR}/include/
-        PUBLIC ${CMAKE_SOURCE_DIR}/crypto/include/)
+        PUBLIC ${CMAKE_SOURCE_DIR}/crypto/include/
+        PRIVATE ${CMAKE_SOURCE_DIR}/crypto/library/)
 
     if(${data_name} MATCHES ${SKIP_TEST_SUITES_REGEX})
         message(STATUS "The test suite ${data_name} will not be executed.")


### PR DESCRIPTION
Some tests use internal-only header files, which are stored in the
'library' folder, and therefore need the library folder passed in on the
include path. For non-submoudle builds, this is set globally in the
top-level CMakeLists.txt file. For submodule builds, this is set through
target includes to a path only meaningful when Mbed Crypto is built as a
submodule.