### PR TITLE
Pass handle parameter last on key creation

### DIFF
--- a/include/psa/crypto.h
+++ b/include/psa/crypto.h
@@ -631,9 +631,9 @@ psa_status_t psa_close_key(psa_key_handle_t handle);
  *         results in this error code.
  */
 psa_status_t psa_import_key(const psa_key_attributes_t *attributes,
-                            psa_key_handle_t *handle,
                             const uint8_t *data,
-                            size_t data_length);
+                            size_t data_length,
+                            psa_key_handle_t *handle);
 
 /**
  * \brief Destroy a key.

--- a/include/psa/crypto.h
+++ b/include/psa/crypto.h
@@ -3068,9 +3068,9 @@ psa_status_t psa_generator_read(psa_crypto_generator_t *generator,
  * The generator's capacity is decreased by the number of bytes read.
  *
  * \param[in] attributes    The attributes for the new key.
+ * \param[in,out] generator The generator object to read from.
  * \param[out] handle       On success, a handle to the newly created key.
  *                          \c 0 on failure.
- * \param[in,out] generator The generator object to read from.
  *
  * \retval #PSA_SUCCESS
  *         Success.
@@ -3099,8 +3099,8 @@ psa_status_t psa_generator_read(psa_crypto_generator_t *generator,
  *         results in this error code.
  */
 psa_status_t psa_generate_derived_key(const psa_key_attributes_t *attributes,
-                                      psa_key_handle_t *handle,
-                                      psa_crypto_generator_t *generator);
+                                      psa_crypto_generator_t *generator,
+                                      psa_key_handle_t *handle);
 
 /** Abort a generator.
  *

--- a/include/psa/crypto.h
+++ b/include/psa/crypto.h
@@ -3294,10 +3294,10 @@ psa_status_t psa_key_derivation_input_key(psa_crypto_generator_t *generator,
  *                          public key type corresponding to the type of
  *                          private_key. That is, this function performs the
  *                          equivalent of
- *                          #psa_import_key(`internal_public_key_handle`,
- *                          #PSA_KEY_TYPE_PUBLIC_KEY_OF_KEYPAIR(`private_key_type`),
+ *                          #psa_import_key(...,
  *                          `peer_key`, `peer_key_length`) where
- *                          `private_key_type` is the type of `private_key`.
+ *                          with key attributes indicating the public key
+ *                          type corresponding to the type of `private_key`.
  *                          For example, for EC keys, this means that peer_key
  *                          is interpreted as a point on the curve that the
  *                          private key is on. The standard formats for public

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -1533,9 +1533,9 @@ static psa_status_t psa_check_key_slot_attributes(
 }
 
 psa_status_t psa_import_key( const psa_key_attributes_t *attributes,
-                             psa_key_handle_t *handle,
                              const uint8_t *data,
-                             size_t data_length )
+                             size_t data_length,
+                             psa_key_handle_t *handle )
 {
     psa_status_t status;
     psa_key_slot_t *slot = NULL;

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -4409,8 +4409,8 @@ exit:
 }
 
 psa_status_t psa_generate_derived_key( const psa_key_attributes_t *attributes,
-                                       psa_key_handle_t *handle,
-                                       psa_crypto_generator_t *generator )
+                                       psa_crypto_generator_t *generator,
+                                       psa_key_handle_t *handle )
 {
     psa_status_t status;
     psa_key_slot_t *slot = NULL;

--- a/programs/psa/key_ladder_demo.c
+++ b/programs/psa/key_ladder_demo.c
@@ -306,8 +306,8 @@ static psa_status_t derive_key_ladder( const char *ladder[],
         *key_handle = 0;
         /* Use the generator obtained from the parent key to create
          * the next intermediate key. */
-        PSA_CHECK( psa_generate_derived_key( &attributes, key_handle,
-                                             &generator ) );
+        PSA_CHECK( psa_generate_derived_key( &attributes, &generator,
+                                             key_handle ) );
         PSA_CHECK( psa_generator_abort( &generator ) );
     }
 
@@ -343,8 +343,8 @@ static psa_status_t derive_wrapping_key( psa_key_usage_t usage,
                    WRAPPING_KEY_SALT, WRAPPING_KEY_SALT_LENGTH,
                    NULL, 0,
                    PSA_BITS_TO_BYTES( WRAPPING_KEY_BITS ) ) );
-    PSA_CHECK( psa_generate_derived_key( &attributes, wrapping_key_handle,
-                                         &generator ) );
+    PSA_CHECK( psa_generate_derived_key( &attributes, &generator,
+                                         wrapping_key_handle ) );
 
 exit:
     psa_generator_abort( &generator );

--- a/programs/psa/key_ladder_demo.c
+++ b/programs/psa/key_ladder_demo.c
@@ -252,8 +252,8 @@ static psa_status_t import_key_from_file( psa_key_usage_t usage,
     psa_set_key_usage_flags( &attributes, usage );
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, PSA_KEY_TYPE_DERIVE );
-    PSA_CHECK( psa_import_key( &attributes, master_key_handle,
-                               key_data, key_size ) );
+    PSA_CHECK( psa_import_key( &attributes, key_data, key_size,
+                               master_key_handle ) );
 exit:
     if( key_file != NULL )
         fclose( key_file );

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -216,7 +216,7 @@ int exercise_mac_setup( psa_key_type_t key_type,
     psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_SIGN );
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
-    PSA_ASSERT( psa_import_key( &attributes, &handle, key_bytes, key_length ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_bytes, key_length, &handle ) );
 
     *status = psa_mac_sign_setup( operation, handle, alg );
     /* Whether setup succeeded or failed, abort must succeed. */
@@ -250,7 +250,7 @@ int exercise_cipher_setup( psa_key_type_t key_type,
     psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_ENCRYPT );
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
-    PSA_ASSERT( psa_import_key( &attributes, &handle, key_bytes, key_length ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_bytes, key_length, &handle ) );
 
     *status = psa_cipher_encrypt_setup( operation, handle, alg );
     /* Whether setup succeeded or failed, abort must succeed. */
@@ -1220,7 +1220,7 @@ void import( data_t *data, int type_arg,
 
     psa_set_key_type( &attributes, type );
     psa_set_key_bits( &attributes, attr_bits );
-    status = psa_import_key( &attributes, &handle, data->x, data->len );
+    status = psa_import_key( &attributes, data->x, data->len, &handle );
     TEST_EQUAL( status, expected_status );
     if( status != PSA_SUCCESS )
         goto exit;
@@ -1266,7 +1266,7 @@ void import_rsa_made_up( int bits_arg, int keypair, int expected_status_arg )
 
     /* Try importing the key */
     psa_set_key_type( &attributes, type );
-    status = psa_import_key( &attributes, &handle, p, length );
+    status = psa_import_key( &attributes, p, length, &handle );
     TEST_EQUAL( status, expected_status );
     if( status == PSA_SUCCESS )
         PSA_ASSERT( psa_destroy_key( handle ) );
@@ -1311,7 +1311,7 @@ void import_export( data_t *data,
     psa_set_key_type( &attributes, type );
 
     /* Import the key */
-    PSA_ASSERT( psa_import_key( &attributes, &handle, data->x, data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, data->x, data->len, &handle ) );
 
     /* Test the key information */
     PSA_ASSERT( psa_get_key_attributes( handle, &got_attributes ) );
@@ -1346,8 +1346,7 @@ void import_export( data_t *data,
     else
     {
         psa_key_handle_t handle2;
-        PSA_ASSERT( psa_import_key( &attributes, &handle2,
-                                    exported, exported_length ) );
+        PSA_ASSERT( psa_import_key( &attributes, exported, exported_length, &handle2 ) );
         PSA_ASSERT( psa_export_key( handle2,
                                     reexported,
                                     export_size,
@@ -1407,7 +1406,7 @@ void import_export_public_key( data_t *data,
     psa_set_key_type( &attributes, type );
 
     /* Import the key */
-    PSA_ASSERT( psa_import_key( &attributes, &handle, data->x, data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, data->x, data->len, &handle ) );
 
     /* Export the public key */
     ASSERT_ALLOC( exported, export_size );
@@ -1456,7 +1455,7 @@ void import_and_exercise_key( data_t *data,
     psa_set_key_type( &attributes, type );
 
     /* Import the key */
-    PSA_ASSERT( psa_import_key( &attributes, &handle, data->x, data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, data->x, data->len, &handle ) );
 
     /* Test the key information */
     PSA_ASSERT( psa_get_key_attributes( handle, &got_attributes ) );
@@ -1495,7 +1494,7 @@ void key_policy( int usage_arg, int alg_arg )
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, &handle, key, sizeof( key ) ) );
+    PSA_ASSERT( psa_import_key( &attributes, key, sizeof( key ), &handle ) );
 
     PSA_ASSERT( psa_get_key_attributes( handle, &attributes ) );
     TEST_EQUAL( psa_get_key_type( &attributes ), key_type );
@@ -1563,8 +1562,7 @@ void mac_key_policy( int policy_usage,
     psa_set_key_algorithm( &attributes, policy_alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key_data->x, key_data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
 
     status = psa_mac_sign_setup( &operation, handle, exercise_alg );
     if( policy_alg == exercise_alg &&
@@ -1607,8 +1605,7 @@ void cipher_key_policy( int policy_usage,
     psa_set_key_algorithm( &attributes, policy_alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key_data->x, key_data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
 
     status = psa_cipher_encrypt_setup( &operation, handle, exercise_alg );
     if( policy_alg == exercise_alg &&
@@ -1659,8 +1656,7 @@ void aead_key_policy( int policy_usage,
     psa_set_key_algorithm( &attributes, policy_alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key_data->x, key_data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
 
     status = psa_aead_encrypt( handle, exercise_alg,
                                nonce, nonce_length,
@@ -1714,8 +1710,7 @@ void asymmetric_encryption_key_policy( int policy_usage,
     psa_set_key_algorithm( &attributes, policy_alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key_data->x, key_data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
 
     PSA_ASSERT( psa_get_key_attributes( handle, &attributes ) );
     key_bits = psa_get_key_bits( &attributes );
@@ -1782,8 +1777,7 @@ void asymmetric_signature_key_policy( int policy_usage,
     psa_set_key_algorithm( &attributes, policy_alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key_data->x, key_data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
 
     status = psa_asymmetric_sign( handle, exercise_alg,
                                   payload, payload_length,
@@ -1827,8 +1821,7 @@ void derive_key_policy( int policy_usage,
     psa_set_key_algorithm( &attributes, policy_alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key_data->x, key_data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
 
     status = psa_key_derivation( &generator, handle,
                                  exercise_alg,
@@ -1867,8 +1860,7 @@ void agreement_key_policy( int policy_usage,
     psa_set_key_algorithm( &attributes, policy_alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key_data->x, key_data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
 
     PSA_ASSERT( psa_key_derivation_setup( &generator, exercise_alg ) );
     status = key_agreement_with_self( &generator, handle );
@@ -1905,8 +1897,7 @@ void raw_agreement_key_policy( int policy_usage,
     psa_set_key_algorithm( &attributes, policy_alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key_data->x, key_data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
 
     status = raw_key_agreement_with_self( exercise_alg, handle );
 
@@ -1944,8 +1935,7 @@ void copy_success( int source_usage_arg, int source_alg_arg,
     psa_set_key_usage_flags( &source_attributes, source_usage_arg );
     psa_set_key_algorithm( &source_attributes, source_alg_arg );
     psa_set_key_type( &source_attributes, type_arg );
-    PSA_ASSERT( psa_import_key( &source_attributes, &source_handle,
-                                material->x, material->len ) );
+    PSA_ASSERT( psa_import_key( &source_attributes, material->x, material->len, &source_handle ) );
     PSA_ASSERT( psa_get_key_attributes( source_handle, &source_attributes ) );
 
     /* Prepare the target attributes. */
@@ -2011,8 +2001,7 @@ void copy_fail( int source_usage_arg, int source_alg_arg,
     psa_set_key_usage_flags( &source_attributes, source_usage_arg );
     psa_set_key_algorithm( &source_attributes, source_alg_arg );
     psa_set_key_type( &source_attributes, type_arg );
-    PSA_ASSERT( psa_import_key( &source_attributes, &source_handle,
-                                material->x, material->len ) );
+    PSA_ASSERT( psa_import_key( &source_attributes, material->x, material->len, &source_handle ) );
 
     /* Prepare the target attributes. */
     psa_set_key_type( &target_attributes, target_type_arg );
@@ -2420,8 +2409,7 @@ void mac_bad_order( )
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key, sizeof(key) ) );
+    PSA_ASSERT( psa_import_key( &attributes, key, sizeof( key ), &handle ) );
 
     /* Call update without calling setup beforehand. */
     TEST_EQUAL( psa_mac_update( &operation, input, sizeof( input ) ),
@@ -2547,8 +2535,7 @@ void mac_sign( int key_type_arg,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key->x, key->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, key->x, key->len, &handle ) );
 
     /* Calculate the MAC. */
     PSA_ASSERT( psa_mac_sign_setup( &operation,
@@ -2594,8 +2581,7 @@ void mac_verify( int key_type_arg,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key->x, key->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, key->x, key->len, &handle ) );
 
     PSA_ASSERT( psa_mac_verify_setup( &operation,
                                       handle, alg ) );
@@ -2712,8 +2698,7 @@ void cipher_bad_order( )
     psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_ENCRYPT | PSA_KEY_USAGE_DECRYPT );
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key, sizeof(key) ) );
+    PSA_ASSERT( psa_import_key( &attributes, key, sizeof( key ), &handle ) );
 
 
     /* Call encrypt setup twice in a row. */
@@ -2870,8 +2855,7 @@ void cipher_encrypt( int alg_arg, int key_type_arg,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key->x, key->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, key->x, key->len, &handle ) );
 
     PSA_ASSERT( psa_cipher_encrypt_setup( &operation,
                                           handle, alg ) );
@@ -2940,8 +2924,7 @@ void cipher_encrypt_multipart( int alg_arg, int key_type_arg,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key->x, key->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, key->x, key->len, &handle ) );
 
     PSA_ASSERT( psa_cipher_encrypt_setup( &operation,
                                           handle, alg ) );
@@ -3016,8 +2999,7 @@ void cipher_decrypt_multipart( int alg_arg, int key_type_arg,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key->x, key->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, key->x, key->len, &handle ) );
 
     PSA_ASSERT( psa_cipher_decrypt_setup( &operation,
                                           handle, alg ) );
@@ -3090,8 +3072,7 @@ void cipher_decrypt( int alg_arg, int key_type_arg,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key->x, key->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, key->x, key->len, &handle ) );
 
     PSA_ASSERT( psa_cipher_decrypt_setup( &operation,
                                           handle, alg ) );
@@ -3157,8 +3138,7 @@ void cipher_verify_output( int alg_arg, int key_type_arg,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key->x, key->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, key->x, key->len, &handle ) );
 
     PSA_ASSERT( psa_cipher_encrypt_setup( &operation1,
                                           handle, alg ) );
@@ -3243,8 +3223,7 @@ void cipher_verify_output_multipart( int alg_arg,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key->x, key->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, key->x, key->len, &handle ) );
 
     PSA_ASSERT( psa_cipher_encrypt_setup( &operation1,
                                           handle, alg ) );
@@ -3345,8 +3324,7 @@ void aead_encrypt_decrypt( int key_type_arg, data_t *key_data,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key_data->x, key_data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
 
     TEST_EQUAL( psa_aead_encrypt( handle, alg,
                                   nonce->x, nonce->len,
@@ -3408,8 +3386,7 @@ void aead_encrypt( int key_type_arg, data_t *key_data,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key_data->x, key_data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
 
     PSA_ASSERT( psa_aead_encrypt( handle, alg,
                                   nonce->x, nonce->len,
@@ -3456,8 +3433,7 @@ void aead_decrypt( int key_type_arg, data_t *key_data,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key_data->x, key_data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
 
     TEST_EQUAL( psa_aead_decrypt( handle, alg,
                                   nonce->x, nonce->len,
@@ -3514,8 +3490,7 @@ void sign_deterministic( int key_type_arg, data_t *key_data,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key_data->x, key_data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
     PSA_ASSERT( psa_get_key_attributes( handle, &attributes ) );
     key_bits = psa_get_key_bits( &attributes );
 
@@ -3567,8 +3542,7 @@ void sign_fail( int key_type_arg, data_t *key_data,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key_data->x, key_data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
 
     actual_status = psa_asymmetric_sign( handle, alg,
                                          input_data->x, input_data->len,
@@ -3608,8 +3582,7 @@ void sign_verify( int key_type_arg, data_t *key_data,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key_data->x, key_data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
     PSA_ASSERT( psa_get_key_attributes( handle, &attributes ) );
     key_bits = psa_get_key_bits( &attributes );
 
@@ -3674,8 +3647,7 @@ void asymmetric_verify( int key_type_arg, data_t *key_data,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key_data->x, key_data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
 
     PSA_ASSERT( psa_asymmetric_verify( handle, alg,
                                        hash_data->x, hash_data->len,
@@ -3707,8 +3679,7 @@ void asymmetric_verify_fail( int key_type_arg, data_t *key_data,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key_data->x, key_data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
 
     actual_status = psa_asymmetric_verify( handle, alg,
                                            hash_data->x, hash_data->len,
@@ -3751,8 +3722,7 @@ void asymmetric_encrypt( int key_type_arg,
     psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_ENCRYPT );
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key_data->x, key_data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
 
     /* Determine the maximum output length */
     PSA_ASSERT( psa_get_key_attributes( handle, &attributes ) );
@@ -3818,8 +3788,7 @@ void asymmetric_encrypt_decrypt( int key_type_arg,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key_data->x, key_data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
 
     /* Determine the maximum ciphertext length */
     PSA_ASSERT( psa_get_key_attributes( handle, &attributes ) );
@@ -3883,8 +3852,7 @@ void asymmetric_decrypt( int key_type_arg,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key_data->x, key_data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
 
     PSA_ASSERT( psa_asymmetric_decrypt( handle, alg,
                                         input_data->x, input_data->len,
@@ -3947,8 +3915,7 @@ void asymmetric_decrypt_fail( int key_type_arg,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key_data->x, key_data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
 
     actual_status = psa_asymmetric_decrypt( handle, alg,
                                             input_data->x, input_data->len,
@@ -4034,8 +4001,7 @@ void derive_setup( int key_type_arg,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key_data->x, key_data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
 
     TEST_EQUAL( psa_key_derivation( &generator, handle, alg,
                                     salt->x, salt->len,
@@ -4070,8 +4036,9 @@ void test_derive_invalid_generator_state( )
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key_data, sizeof( key_data ) ) );
+    PSA_ASSERT( psa_import_key( &attributes,
+                                key_data, sizeof( key_data ),
+                                &handle ) );
 
     /* valid key derivation */
     PSA_ASSERT(  psa_key_derivation( &generator, handle, alg,
@@ -4164,8 +4131,7 @@ void derive_output( int alg_arg,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, PSA_KEY_TYPE_DERIVE );
 
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key_data->x, key_data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
 
     /* Extraction phase. */
     if( PSA_ALG_IS_HKDF( alg ) )
@@ -4260,8 +4226,7 @@ void derive_full( int alg_arg,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, PSA_KEY_TYPE_DERIVE );
 
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key_data->x, key_data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
 
     /* Extraction phase. */
     if( PSA_ALG_IS_HKDF( alg ) )
@@ -4346,8 +4311,7 @@ void derive_key_exercise( int alg_arg,
     psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_DERIVE );
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, PSA_KEY_TYPE_DERIVE );
-    PSA_ASSERT( psa_import_key( &attributes, &base_handle,
-                                key_data->x, key_data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &base_handle ) );
 
     /* Derive a key. */
     PSA_ASSERT( psa_key_derivation( &generator, base_handle, alg,
@@ -4407,8 +4371,7 @@ void derive_key_export( int alg_arg,
     psa_set_key_usage_flags( &base_attributes, PSA_KEY_USAGE_DERIVE );
     psa_set_key_algorithm( &base_attributes, alg );
     psa_set_key_type( &base_attributes, PSA_KEY_TYPE_DERIVE );
-    PSA_ASSERT( psa_import_key( &base_attributes, &base_handle,
-                                key_data->x, key_data->len ) );
+    PSA_ASSERT( psa_import_key( &base_attributes, key_data->x, key_data->len, &base_handle ) );
 
     /* Derive some material and output it. */
     PSA_ASSERT( psa_key_derivation( &generator, base_handle, alg,
@@ -4477,8 +4440,7 @@ void key_agreement_setup( int alg_arg,
     psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_DERIVE );
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, our_key_type );
-    PSA_ASSERT( psa_import_key( &attributes, &our_key,
-                                our_key_data->x, our_key_data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, our_key_data->x, our_key_data->len, &our_key ) );
 
     /* The tests currently include inputs that should fail at either step.
      * Test cases that fail at the setup step should be changed to call
@@ -4523,8 +4485,7 @@ void raw_key_agreement( int alg_arg,
     psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_DERIVE );
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, our_key_type );
-    PSA_ASSERT( psa_import_key( &attributes, &our_key,
-                                our_key_data->x, our_key_data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, our_key_data->x, our_key_data->len, &our_key ) );
 
     PSA_ASSERT( psa_key_agreement_raw_shared_secret(
                     alg, our_key,
@@ -4559,8 +4520,7 @@ void key_agreement_capacity( int alg_arg,
     psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_DERIVE );
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, our_key_type );
-    PSA_ASSERT( psa_import_key( &attributes, &our_key,
-                                our_key_data->x, our_key_data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, our_key_data->x, our_key_data->len, &our_key ) );
 
     PSA_ASSERT( psa_key_derivation_setup( &generator, alg ) );
     PSA_ASSERT( psa_key_agreement( &generator, PSA_KDF_STEP_SECRET,
@@ -4619,8 +4579,7 @@ void key_agreement_output( int alg_arg,
     psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_DERIVE );
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, our_key_type );
-    PSA_ASSERT( psa_import_key( &attributes, &our_key,
-                                our_key_data->x, our_key_data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, our_key_data->x, our_key_data->len, &our_key ) );
 
     PSA_ASSERT( psa_key_derivation_setup( &generator, alg ) );
     PSA_ASSERT( psa_key_agreement( &generator, PSA_KDF_STEP_SECRET,
@@ -4893,8 +4852,7 @@ void persistent_key_load_key_from_storage( data_t *data,
     {
         case IMPORT_KEY:
             /* Import the key */
-            PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                        data->x, data->len ) );
+            PSA_ASSERT( psa_import_key( &attributes, data->x, data->len, &handle ) );
             break;
 
         case GENERATE_KEY:
@@ -4911,8 +4869,7 @@ void persistent_key_load_key_from_storage( data_t *data,
                                          PSA_KEY_USAGE_DERIVE );
                 psa_set_key_algorithm( &base_attributes, derive_alg );
                 psa_set_key_type( &base_attributes, PSA_KEY_TYPE_DERIVE );
-                PSA_ASSERT( psa_import_key( &base_attributes, &base_key,
-                                            data->x, data->len ) );
+                PSA_ASSERT( psa_import_key( &base_attributes, data->x, data->len, &base_key ) );
                 /* Derive a key. */
                 PSA_ASSERT( psa_key_derivation_setup( &generator, derive_alg ) );
                 PSA_ASSERT( psa_key_derivation_input_key( &generator,

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -4358,8 +4358,8 @@ void derive_key_exercise( int alg_arg,
     psa_set_key_algorithm( &attributes, derived_alg );
     psa_set_key_type( &attributes, derived_type );
     psa_set_key_bits( &attributes, derived_bits );
-    PSA_ASSERT( psa_generate_derived_key( &attributes, &derived_handle,
-                                          &generator ) );
+    PSA_ASSERT( psa_generate_derived_key( &attributes, &generator,
+                                          &derived_handle ) );
 
     /* Test the key information */
     PSA_ASSERT( psa_get_key_attributes( derived_handle, &got_attributes ) );
@@ -4429,16 +4429,16 @@ void derive_key_export( int alg_arg,
     psa_set_key_algorithm( &derived_attributes, 0 );
     psa_set_key_type( &derived_attributes, PSA_KEY_TYPE_RAW_DATA );
     psa_set_key_bits( &derived_attributes, PSA_BYTES_TO_BITS( bytes1 ) );
-    PSA_ASSERT( psa_generate_derived_key( &derived_attributes, &derived_handle,
-                                          &generator ) );
+    PSA_ASSERT( psa_generate_derived_key( &derived_attributes, &generator,
+                                          &derived_handle ) );
     PSA_ASSERT( psa_export_key( derived_handle,
                                 export_buffer, bytes1,
                                 &length ) );
     TEST_EQUAL( length, bytes1 );
     PSA_ASSERT( psa_destroy_key( derived_handle ) );
     psa_set_key_bits( &derived_attributes, PSA_BYTES_TO_BITS( bytes2 ) );
-    PSA_ASSERT( psa_generate_derived_key( &derived_attributes, &derived_handle,
-                                          &generator ) );
+    PSA_ASSERT( psa_generate_derived_key( &derived_attributes, &generator,
+                                          &derived_handle ) );
     PSA_ASSERT( psa_export_key( derived_handle,
                                 export_buffer + bytes1, bytes2,
                                 &length ) );
@@ -4921,8 +4921,8 @@ void persistent_key_load_key_from_storage( data_t *data,
                 PSA_ASSERT( psa_key_derivation_input_bytes(
                                 &generator, PSA_KDF_STEP_INFO,
                                 NULL, 0 ) );
-                PSA_ASSERT( psa_generate_derived_key( &attributes, &handle,
-                                                      &generator ) );
+                PSA_ASSERT( psa_generate_derived_key( &attributes, &generator,
+                                                      &handle ) );
                 PSA_ASSERT( psa_generator_abort( &generator ) );
                 PSA_ASSERT( psa_destroy_key( base_key ) );
                 base_key = 0;

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -216,7 +216,8 @@ int exercise_mac_setup( psa_key_type_t key_type,
     psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_SIGN );
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
-    PSA_ASSERT( psa_import_key( &attributes, key_bytes, key_length, &handle ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_bytes, key_length,
+                                &handle ) );
 
     *status = psa_mac_sign_setup( operation, handle, alg );
     /* Whether setup succeeded or failed, abort must succeed. */
@@ -250,7 +251,8 @@ int exercise_cipher_setup( psa_key_type_t key_type,
     psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_ENCRYPT );
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
-    PSA_ASSERT( psa_import_key( &attributes, key_bytes, key_length, &handle ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_bytes, key_length,
+                                &handle ) );
 
     *status = psa_cipher_encrypt_setup( operation, handle, alg );
     /* Whether setup succeeded or failed, abort must succeed. */
@@ -1346,7 +1348,8 @@ void import_export( data_t *data,
     else
     {
         psa_key_handle_t handle2;
-        PSA_ASSERT( psa_import_key( &attributes, exported, exported_length, &handle2 ) );
+        PSA_ASSERT( psa_import_key( &attributes, exported, exported_length,
+                                    &handle2 ) );
         PSA_ASSERT( psa_export_key( handle2,
                                     reexported,
                                     export_size,
@@ -1562,7 +1565,8 @@ void mac_key_policy( int policy_usage,
     psa_set_key_algorithm( &attributes, policy_alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len,
+                                &handle ) );
 
     status = psa_mac_sign_setup( &operation, handle, exercise_alg );
     if( policy_alg == exercise_alg &&
@@ -1605,7 +1609,8 @@ void cipher_key_policy( int policy_usage,
     psa_set_key_algorithm( &attributes, policy_alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len,
+                                &handle ) );
 
     status = psa_cipher_encrypt_setup( &operation, handle, exercise_alg );
     if( policy_alg == exercise_alg &&
@@ -1656,7 +1661,8 @@ void aead_key_policy( int policy_usage,
     psa_set_key_algorithm( &attributes, policy_alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len,
+                                &handle ) );
 
     status = psa_aead_encrypt( handle, exercise_alg,
                                nonce, nonce_length,
@@ -1710,7 +1716,8 @@ void asymmetric_encryption_key_policy( int policy_usage,
     psa_set_key_algorithm( &attributes, policy_alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len,
+                                &handle ) );
 
     PSA_ASSERT( psa_get_key_attributes( handle, &attributes ) );
     key_bits = psa_get_key_bits( &attributes );
@@ -1777,7 +1784,8 @@ void asymmetric_signature_key_policy( int policy_usage,
     psa_set_key_algorithm( &attributes, policy_alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len,
+                                &handle ) );
 
     status = psa_asymmetric_sign( handle, exercise_alg,
                                   payload, payload_length,
@@ -1821,7 +1829,8 @@ void derive_key_policy( int policy_usage,
     psa_set_key_algorithm( &attributes, policy_alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len,
+                                &handle ) );
 
     status = psa_key_derivation( &generator, handle,
                                  exercise_alg,
@@ -1860,7 +1869,8 @@ void agreement_key_policy( int policy_usage,
     psa_set_key_algorithm( &attributes, policy_alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len,
+                                &handle ) );
 
     PSA_ASSERT( psa_key_derivation_setup( &generator, exercise_alg ) );
     status = key_agreement_with_self( &generator, handle );
@@ -1897,7 +1907,8 @@ void raw_agreement_key_policy( int policy_usage,
     psa_set_key_algorithm( &attributes, policy_alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len,
+                                &handle ) );
 
     status = raw_key_agreement_with_self( exercise_alg, handle );
 
@@ -1935,7 +1946,9 @@ void copy_success( int source_usage_arg, int source_alg_arg,
     psa_set_key_usage_flags( &source_attributes, source_usage_arg );
     psa_set_key_algorithm( &source_attributes, source_alg_arg );
     psa_set_key_type( &source_attributes, type_arg );
-    PSA_ASSERT( psa_import_key( &source_attributes, material->x, material->len, &source_handle ) );
+    PSA_ASSERT( psa_import_key( &source_attributes,
+                                material->x, material->len,
+                                &source_handle ) );
     PSA_ASSERT( psa_get_key_attributes( source_handle, &source_attributes ) );
 
     /* Prepare the target attributes. */
@@ -2001,7 +2014,9 @@ void copy_fail( int source_usage_arg, int source_alg_arg,
     psa_set_key_usage_flags( &source_attributes, source_usage_arg );
     psa_set_key_algorithm( &source_attributes, source_alg_arg );
     psa_set_key_type( &source_attributes, type_arg );
-    PSA_ASSERT( psa_import_key( &source_attributes, material->x, material->len, &source_handle ) );
+    PSA_ASSERT( psa_import_key( &source_attributes,
+                                material->x, material->len,
+                                &source_handle ) );
 
     /* Prepare the target attributes. */
     psa_set_key_type( &target_attributes, target_type_arg );
@@ -3324,7 +3339,8 @@ void aead_encrypt_decrypt( int key_type_arg, data_t *key_data,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len,
+                                &handle ) );
 
     TEST_EQUAL( psa_aead_encrypt( handle, alg,
                                   nonce->x, nonce->len,
@@ -3386,7 +3402,8 @@ void aead_encrypt( int key_type_arg, data_t *key_data,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len,
+                                &handle ) );
 
     PSA_ASSERT( psa_aead_encrypt( handle, alg,
                                   nonce->x, nonce->len,
@@ -3433,7 +3450,8 @@ void aead_decrypt( int key_type_arg, data_t *key_data,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len,
+                                &handle ) );
 
     TEST_EQUAL( psa_aead_decrypt( handle, alg,
                                   nonce->x, nonce->len,
@@ -3490,7 +3508,8 @@ void sign_deterministic( int key_type_arg, data_t *key_data,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len,
+                                &handle ) );
     PSA_ASSERT( psa_get_key_attributes( handle, &attributes ) );
     key_bits = psa_get_key_bits( &attributes );
 
@@ -3542,7 +3561,8 @@ void sign_fail( int key_type_arg, data_t *key_data,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len,
+                                &handle ) );
 
     actual_status = psa_asymmetric_sign( handle, alg,
                                          input_data->x, input_data->len,
@@ -3582,7 +3602,8 @@ void sign_verify( int key_type_arg, data_t *key_data,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len,
+                                &handle ) );
     PSA_ASSERT( psa_get_key_attributes( handle, &attributes ) );
     key_bits = psa_get_key_bits( &attributes );
 
@@ -3647,7 +3668,8 @@ void asymmetric_verify( int key_type_arg, data_t *key_data,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len,
+                                &handle ) );
 
     PSA_ASSERT( psa_asymmetric_verify( handle, alg,
                                        hash_data->x, hash_data->len,
@@ -3679,7 +3701,8 @@ void asymmetric_verify_fail( int key_type_arg, data_t *key_data,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len,
+                                &handle ) );
 
     actual_status = psa_asymmetric_verify( handle, alg,
                                            hash_data->x, hash_data->len,
@@ -3722,7 +3745,8 @@ void asymmetric_encrypt( int key_type_arg,
     psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_ENCRYPT );
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
-    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len,
+                                &handle ) );
 
     /* Determine the maximum output length */
     PSA_ASSERT( psa_get_key_attributes( handle, &attributes ) );
@@ -3788,7 +3812,8 @@ void asymmetric_encrypt_decrypt( int key_type_arg,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len,
+                                &handle ) );
 
     /* Determine the maximum ciphertext length */
     PSA_ASSERT( psa_get_key_attributes( handle, &attributes ) );
@@ -3852,7 +3877,8 @@ void asymmetric_decrypt( int key_type_arg,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len,
+                                &handle ) );
 
     PSA_ASSERT( psa_asymmetric_decrypt( handle, alg,
                                         input_data->x, input_data->len,
@@ -3915,7 +3941,8 @@ void asymmetric_decrypt_fail( int key_type_arg,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len,
+                                &handle ) );
 
     actual_status = psa_asymmetric_decrypt( handle, alg,
                                             input_data->x, input_data->len,
@@ -4001,7 +4028,8 @@ void derive_setup( int key_type_arg,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, key_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len,
+                                &handle ) );
 
     TEST_EQUAL( psa_key_derivation( &generator, handle, alg,
                                     salt->x, salt->len,
@@ -4131,7 +4159,8 @@ void derive_output( int alg_arg,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, PSA_KEY_TYPE_DERIVE );
 
-    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len,
+                                &handle ) );
 
     /* Extraction phase. */
     if( PSA_ALG_IS_HKDF( alg ) )
@@ -4226,7 +4255,8 @@ void derive_full( int alg_arg,
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, PSA_KEY_TYPE_DERIVE );
 
-    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len,
+                                &handle ) );
 
     /* Extraction phase. */
     if( PSA_ALG_IS_HKDF( alg ) )
@@ -4311,7 +4341,8 @@ void derive_key_exercise( int alg_arg,
     psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_DERIVE );
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, PSA_KEY_TYPE_DERIVE );
-    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &base_handle ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len,
+                                &base_handle ) );
 
     /* Derive a key. */
     PSA_ASSERT( psa_key_derivation( &generator, base_handle, alg,
@@ -4371,7 +4402,8 @@ void derive_key_export( int alg_arg,
     psa_set_key_usage_flags( &base_attributes, PSA_KEY_USAGE_DERIVE );
     psa_set_key_algorithm( &base_attributes, alg );
     psa_set_key_type( &base_attributes, PSA_KEY_TYPE_DERIVE );
-    PSA_ASSERT( psa_import_key( &base_attributes, key_data->x, key_data->len, &base_handle ) );
+    PSA_ASSERT( psa_import_key( &base_attributes, key_data->x, key_data->len,
+                                &base_handle ) );
 
     /* Derive some material and output it. */
     PSA_ASSERT( psa_key_derivation( &generator, base_handle, alg,
@@ -4440,7 +4472,9 @@ void key_agreement_setup( int alg_arg,
     psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_DERIVE );
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, our_key_type );
-    PSA_ASSERT( psa_import_key( &attributes, our_key_data->x, our_key_data->len, &our_key ) );
+    PSA_ASSERT( psa_import_key( &attributes,
+                                our_key_data->x, our_key_data->len,
+                                &our_key ) );
 
     /* The tests currently include inputs that should fail at either step.
      * Test cases that fail at the setup step should be changed to call
@@ -4485,7 +4519,9 @@ void raw_key_agreement( int alg_arg,
     psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_DERIVE );
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, our_key_type );
-    PSA_ASSERT( psa_import_key( &attributes, our_key_data->x, our_key_data->len, &our_key ) );
+    PSA_ASSERT( psa_import_key( &attributes,
+                                our_key_data->x, our_key_data->len,
+                                &our_key ) );
 
     PSA_ASSERT( psa_key_agreement_raw_shared_secret(
                     alg, our_key,
@@ -4520,7 +4556,9 @@ void key_agreement_capacity( int alg_arg,
     psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_DERIVE );
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, our_key_type );
-    PSA_ASSERT( psa_import_key( &attributes, our_key_data->x, our_key_data->len, &our_key ) );
+    PSA_ASSERT( psa_import_key( &attributes,
+                                our_key_data->x, our_key_data->len,
+                                &our_key ) );
 
     PSA_ASSERT( psa_key_derivation_setup( &generator, alg ) );
     PSA_ASSERT( psa_key_agreement( &generator, PSA_KDF_STEP_SECRET,
@@ -4579,7 +4617,9 @@ void key_agreement_output( int alg_arg,
     psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_DERIVE );
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, our_key_type );
-    PSA_ASSERT( psa_import_key( &attributes, our_key_data->x, our_key_data->len, &our_key ) );
+    PSA_ASSERT( psa_import_key( &attributes,
+                                our_key_data->x, our_key_data->len,
+                                &our_key ) );
 
     PSA_ASSERT( psa_key_derivation_setup( &generator, alg ) );
     PSA_ASSERT( psa_key_agreement( &generator, PSA_KDF_STEP_SECRET,
@@ -4852,7 +4892,8 @@ void persistent_key_load_key_from_storage( data_t *data,
     {
         case IMPORT_KEY:
             /* Import the key */
-            PSA_ASSERT( psa_import_key( &attributes, data->x, data->len, &handle ) );
+            PSA_ASSERT( psa_import_key( &attributes, data->x, data->len,
+                                        &handle ) );
             break;
 
         case GENERATE_KEY:
@@ -4869,7 +4910,9 @@ void persistent_key_load_key_from_storage( data_t *data,
                                          PSA_KEY_USAGE_DERIVE );
                 psa_set_key_algorithm( &base_attributes, derive_alg );
                 psa_set_key_type( &base_attributes, PSA_KEY_TYPE_DERIVE );
-                PSA_ASSERT( psa_import_key( &base_attributes, data->x, data->len, &base_key ) );
+                PSA_ASSERT( psa_import_key( &base_attributes,
+                                            data->x, data->len,
+                                            &base_key ) );
                 /* Derive a key. */
                 PSA_ASSERT( psa_key_derivation_setup( &generator, derive_alg ) );
                 PSA_ASSERT( psa_key_derivation_input_key( &generator,

--- a/tests/suites/test_suite_psa_crypto_init.function
+++ b/tests/suites/test_suite_psa_crypto_init.function
@@ -193,7 +193,7 @@ void validate_module_init_key_based( int count )
         mbedtls_psa_crypto_free( );
     }
     psa_set_key_type( &attributes, PSA_KEY_TYPE_RAW_DATA );
-    status = psa_import_key( &attributes, &handle, data, sizeof( data ) );
+    status = psa_import_key( &attributes, data, sizeof( data ), &handle );
     TEST_EQUAL( status, PSA_ERROR_BAD_STATE );
     TEST_EQUAL( handle, 0 );
 }

--- a/tests/suites/test_suite_psa_crypto_persistent_key.function
+++ b/tests/suites/test_suite_psa_crypto_persistent_key.function
@@ -125,7 +125,8 @@ void persistent_key_destroy( int key_id_arg, int restart,
     psa_make_key_persistent( &attributes, key_id, PSA_KEY_LIFETIME_PERSISTENT );
     psa_set_key_type( &attributes, first_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, first_data->x, first_data->len, &handle ) );
+    PSA_ASSERT( psa_import_key( &attributes, first_data->x, first_data->len,
+                                &handle ) );
 
     if( restart )
     {
@@ -153,7 +154,8 @@ void persistent_key_destroy( int key_id_arg, int restart,
     /* Create another key in the same slot */
     psa_make_key_persistent( &attributes, key_id, PSA_KEY_LIFETIME_PERSISTENT );
     psa_set_key_type( &attributes, second_type );
-    PSA_ASSERT( psa_import_key( &attributes, second_data->x, second_data->len, &handle ) );
+    PSA_ASSERT( psa_import_key( &attributes, second_data->x, second_data->len,
+                                &handle ) );
 
 exit:
     mbedtls_psa_crypto_free();

--- a/tests/suites/test_suite_psa_crypto_persistent_key.function
+++ b/tests/suites/test_suite_psa_crypto_persistent_key.function
@@ -99,8 +99,7 @@ void save_large_persistent_key( int data_too_large, int expected_status )
     psa_make_key_persistent( &attributes, key_id, PSA_KEY_LIFETIME_PERSISTENT );
     psa_set_key_type( &attributes, PSA_KEY_TYPE_RAW_DATA );
 
-    TEST_EQUAL( psa_import_key( &attributes, &handle,
-                                data, data_length ),
+    TEST_EQUAL( psa_import_key( &attributes, data, data_length, &handle ),
                 expected_status );
 
 exit:
@@ -126,8 +125,7 @@ void persistent_key_destroy( int key_id_arg, int restart,
     psa_make_key_persistent( &attributes, key_id, PSA_KEY_LIFETIME_PERSISTENT );
     psa_set_key_type( &attributes, first_type );
 
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                first_data->x, first_data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, first_data->x, first_data->len, &handle ) );
 
     if( restart )
     {
@@ -155,8 +153,7 @@ void persistent_key_destroy( int key_id_arg, int restart,
     /* Create another key in the same slot */
     psa_make_key_persistent( &attributes, key_id, PSA_KEY_LIFETIME_PERSISTENT );
     psa_set_key_type( &attributes, second_type );
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                second_data->x, second_data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, second_data->x, second_data->len, &handle ) );
 
 exit:
     mbedtls_psa_crypto_free();
@@ -177,7 +174,7 @@ void persistent_key_import( int key_id_arg, int type_arg, data_t *data,
 
     psa_make_key_persistent( &attributes, key_id, PSA_KEY_LIFETIME_PERSISTENT );
     psa_set_key_type( &attributes, type );
-    TEST_EQUAL( psa_import_key( &attributes, &handle, data->x, data->len ),
+    TEST_EQUAL( psa_import_key( &attributes, data->x, data->len, &handle ),
                 expected_status );
 
     if( expected_status != PSA_SUCCESS )
@@ -233,8 +230,7 @@ void import_export_persistent_key( data_t *data, int type_arg,
     psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_EXPORT );
 
     /* Import the key */
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                data->x, data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, data->x, data->len, &handle ) );
 
 
     if( restart )

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -75,8 +75,7 @@ void transient_slot_lifecycle( int alg_arg, int usage_arg,
     psa_set_key_usage_flags( &attributes, usage_flags );
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, type );
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key_data->x, key_data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
     TEST_ASSERT( handle != 0 );
     PSA_ASSERT( psa_get_key_attributes( handle, &attributes ) );
     TEST_EQUAL( psa_get_key_type( &attributes ), type );
@@ -131,8 +130,7 @@ void persistent_slot_lifecycle( int lifetime_arg, int id_arg,
     psa_set_key_type( &attributes, type );
     psa_set_key_usage_flags( &attributes, usage_flags );
     psa_set_key_algorithm( &attributes, alg );
-    PSA_ASSERT( psa_import_key( &attributes, &handle,
-                                key_data->x, key_data->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
     TEST_ASSERT( handle != 0 );
     PSA_ASSERT( psa_get_key_information( handle, &read_type, NULL ) );
     TEST_EQUAL( read_type, type );
@@ -209,16 +207,14 @@ void create_existent( int lifetime_arg, int id_arg,
     psa_set_key_type( &attributes, type1 );
     psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_EXPORT );
     psa_set_key_algorithm( &attributes, 0 );
-    PSA_ASSERT( psa_import_key( &attributes, &handle1,
-                                material1, sizeof( material1 ) ) );
+    PSA_ASSERT( psa_import_key( &attributes, material1, sizeof( material1 ), &handle1 ) );
     TEST_ASSERT( handle1 != 0 );
 
     if( reopen_policy == CLOSE_BEFORE )
         PSA_ASSERT( psa_close_key( handle1 ) );
 
     /* Attempt to create a new key in the same slot. */
-    TEST_EQUAL( psa_import_key( &attributes, &handle2,
-                                material2, sizeof( material2 ) ),
+    TEST_EQUAL( psa_import_key( &attributes, material2, sizeof( material2 ), &handle2 ),
                 PSA_ERROR_ALREADY_EXISTS );
     TEST_EQUAL( handle2, 0 );
 
@@ -285,8 +281,7 @@ void create_fail( int lifetime_arg, int id_arg,
 
     psa_make_key_persistent( &attributes, id, lifetime );
     psa_set_key_type( &attributes, PSA_KEY_TYPE_RAW_DATA );
-    TEST_EQUAL( psa_import_key( &attributes, &handle,
-                                material, sizeof( material ) ),
+    TEST_EQUAL( psa_import_key( &attributes, material, sizeof( material ), &handle ),
                 expected_status );
     TEST_EQUAL( handle, 0 );
 
@@ -335,8 +330,7 @@ void copy_across_lifetimes( int source_lifetime_arg, int source_id_arg,
     psa_set_key_type( &source_attributes, source_type );
     psa_set_key_usage_flags( &source_attributes, source_usage );
     psa_set_key_algorithm( &source_attributes, source_alg );
-    PSA_ASSERT( psa_import_key( &source_attributes, &source_handle,
-                                material->x, material->len ) );
+    PSA_ASSERT( psa_import_key( &source_attributes, material->x, material->len, &source_handle ) );
     /* Update the attributes with the bit size. */
     PSA_ASSERT( psa_get_key_attributes( source_handle, &source_attributes ) );
 
@@ -439,8 +433,7 @@ void copy_to_occupied( int source_lifetime_arg, int source_id_arg,
     psa_set_key_type( &attributes, source_type );
     psa_set_key_usage_flags( &attributes, source_usage );
     psa_set_key_algorithm( &attributes, source_alg );
-    PSA_ASSERT( psa_import_key( &attributes, &source_handle,
-                                source_material->x, source_material->len ) );
+    PSA_ASSERT( psa_import_key( &attributes, source_material->x, source_material->len, &source_handle ) );
 
     /* Populate the target slot. */
     if( target_id == source_id )
@@ -453,8 +446,7 @@ void copy_to_occupied( int source_lifetime_arg, int source_id_arg,
         psa_set_key_type( &attributes1, target_type );
         psa_set_key_usage_flags( &attributes1, target_usage );
         psa_set_key_algorithm( &attributes1, target_alg );
-        PSA_ASSERT( psa_import_key( &attributes1, &target_handle,
-                                    target_material->x, target_material->len ) );
+        PSA_ASSERT( psa_import_key( &attributes1, target_material->x, target_material->len, &target_handle ) );
     }
     PSA_ASSERT( psa_get_key_attributes( target_handle, &attributes1 ) );
 
@@ -513,8 +505,7 @@ void invalid_handle( )
     psa_set_key_type( &attributes, PSA_KEY_TYPE_RAW_DATA );
     psa_set_key_usage_flags( &attributes, 0 );
     psa_set_key_algorithm( &attributes, 0 );
-    PSA_ASSERT( psa_import_key( &attributes, &handle1,
-                                material, sizeof( material ) ) );
+    PSA_ASSERT( psa_import_key( &attributes, material, sizeof( material ), &handle1 ) );
     TEST_ASSERT( handle1 != 0 );
 
     /* Attempt to close and destroy some invalid handles. */
@@ -556,8 +547,9 @@ void many_transient_handles( int max_handles_arg )
 
     for( i = 0; i < max_handles; i++ )
     {
-        status = psa_import_key( &attributes, &handles[i],
-                                 (uint8_t *) &i, sizeof( i ) );
+        status = psa_import_key( &attributes,
+                                 (uint8_t *) &i, sizeof( i ),
+                                 &handles[i] );
         if( status == PSA_ERROR_INSUFFICIENT_MEMORY )
             break;
         PSA_ASSERT( status );

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -75,7 +75,8 @@ void transient_slot_lifecycle( int alg_arg, int usage_arg,
     psa_set_key_usage_flags( &attributes, usage_flags );
     psa_set_key_algorithm( &attributes, alg );
     psa_set_key_type( &attributes, type );
-    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len,
+                                &handle ) );
     TEST_ASSERT( handle != 0 );
     PSA_ASSERT( psa_get_key_attributes( handle, &attributes ) );
     TEST_EQUAL( psa_get_key_type( &attributes ), type );
@@ -130,7 +131,8 @@ void persistent_slot_lifecycle( int lifetime_arg, int id_arg,
     psa_set_key_type( &attributes, type );
     psa_set_key_usage_flags( &attributes, usage_flags );
     psa_set_key_algorithm( &attributes, alg );
-    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len, &handle ) );
+    PSA_ASSERT( psa_import_key( &attributes, key_data->x, key_data->len,
+                                &handle ) );
     TEST_ASSERT( handle != 0 );
     PSA_ASSERT( psa_get_key_information( handle, &read_type, NULL ) );
     TEST_EQUAL( read_type, type );
@@ -207,14 +209,16 @@ void create_existent( int lifetime_arg, int id_arg,
     psa_set_key_type( &attributes, type1 );
     psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_EXPORT );
     psa_set_key_algorithm( &attributes, 0 );
-    PSA_ASSERT( psa_import_key( &attributes, material1, sizeof( material1 ), &handle1 ) );
+    PSA_ASSERT( psa_import_key( &attributes, material1, sizeof( material1 ),
+                                &handle1 ) );
     TEST_ASSERT( handle1 != 0 );
 
     if( reopen_policy == CLOSE_BEFORE )
         PSA_ASSERT( psa_close_key( handle1 ) );
 
     /* Attempt to create a new key in the same slot. */
-    TEST_EQUAL( psa_import_key( &attributes, material2, sizeof( material2 ), &handle2 ),
+    TEST_EQUAL( psa_import_key( &attributes, material2, sizeof( material2 ),
+                                &handle2 ),
                 PSA_ERROR_ALREADY_EXISTS );
     TEST_EQUAL( handle2, 0 );
 
@@ -281,7 +285,8 @@ void create_fail( int lifetime_arg, int id_arg,
 
     psa_make_key_persistent( &attributes, id, lifetime );
     psa_set_key_type( &attributes, PSA_KEY_TYPE_RAW_DATA );
-    TEST_EQUAL( psa_import_key( &attributes, material, sizeof( material ), &handle ),
+    TEST_EQUAL( psa_import_key( &attributes, material, sizeof( material ),
+                                &handle ),
                 expected_status );
     TEST_EQUAL( handle, 0 );
 
@@ -330,7 +335,9 @@ void copy_across_lifetimes( int source_lifetime_arg, int source_id_arg,
     psa_set_key_type( &source_attributes, source_type );
     psa_set_key_usage_flags( &source_attributes, source_usage );
     psa_set_key_algorithm( &source_attributes, source_alg );
-    PSA_ASSERT( psa_import_key( &source_attributes, material->x, material->len, &source_handle ) );
+    PSA_ASSERT( psa_import_key( &source_attributes,
+                                material->x, material->len,
+                                &source_handle ) );
     /* Update the attributes with the bit size. */
     PSA_ASSERT( psa_get_key_attributes( source_handle, &source_attributes ) );
 
@@ -433,7 +440,9 @@ void copy_to_occupied( int source_lifetime_arg, int source_id_arg,
     psa_set_key_type( &attributes, source_type );
     psa_set_key_usage_flags( &attributes, source_usage );
     psa_set_key_algorithm( &attributes, source_alg );
-    PSA_ASSERT( psa_import_key( &attributes, source_material->x, source_material->len, &source_handle ) );
+    PSA_ASSERT( psa_import_key( &attributes,
+                                source_material->x, source_material->len,
+                                &source_handle ) );
 
     /* Populate the target slot. */
     if( target_id == source_id )
@@ -446,7 +455,9 @@ void copy_to_occupied( int source_lifetime_arg, int source_id_arg,
         psa_set_key_type( &attributes1, target_type );
         psa_set_key_usage_flags( &attributes1, target_usage );
         psa_set_key_algorithm( &attributes1, target_alg );
-        PSA_ASSERT( psa_import_key( &attributes1, target_material->x, target_material->len, &target_handle ) );
+        PSA_ASSERT( psa_import_key( &attributes1,
+                                    target_material->x, target_material->len,
+                                    &target_handle ) );
     }
     PSA_ASSERT( psa_get_key_attributes( target_handle, &attributes1 ) );
 
@@ -505,7 +516,9 @@ void invalid_handle( )
     psa_set_key_type( &attributes, PSA_KEY_TYPE_RAW_DATA );
     psa_set_key_usage_flags( &attributes, 0 );
     psa_set_key_algorithm( &attributes, 0 );
-    PSA_ASSERT( psa_import_key( &attributes, material, sizeof( material ), &handle1 ) );
+    PSA_ASSERT( psa_import_key( &attributes,
+                                material, sizeof( material ),
+                                &handle1 ) );
     TEST_ASSERT( handle1 != 0 );
 
     /* Attempt to close and destroy some invalid handles. */


### PR DESCRIPTION
Change the order of parameters for `psa_import_key` and `psa_generate_derived_key` to pass the handle output parameter last. This makes the order consistent with the general convention in the library to put inputs before outputs. Other key handle creation functions (`psa_open_key`, `psa_generate_random_key`, `psa_copy_key`) already had the handle output parameter last.