### PR TITLE
Makefile: Remove extra debug print

### DIFF
--- a/library/Makefile
+++ b/library/Makefile
@@ -103,8 +103,6 @@ OBJS_CRYPTO += version.o
 OBJS_CRYPTO += version_features.o
 endif
 
-$(info $(OBJS_CRYPTO))
-
 OBJS_X509=	certs.o		pkcs11.o	x509.o		\
 		x509_create.o	x509_crl.o	x509_crt.o	\
 		x509_csr.o	x509write_crt.o	x509write_csr.o


### PR DESCRIPTION
Remove debug print added to print list of source files used in making
libmbedcrypto.

Fixes 92da0bd86237 ("Makefile: Use generated source files from parent").