### PR TITLE
Use Windows-specific renaming function

### DIFF
--- a/library/psa_its_file.c
+++ b/library/psa_its_file.c
@@ -33,6 +33,10 @@
 #define mbedtls_snprintf   snprintf
 #endif
 
+#if defined(_WIN32)
+#include <windows.h>
+#endif
+
 #include "psa_crypto_its.h"
 
 #include <limits.h>
@@ -209,7 +213,12 @@ exit:
     }
     if( status == PSA_SUCCESS )
     {
+#if defined(_WIN32)
+        if( MoveFileExA( PSA_ITS_STORAGE_TEMP, filename,
+                         MOVEFILE_REPLACE_EXISTING ) == 0 )
+#else
         if( rename( PSA_ITS_STORAGE_TEMP, filename ) != 0 )
+#endif
             status = PSA_ERROR_STORAGE_FAILURE;
     }
     remove( PSA_ITS_STORAGE_TEMP );

--- a/library/psa_its_file.c
+++ b/library/psa_its_file.c
@@ -62,9 +62,12 @@
 #define PSA_ITS_MAGIC_STRING "PSA\0ITS\0"
 #define PSA_ITS_MAGIC_LENGTH 8
 
+/* As rename fails on Windows if the new filepath already exists,
+ * use MoveFileExA with the MOVEFILE_REPLACE_EXISTING flag instead.
+ * Returns 0 on success, nonzero on failure. */
 #if defined(_WIN32)
 #define rename_replace_existing( oldpath, newpath ) \
-    (!MoveFileExA( oldpath, newpath, MOVEFILE_REPLACE_EXISTING ))
+    ( ! MoveFileExA( oldpath, newpath, MOVEFILE_REPLACE_EXISTING ) )
 #else
 #define rename_replace_existing( oldpath, newpath ) rename( oldpath, newpath )
 #endif

--- a/library/psa_its_file.c
+++ b/library/psa_its_file.c
@@ -62,6 +62,13 @@
 #define PSA_ITS_MAGIC_STRING "PSA\0ITS\0"
 #define PSA_ITS_MAGIC_LENGTH 8
 
+#if defined(_WIN32)
+#define rename_replace_existing( oldpath, newpath ) \
+    (!MoveFileExA( oldpath, newpath, MOVEFILE_REPLACE_EXISTING ))
+#else
+#define rename_replace_existing( oldpath, newpath ) rename( oldpath, newpath )
+#endif
+
 typedef struct
 {
     uint8_t magic[PSA_ITS_MAGIC_LENGTH];
@@ -213,12 +220,7 @@ exit:
     }
     if( status == PSA_SUCCESS )
     {
-#if defined(_WIN32)
-        if( MoveFileExA( PSA_ITS_STORAGE_TEMP, filename,
-                         MOVEFILE_REPLACE_EXISTING ) == 0 )
-#else
-        if( rename( PSA_ITS_STORAGE_TEMP, filename ) != 0 )
-#endif
+        if( rename_replace_existing( PSA_ITS_STORAGE_TEMP, filename ) != 0 )
             status = PSA_ERROR_STORAGE_FAILURE;
     }
     remove( PSA_ITS_STORAGE_TEMP );


### PR DESCRIPTION
On Windows, rename() fails if the new filename already exists.
Use the Windows specific function MoveFileExA with the
MOVEFILE_REPLACE_EXISTING flag set instead to do renames.