### PR TITLE
Update link to PSA Crypto API HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ There are currently a few deviations where the library does not yet implement th
 
 ### PSA Cryptography API
 
-You can read the [complete PSA cryptography API specification as a PDF document](https://github.com/ARMmbed/mbed-crypto/blob/psa-crypto-api/docs/PSA_Cryptography_API_Specification.pdf). The API reference is also available in [HTML format](https://htmlpreview.github.io/?https://github.com/ARMmbed/mbed-crypto/blob/psa-crypto-api/docs/html/modules.html).
+You can read the [complete PSA cryptography API specification as a PDF document](https://github.com/ARMmbed/mbed-crypto/blob/psa-crypto-api/docs/PSA_Cryptography_API_Specification.pdf). The API reference is also available in [HTML format](https://htmlpreview.github.io/?https://github.com/ARMmbed/mbed-crypto/blob/psa-crypto-api/docs/html/index.html).
 
 ### Browsable library documentation
 


### PR DESCRIPTION
Now that we aren't using Doxygen directly any longer (#122), there is no longer a `modules.html`. Link to `index.html` instead.