### PR TITLE
Fix PSA Crypto API links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ There are currently a few deviations where the library does not yet implement th
 
 ### PSA Cryptography API
 
-You can read the [complete PSA cryptography API specification as a PDF document](https://github.com/ARMmbed/mbed-crypto/blob/psa-crypto-api/docs/PSA_Cryptography_API_Specification.pdf). The API reference is also available in [HTML format](https://htmlpreview.github.io/?https://github.com/ARMmbed/mbed-crypto/blob/psa-crypto-api/docs/html/index.html).
+You can read the [complete PSA cryptography API specification as a PDF document](https://github.com/ARMmbed/mbed-crypto/raw/psa-crypto-api/docs/PSA_Cryptography_API_Specification.pdf). The API reference is also available in [HTML format](https://htmlpreview.github.io/?https://github.com/ARMmbed/mbed-crypto/blob/psa-crypto-api/docs/html/index.html).
 
 ### Browsable library documentation
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ There are currently a few deviations where the library does not yet implement th
 
 ### PSA Cryptography API
 
-You can read the [complete PSA cryptography API specification as a PDF document](https://github.com/ARMmbed/mbed-crypto/raw/psa-crypto-api/docs/PSA_Cryptography_API_Specification.pdf). The API reference is also available in [HTML format](https://htmlpreview.github.io/?https://github.com/ARMmbed/mbed-crypto/blob/psa-crypto-api/docs/html/index.html).
+You can read the [complete PSA cryptography API specification as a PDF document](https://github.com/ARMmbed/mbed-crypto/raw/psa-crypto-api/docs/PSA_Cryptography_API_Specification.pdf). The API reference is also available in [HTML format](https://armmbed.github.io/mbed-crypto/html/index.html).
 
 ### Browsable library documentation
 


### PR DESCRIPTION
The PDF link was to a preview page. Link to the actual PDF instead.

The HTML link went to a third-party service that broke links. Link to Github Pages instead. **This requires the HTML to be in `/docs` on the `master` branch**. Alternatively we could change the repository settings to use a dedicated `gh-pages` branch — @Patater should we do this?

~There is still a problem with the HTML: [Sphinx puts resources (CSS, JS, images) in a directory with the hard-coded name `_static`](https://github.com/sphinx-doc/sphinx/issues/2202) but [Github Pages ignores files whose name starts with an underscore](https://help.github.com/en/articles/files-that-start-with-an-underscore-are-missing). We need to find a solution for this, but in the meantime, [unformatted HTML](https://armmbed.github.io/mbed-crypto/html/index.html) isn't as bad as missing content.~ https://github.com/ARMmbed/mbed-crypto/pull/127 makes `_static` work.
