### PR TITLE
Add a link to the seedfile for out-of-tree cmake builds

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -148,6 +148,9 @@ endif()
 # Make scripts and data files needed for testing available in an
 # out-of-source build.
 if (NOT ${CMAKE_CURRENT_BINARY_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/seedfile")
+        link_to_source(seedfile)
+    endif()
     link_to_source(data_files)
     link_to_source(scripts)
     link_to_source(suites)


### PR DESCRIPTION
This PR adds link creation for the crypto seedfile, in a case if one is present. This is needed for out-of-tree cmake builds (which are, for example, used in the CI).
This has been tested with https://github.com/ARMmbed/mbedtls/pull/2403.