### PR TITLE
Test that closing a handle reclaims its resources

### DIFF
--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -116,6 +116,43 @@ static inline psa_algorithm_t psa_get_key_enrollment_algorithm(
  */
 void mbedtls_psa_crypto_free( void );
 
+/** \brief Statistics about
+ * resource consumption related to the PSA keystore.
+ *
+ * \note The content of this structure is not part of the stable API and ABI
+ *       of Mbed Crypto and may change arbitrarily from version to version.
+ */
+typedef struct mbedtls_psa_stats_s
+{
+    /** Number of slots containing key material for a volatile key. */
+    size_t volatile_slots;
+    /** Number of slots containing key material for a key which is in
+     * internal persistent storage. */
+    size_t persistent_slots;
+    /** Number of slots containing a reference to a key in a
+     * secure element. */
+    size_t external_slots;
+    /** Number of slots which are occupied, but do not contain
+     * key material yet. */
+    size_t half_filled_slots;
+    /** Number of slots that contain cache data. */
+    size_t cache_slots;
+    /** Number of slots that are not used for anything. */
+    size_t empty_slots;
+    /** Largest key id value among open keys in internal persistent storage. */
+    psa_key_id_t max_open_internal_key_id;
+    /** Largest key id value among open keys in secure elements. */
+    psa_key_id_t max_open_external_key_id;
+} mbedtls_psa_stats_t;
+
+/** \brief Get statistics about
+ * resource consumption related to the PSA keystore.
+ *
+ * \note When Mbed Crypto is built as part of a service, with isolation
+ *       between the application and the keystore, the service may or
+ *       may not expose this function.
+ */
+void mbedtls_psa_get_stats( mbedtls_psa_stats_t *stats );
 
 /**
  * \brief Inject an initial entropy seed for the random generator into

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -104,6 +104,7 @@ $(BINARIES): %$(EXEXT): %.c $(DEP)
 	echo "  CC    $<"
 	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
+$(filter test_suite_psa_crypto%, $(BINARIES)): psa_helpers.function
 
 clean:
 ifndef WINDOWS

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -104,8 +104,11 @@ $(BINARIES): %$(EXEXT): %.c $(DEP)
 	echo "  CC    $<"
 	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
+# Some test suites require additional header files.
 $(filter test_suite_psa_crypto%, $(BINARIES)): psa_crypto_helpers.h
+$(addprefix embedded_,$(filter test_suite_psa_crypto%, $(APPS))): embedded_%: TESTS/mbedtls/%/psa_crypto_helpers.h
 $(filter test_suite_psa_%, $(BINARIES)): psa_helpers.h
+$(addprefix embedded_,$(filter test_suite_psa_%, $(APPS))): embedded_%: TESTS/mbedtls/%/psa_helpers.h
 
 clean:
 ifndef WINDOWS
@@ -143,3 +146,17 @@ $(EMBEDDED_TESTS): embedded_%: suites/$$(firstword $$(subst ., ,$$*)).function s
 
 generate-target-tests: $(EMBEDDED_TESTS)
 
+define copy_header_to_target
+TESTS/mbedtls/$(1)/$(2): $(2)
+	echo "  Copy ./$$@"
+ifndef WINDOWS
+	mkdir -p $$(@D)
+	cp $$< $$@
+else
+	mkdir $$(@D)
+	copy $$< $$@
+endif
+
+endef
+$(foreach app, $(APPS), $(foreach file, $(wildcard *.h), \
+	$(eval $(call copy_header_to_target,$(app),$(file)))))

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -104,7 +104,7 @@ $(BINARIES): %$(EXEXT): %.c $(DEP)
 	echo "  CC    $<"
 	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
-$(filter test_suite_psa_crypto%, $(BINARIES)): psa_helpers.function
+$(filter test_suite_psa_crypto%, $(BINARIES)): psa_crypto_helpers.h
 
 clean:
 ifndef WINDOWS

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -105,6 +105,7 @@ $(BINARIES): %$(EXEXT): %.c $(DEP)
 	$(CC) $(LOCAL_CFLAGS) $(CFLAGS) $<	$(LOCAL_LDFLAGS) $(LDFLAGS) -o $@
 
 $(filter test_suite_psa_crypto%, $(BINARIES)): psa_crypto_helpers.h
+$(filter test_suite_psa_%, $(BINARIES)): psa_helpers.h
 
 clean:
 ifndef WINDOWS

--- a/tests/psa_crypto_helpers.h
+++ b/tests/psa_crypto_helpers.h
@@ -19,6 +19,9 @@
  *  This file is part of mbed TLS (https://tls.mbed.org)
  */
 
+#ifndef PSA_CRYPTO_HELPERS_H
+#define PSA_CRYPTO_HELPERS_H
+
 #if defined(MBEDTLS_PSA_CRYPTO_SPM)
 #include "spm/psa_defs.h"
 #endif
@@ -78,8 +81,4 @@ static void test_helper_psa_done( int line, const char *file )
  */
 #define PSA_DONE( ) test_helper_psa_done( __LINE__, __FILE__ )
 
-/*
- * Local Variables:
- * mode: c
- * End:
- */
+#endif /* PSA_CRYPTO_HELPERS_H */

--- a/tests/psa_crypto_helpers.h
+++ b/tests/psa_crypto_helpers.h
@@ -1,5 +1,5 @@
 /*
- * Helper functions for tests that use the PSA API.
+ * Helper functions for tests that use the PSA Crypto API.
  */
 /*  Copyright (C) 2019, ARM Limited, All Rights Reserved
  *  SPDX-License-Identifier: Apache-2.0
@@ -22,18 +22,9 @@
 #ifndef PSA_CRYPTO_HELPERS_H
 #define PSA_CRYPTO_HELPERS_H
 
-#if defined(MBEDTLS_PSA_CRYPTO_SPM)
-#include "spm/psa_defs.h"
-#endif
-#include <psa/crypto.h>
+#include "psa_helpers.h"
 
-/** Evaluate an expression and fail the test case if it returns an error.
- *
- * \param expr      The expression to evaluate. This is typically a call
- *                  to a \c psa_xxx function that returns a value of type
- *                  #psa_status_t.
- */
-#define PSA_ASSERT( expr ) TEST_EQUAL( ( expr ), PSA_SUCCESS )
+#include <psa/crypto.h>
 
 static int test_helper_is_psa_pristine( int line, const char *file )
 {
@@ -60,7 +51,7 @@ static int test_helper_is_psa_pristine( int line, const char *file )
     return( msg == NULL );
 }
 
-/** Check that no PSA slots are in use.
+/** Check that no PSA Crypto key slots are in use.
  */
 #define ASSERT_PSA_PRISTINE( )                                    \
     do                                                            \
@@ -76,7 +67,7 @@ static void test_helper_psa_done( int line, const char *file )
     mbedtls_psa_crypto_free( );
 }
 
-/** Shut down the PSA subsystem. Expect a clean shutdown, with no slots
+/** Shut down the PSA Crypto subsystem. Expect a clean shutdown, with no slots
  * in use.
  */
 #define PSA_DONE( ) test_helper_psa_done( __LINE__, __FILE__ )

--- a/tests/psa_helpers.function
+++ b/tests/psa_helpers.function
@@ -32,7 +32,7 @@
  */
 #define PSA_ASSERT( expr ) TEST_EQUAL( ( expr ), PSA_SUCCESS )
 
-static void test_helper_psa_done( int line, const char *file )
+static int test_helper_is_psa_pristine( int line, const char *file )
 {
     mbedtls_psa_stats_t stats;
     const char *msg = NULL;
@@ -48,12 +48,28 @@ static void test_helper_psa_done( int line, const char *file )
     else if( stats.half_filled_slots != 0 )
         msg = "A half-filled slot has not been cleared properly.";
 
-    /* If the test failed, don't overwrite the failure information.
-     * Do keep the stats lookup above, because it can be convenient to
-     * break on it when debugging a failure. */
+    /* If the test has already failed, don't overwrite the failure
+     * information. Do keep the stats lookup above, because it can be
+     * convenient to break on it when debugging a failure. */
     if( msg != NULL && test_info.failed == 0 )
         test_fail( msg, line, file );
 
+    return( msg == NULL );
+}
+
+/** Check that no PSA slots are in use.
+ */
+#define ASSERT_PSA_PRISTINE( )                                    \
+    do                                                            \
+    {                                                             \
+        if( ! test_helper_is_psa_pristine( __LINE__, __FILE__ ) ) \
+            goto exit;                                            \
+    }                                                             \
+    while( 0 )
+
+static void test_helper_psa_done( int line, const char *file )
+{
+    (void) test_helper_is_psa_pristine( line, file );
     mbedtls_psa_crypto_free( );
 }
 

--- a/tests/psa_helpers.function
+++ b/tests/psa_helpers.function
@@ -32,6 +32,36 @@
  */
 #define PSA_ASSERT( expr ) TEST_EQUAL( ( expr ), PSA_SUCCESS )
 
+static void test_helper_psa_done( int line, const char *file )
+{
+    mbedtls_psa_stats_t stats;
+    const char *msg = NULL;
+
+    mbedtls_psa_get_stats( &stats );
+
+    if( stats.volatile_slots != 0 )
+        msg = "A volatile slot has not been closed properly.";
+    else if( stats.persistent_slots != 0 )
+        msg = "A persistent slot has not been closed properly.";
+    else if( stats.external_slots != 0 )
+        msg = "An external slot has not been closed properly.";
+    else if( stats.half_filled_slots != 0 )
+        msg = "A half-filled slot has not been cleared properly.";
+
+    /* If the test failed, don't overwrite the failure information.
+     * Do keep the stats lookup above, because it can be convenient to
+     * break on it when debugging a failure. */
+    if( msg != NULL && test_info.failed == 0 )
+        test_fail( msg, line, file );
+
+    mbedtls_psa_crypto_free( );
+}
+
+/** Shut down the PSA subsystem. Expect a clean shutdown, with no slots
+ * in use.
+ */
+#define PSA_DONE( ) test_helper_psa_done( __LINE__, __FILE__ )
+
 /*
  * Local Variables:
  * mode: c

--- a/tests/psa_helpers.function
+++ b/tests/psa_helpers.function
@@ -1,0 +1,39 @@
+/*
+ * Helper functions for tests that use the PSA API.
+ */
+/*  Copyright (C) 2019, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+
+#if defined(MBEDTLS_PSA_CRYPTO_SPM)
+#include "spm/psa_defs.h"
+#endif
+#include <psa/crypto.h>
+
+/** Evaluate an expression and fail the test case if it returns an error.
+ *
+ * \param expr      The expression to evaluate. This is typically a call
+ *                  to a \c psa_xxx function that returns a value of type
+ *                  #psa_status_t.
+ */
+#define PSA_ASSERT( expr ) TEST_EQUAL( ( expr ), PSA_SUCCESS )
+
+/*
+ * Local Variables:
+ * mode: c
+ * End:
+ */

--- a/tests/psa_helpers.h
+++ b/tests/psa_helpers.h
@@ -1,0 +1,37 @@
+/*
+ * Helper functions for tests that use any PSA API.
+ */
+/*  Copyright (C) 2019, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+
+#ifndef PSA_HELPERS_H
+#define PSA_HELPERS_H
+
+#if defined(MBEDTLS_PSA_CRYPTO_SPM)
+#include "spm/psa_defs.h"
+#endif
+
+/** Evaluate an expression and fail the test case if it returns an error.
+ *
+ * \param expr      The expression to evaluate. This is typically a call
+ *                  to a \c psa_xxx function that returns a value of type
+ *                  #psa_status_t.
+ */
+#define PSA_ASSERT( expr ) TEST_EQUAL( ( expr ), PSA_SUCCESS )
+
+#endif /* PSA_HELPERS_H */

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -126,14 +126,6 @@ typedef enum
 #define TEST_EQUAL( expr1, expr2 )              \
     TEST_ASSERT( ( expr1 ) == ( expr2 ) )
 
-/** Evaluate an expression and fail the test case if it returns an error.
- *
- * \param expr      The expression to evaluate. This is typically a call
- *                  to a \c psa_xxx function that returns a value of type
- *                  #psa_status_t.
- */
-#define PSA_ASSERT( expr ) TEST_EQUAL( ( expr ), PSA_SUCCESS )
-
 /** Allocate memory dynamically and fail the test case if this fails.
  *
  * You must set \p pointer to \c NULL before calling this macro and

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -10,6 +10,11 @@
 #include <limits.h>
 #include <stdint.h>
 
+#if defined(MBEDTLS_USE_PSA_CRYPTO)
+#include "mbedtls/psa_util.h"
+#include "psa_helpers.function"
+#endif
+
 static int rnd_std_rand( void *rng_state, unsigned char *output, size_t len );
 
 #define RSA_KEY_SIZE 512
@@ -66,8 +71,6 @@ size_t mbedtls_rsa_key_len_func( void *ctx )
 #endif /* MBEDTLS_RSA_C */
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
-
-#include "mbedtls/psa_util.h"
 
 /*
  * Generate a key using PSA and return a handle to that key,

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -12,7 +12,7 @@
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 #include "mbedtls/psa_util.h"
-#include "psa_helpers.function"
+#include "psa_crypto_helpers.h"
 #endif
 
 static int rnd_std_rand( void *rng_state, unsigned char *output, size_t len );

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -1,15 +1,11 @@
 /* BEGIN_HEADER */
 #include <stdint.h>
 
-#if defined(MBEDTLS_PSA_CRYPTO_SPM)
-#include "spm/psa_defs.h"
-#endif
-
 #include "mbedtls/asn1.h"
 #include "mbedtls/asn1write.h"
 #include "mbedtls/oid.h"
 
-#include "psa/crypto.h"
+#include "psa_helpers.function"
 
 /** An invalid export length that will never be set by psa_export_key(). */
 static const size_t INVALID_EXPORT_LENGTH = ~0U;

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -1259,7 +1259,7 @@ void import( data_t *data, int type_arg,
 exit:
     psa_destroy_key( handle );
     psa_reset_key_attributes( &got_attributes );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -1296,7 +1296,7 @@ void import_rsa_made_up( int bits_arg, int keypair, int expected_status_arg )
 
 exit:
     mbedtls_free( buffer );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -1389,7 +1389,7 @@ exit:
     mbedtls_free( exported );
     mbedtls_free( reexported );
     psa_reset_key_attributes( &got_attributes );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -1400,7 +1400,7 @@ void invalid_handle( int handle )
     test_operations_on_invalid_handle( handle );
 
 exit:
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -1453,7 +1453,7 @@ exit:
     mbedtls_free( exported );
     psa_destroy_key( handle );
     psa_reset_key_attributes( &attributes );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -1495,7 +1495,7 @@ void import_and_exercise_key( data_t *data,
 exit:
     psa_destroy_key( handle );
     psa_reset_key_attributes( &got_attributes );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -1527,7 +1527,7 @@ void key_policy( int usage_arg, int alg_arg )
 exit:
     psa_destroy_key( handle );
     psa_reset_key_attributes( &attributes );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -1607,7 +1607,7 @@ void mac_key_policy( int policy_usage,
 exit:
     psa_mac_abort( &operation );
     psa_destroy_key( handle );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -1650,7 +1650,7 @@ void cipher_key_policy( int policy_usage,
 exit:
     psa_cipher_abort( &operation );
     psa_destroy_key( handle );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -1711,7 +1711,7 @@ void aead_key_policy( int policy_usage,
 
 exit:
     psa_destroy_key( handle );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -1772,7 +1772,7 @@ void asymmetric_encryption_key_policy( int policy_usage,
 exit:
     psa_destroy_key( handle );
     psa_reset_key_attributes( &attributes );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
     mbedtls_free( buffer );
 }
 /* END_CASE */
@@ -1827,7 +1827,7 @@ void asymmetric_signature_key_policy( int policy_usage,
 
 exit:
     psa_destroy_key( handle );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -1866,7 +1866,7 @@ void derive_key_policy( int policy_usage,
 exit:
     psa_key_derivation_abort( &operation );
     psa_destroy_key( handle );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -1904,7 +1904,7 @@ void agreement_key_policy( int policy_usage,
 exit:
     psa_key_derivation_abort( &operation );
     psa_destroy_key( handle );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -1941,7 +1941,7 @@ void key_policy_alg2( int key_type_arg, data_t *key_data,
 
 exit:
     psa_destroy_key( handle );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -1978,7 +1978,7 @@ void raw_agreement_key_policy( int policy_usage,
 exit:
     psa_key_derivation_abort( &operation );
     psa_destroy_key( handle );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -2059,7 +2059,7 @@ void copy_success( int source_usage_arg,
 exit:
     psa_reset_key_attributes( &source_attributes );
     psa_reset_key_attributes( &target_attributes );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
     mbedtls_free( export_buffer );
 }
 /* END_CASE */
@@ -2103,7 +2103,7 @@ void copy_fail( int source_usage_arg,
 exit:
     psa_reset_key_attributes( &source_attributes );
     psa_reset_key_attributes( &target_attributes );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -2165,7 +2165,7 @@ void hash_setup( int alg_arg,
 #endif
 
 exit:
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -2253,7 +2253,7 @@ void hash_bad_order( )
     PSA_ASSERT( psa_hash_abort( &operation ) );
 
 exit:
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -2288,7 +2288,7 @@ void hash_verify_bad_args( )
                 PSA_ERROR_INVALID_SIGNATURE );
 
 exit:
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -2310,7 +2310,7 @@ void hash_finish_bad_args( )
                 PSA_ERROR_BUFFER_TOO_SMALL );
 
 exit:
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -2355,7 +2355,7 @@ exit:
     psa_hash_abort( &op_setup );
     psa_hash_abort( &op_finished );
     psa_hash_abort( &op_aborted );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -2396,7 +2396,7 @@ exit:
     psa_hash_abort( &op_setup );
     psa_hash_abort( &op_finished );
     psa_hash_abort( &op_aborted );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -2467,7 +2467,7 @@ void mac_setup( int key_type_arg,
 #endif
 
 exit:
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -2588,7 +2588,7 @@ void mac_bad_order( )
     PSA_ASSERT( psa_mac_abort( &operation ) );
 
 exit:
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -2643,7 +2643,7 @@ void mac_sign( int key_type_arg,
 
 exit:
     psa_destroy_key( handle );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -2681,7 +2681,7 @@ void mac_verify( int key_type_arg,
 
 exit:
     psa_destroy_key( handle );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -2759,7 +2759,7 @@ void cipher_setup( int key_type_arg,
 #endif
 
 exit:
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -2909,7 +2909,7 @@ void cipher_bad_order( )
     PSA_ASSERT( psa_cipher_abort( &operation ) );
 
 exit:
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -2969,7 +2969,7 @@ void cipher_encrypt( int alg_arg, int key_type_arg,
 exit:
     mbedtls_free( output );
     psa_destroy_key( handle );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -3037,7 +3037,7 @@ void cipher_encrypt_multipart( int alg_arg, int key_type_arg,
 exit:
     mbedtls_free( output );
     psa_destroy_key( handle );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -3108,7 +3108,7 @@ void cipher_decrypt_multipart( int alg_arg, int key_type_arg,
 exit:
     mbedtls_free( output );
     psa_destroy_key( handle );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -3169,7 +3169,7 @@ void cipher_decrypt( int alg_arg, int key_type_arg,
 exit:
     mbedtls_free( output );
     psa_destroy_key( handle );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -3251,7 +3251,7 @@ exit:
     mbedtls_free( output1 );
     mbedtls_free( output2 );
     psa_destroy_key( handle );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -3354,7 +3354,7 @@ exit:
     mbedtls_free( output1 );
     mbedtls_free( output2 );
     psa_destroy_key( handle );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -3430,7 +3430,7 @@ exit:
     psa_destroy_key( handle );
     mbedtls_free( output_data );
     mbedtls_free( output_data2 );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -3480,7 +3480,7 @@ void aead_encrypt( int key_type_arg, data_t *key_data,
 exit:
     psa_destroy_key( handle );
     mbedtls_free( output_data );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -3536,7 +3536,7 @@ void aead_decrypt( int key_type_arg, data_t *key_data,
 exit:
     psa_destroy_key( handle );
     mbedtls_free( output_data );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -3601,7 +3601,7 @@ exit:
     psa_reset_key_attributes( &attributes );
     psa_destroy_key( handle );
     mbedtls_free( signature );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -3646,7 +3646,7 @@ exit:
     psa_reset_key_attributes( &attributes );
     psa_destroy_key( handle );
     mbedtls_free( signature );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -3713,7 +3713,7 @@ exit:
     psa_reset_key_attributes( &attributes );
     psa_destroy_key( handle );
     mbedtls_free( signature );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -3745,7 +3745,7 @@ void asymmetric_verify( int key_type_arg, data_t *key_data,
 exit:
     psa_reset_key_attributes( &attributes );
     psa_destroy_key( handle );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -3781,7 +3781,7 @@ void asymmetric_verify_fail( int key_type_arg, data_t *key_data,
 exit:
     psa_reset_key_attributes( &attributes );
     psa_destroy_key( handle );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -3850,7 +3850,7 @@ exit:
     psa_reset_key_attributes( &attributes );
     psa_destroy_key( handle );
     mbedtls_free( output );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -3915,7 +3915,7 @@ exit:
     psa_destroy_key( handle );
     mbedtls_free( output );
     mbedtls_free( output2 );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -3977,7 +3977,7 @@ exit:
     psa_reset_key_attributes( &attributes );
     psa_destroy_key( handle );
     mbedtls_free( output );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -4039,7 +4039,7 @@ exit:
     psa_reset_key_attributes( &attributes );
     psa_destroy_key( handle );
     mbedtls_free( output );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -4107,7 +4107,7 @@ void derive_setup( int key_type_arg,
 exit:
     psa_key_derivation_abort( &operation );
     psa_destroy_key( handle );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -4156,7 +4156,7 @@ void test_derive_invalid_key_derivation_state( )
 exit:
     psa_key_derivation_abort( &operation );
     psa_destroy_key( handle );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -4298,7 +4298,7 @@ exit:
     mbedtls_free( output_buffer );
     psa_key_derivation_abort( &operation );
     psa_destroy_key( handle );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -4379,7 +4379,7 @@ void derive_full( int alg_arg,
 exit:
     psa_key_derivation_abort( &operation );
     psa_destroy_key( handle );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -4439,7 +4439,7 @@ exit:
     psa_reset_key_attributes( &got_attributes );
     psa_destroy_key( base_handle );
     psa_destroy_key( derived_handle );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -4518,7 +4518,7 @@ exit:
     psa_key_derivation_abort( &operation );
     psa_destroy_key( base_handle );
     psa_destroy_key( derived_handle );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -4566,7 +4566,7 @@ void key_agreement_setup( int alg_arg,
 exit:
     psa_key_derivation_abort( &operation );
     psa_destroy_key( our_key );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -4603,7 +4603,7 @@ void raw_key_agreement( int alg_arg,
 exit:
     mbedtls_free( output );
     psa_destroy_key( our_key );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -4663,7 +4663,7 @@ void key_agreement_capacity( int alg_arg,
 exit:
     psa_key_derivation_abort( &operation );
     psa_destroy_key( our_key );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -4722,7 +4722,7 @@ void key_agreement_output( int alg_arg,
 exit:
     psa_key_derivation_abort( &operation );
     psa_destroy_key( our_key );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
     mbedtls_free( actual_output );
 }
 /* END_CASE */
@@ -4772,7 +4772,7 @@ void generate_random( int bytes_arg )
     }
 
 exit:
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
     mbedtls_free( output );
     mbedtls_free( changed );
 }
@@ -4818,7 +4818,7 @@ void generate_key( int type_arg,
 exit:
     psa_reset_key_attributes( &got_attributes );
     psa_destroy_key( handle );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -4919,7 +4919,7 @@ void generate_key_rsa( int bits_arg,
 exit:
     psa_reset_key_attributes( &attributes );
     psa_destroy_key( handle );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
     mbedtls_free( e_read_buffer );
     mbedtls_free( exported );
 }
@@ -5016,7 +5016,7 @@ void persistent_key_load_key_from_storage( data_t *data,
     }
 
     /* Shutdown and restart */
-    mbedtls_psa_crypto_free();
+    PSA_DONE();
     PSA_ASSERT( psa_crypto_init() );
 
     /* Check key slot still contains key data */
@@ -5058,6 +5058,6 @@ exit:
         psa_open_key( key_id, &handle );
     }
     psa_destroy_key( handle );
-    mbedtls_psa_crypto_free();
+    PSA_DONE();
 }
 /* END_CASE */

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -1291,6 +1291,7 @@ void import_rsa_made_up( int bits_arg, int keypair, int expected_status_arg )
     psa_set_key_type( &attributes, type );
     status = psa_import_key( &attributes, p, length, &handle );
     TEST_EQUAL( status, expected_status );
+
     if( status == PSA_SUCCESS )
         PSA_ASSERT( psa_destroy_key( handle ) );
 
@@ -2100,6 +2101,9 @@ void copy_fail( int source_usage_arg,
     TEST_EQUAL( psa_copy_key( source_handle,
                               &target_attributes, &target_handle ),
                 expected_status_arg );
+
+    PSA_ASSERT( psa_destroy_key( source_handle ) );
+
 exit:
     psa_reset_key_attributes( &source_attributes );
     psa_reset_key_attributes( &target_attributes );
@@ -2587,6 +2591,8 @@ void mac_bad_order( )
                 PSA_ERROR_BAD_STATE );
     PSA_ASSERT( psa_mac_abort( &operation ) );
 
+    PSA_ASSERT( psa_destroy_key( handle ) );
+
 exit:
     PSA_DONE( );
 }
@@ -2907,6 +2913,8 @@ void cipher_bad_order( )
                                    buffer, sizeof( buffer ), &length ),
                 PSA_ERROR_BAD_STATE );
     PSA_ASSERT( psa_cipher_abort( &operation ) );
+
+    PSA_ASSERT( psa_destroy_key( handle ) );
 
 exit:
     PSA_DONE( );
@@ -5016,6 +5024,7 @@ void persistent_key_load_key_from_storage( data_t *data,
     }
 
     /* Shutdown and restart */
+    PSA_ASSERT( psa_close_key( handle ) );
     PSA_DONE();
     PSA_ASSERT( psa_crypto_init() );
 

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -5,7 +5,7 @@
 #include "mbedtls/asn1write.h"
 #include "mbedtls/oid.h"
 
-#include "psa_helpers.function"
+#include "psa_crypto_helpers.h"
 
 /** An invalid export length that will never be set by psa_export_key(). */
 static const size_t INVALID_EXPORT_LENGTH = ~0U;

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -682,43 +682,6 @@ exit:
     return( ok );
 }
 
-static int is_oid_of_key_type( psa_key_type_t type,
-                               const uint8_t *oid, size_t oid_length )
-{
-    const uint8_t *expected_oid = NULL;
-    size_t expected_oid_length = 0;
-#if defined(MBEDTLS_RSA_C)
-    if( PSA_KEY_TYPE_IS_RSA( type ) )
-    {
-        expected_oid = (uint8_t *) MBEDTLS_OID_PKCS1_RSA;
-        expected_oid_length = sizeof( MBEDTLS_OID_PKCS1_RSA ) - 1;
-    }
-    else
-#endif /* MBEDTLS_RSA_C */
-#if defined(MBEDTLS_ECP_C)
-    if( PSA_KEY_TYPE_IS_ECC( type ) )
-    {
-        expected_oid = (uint8_t *) MBEDTLS_OID_EC_ALG_UNRESTRICTED;
-        expected_oid_length = sizeof( MBEDTLS_OID_EC_ALG_UNRESTRICTED ) - 1;
-    }
-    else
-#endif /* MBEDTLS_ECP_C */
-    {
-        char message[40];
-        mbedtls_snprintf( message, sizeof( message ),
-                          "OID not known for key type=0x%08lx",
-                          (unsigned long) type );
-        test_fail( message, __LINE__, __FILE__ );
-        return( 0 );
-    }
-
-    ASSERT_COMPARE( expected_oid, expected_oid_length, oid, oid_length );
-    return( 1 );
-
-exit:
-    return( 0 );
-}
-
 static int asn1_skip_integer( unsigned char **p, const unsigned char *end,
                               size_t min_bits, size_t max_bits,
                               int must_be_odd )
@@ -755,25 +718,6 @@ static int asn1_skip_integer( unsigned char **p, const unsigned char *end,
     *p += len;
     return( 1 );
 exit:
-    return( 0 );
-}
-
-static int asn1_get_implicit_tag( unsigned char **p, const unsigned char *end,
-                                  size_t *len,
-                                  unsigned char n, unsigned char tag )
-{
-    int ret;
-    ret = mbedtls_asn1_get_tag( p, end, len,
-                                MBEDTLS_ASN1_CONTEXT_SPECIFIC |
-                                MBEDTLS_ASN1_CONSTRUCTED | ( n ) );
-    if( ret != 0 )
-        return( ret );
-    end = *p + *len;
-    ret = mbedtls_asn1_get_tag( p, end, len, tag );
-    if( ret != 0 )
-        return( ret );
-    if( *p + *len != end )
-        return( MBEDTLS_ERR_ASN1_LENGTH_MISMATCH );
     return( 0 );
 }
 

--- a/tests/suites/test_suite_psa_crypto_entropy.function
+++ b/tests/suites/test_suite_psa_crypto_entropy.function
@@ -77,7 +77,7 @@ void validate_entropy_seed_injection( int seed_length_a,
 exit:
     mbedtls_free( seed );
     remove_seed_file( );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -105,12 +105,12 @@ void run_entropy_inject_with_crypto_init( )
     PSA_ASSERT( status );
     status = psa_crypto_init( );
     PSA_ASSERT( status );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
     /* The seed is written by nv_seed callback functions therefore the injection will fail */
     status = mbedtls_psa_inject_entropy( seed, sizeof( seed ) );
     TEST_EQUAL( status, PSA_ERROR_NOT_PERMITTED );
 exit:
     remove_seed_file( );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */

--- a/tests/suites/test_suite_psa_crypto_entropy.function
+++ b/tests/suites/test_suite_psa_crypto_entropy.function
@@ -1,10 +1,10 @@
 /* BEGIN_HEADER */
 #include <stdint.h>
 
-#include "psa/crypto.h"
 #include "mbedtls/entropy.h"
 #include "mbedtls/entropy_poll.h"
 
+#include "psa_helpers.function"
 #if defined(MBEDTLS_PSA_ITS_FILE_C)
 #include <stdio.h>
 #else

--- a/tests/suites/test_suite_psa_crypto_entropy.function
+++ b/tests/suites/test_suite_psa_crypto_entropy.function
@@ -4,7 +4,7 @@
 #include "mbedtls/entropy.h"
 #include "mbedtls/entropy_poll.h"
 
-#include "psa_helpers.function"
+#include "psa_crypto_helpers.h"
 #if defined(MBEDTLS_PSA_ITS_FILE_C)
 #include <stdio.h>
 #else

--- a/tests/suites/test_suite_psa_crypto_hash.function
+++ b/tests/suites/test_suite_psa_crypto_hash.function
@@ -31,7 +31,7 @@ void hash_finish( int alg_arg, data_t *input, data_t *expected_hash )
                     actual_hash, actual_hash_length );
 
 exit:
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -52,7 +52,7 @@ void hash_verify( int alg_arg, data_t *input, data_t *expected_hash )
                                  expected_hash->len ) );
 
 exit:
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -95,6 +95,6 @@ void hash_multi_part( int alg_arg, data_t *input, data_t *expected_hash )
     } while( len++ != input->len );
 
 exit:
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */

--- a/tests/suites/test_suite_psa_crypto_hash.function
+++ b/tests/suites/test_suite_psa_crypto_hash.function
@@ -2,11 +2,7 @@
 
 #include <stdint.h>
 
-#if defined(MBEDTLS_PSA_CRYPTO_SPM)
-#include "spm/psa_defs.h"
-#endif
-
-#include "psa/crypto.h"
+#include "psa_helpers.function"
 
 /* END_HEADER */
 

--- a/tests/suites/test_suite_psa_crypto_hash.function
+++ b/tests/suites/test_suite_psa_crypto_hash.function
@@ -2,7 +2,7 @@
 
 #include <stdint.h>
 
-#include "psa_helpers.function"
+#include "psa_crypto_helpers.h"
 
 /* END_HEADER */
 

--- a/tests/suites/test_suite_psa_crypto_init.function
+++ b/tests/suites/test_suite_psa_crypto_init.function
@@ -138,7 +138,7 @@ void init_deinit( int count )
         PSA_ASSERT( status );
         status = psa_crypto_init( );
         PSA_ASSERT( status );
-        mbedtls_psa_crypto_free( );
+        PSA_DONE( );
     }
 }
 /* END_CASE */
@@ -150,9 +150,9 @@ void deinit_without_init( int count )
     for( i = 0; i < count; i++ )
     {
         PSA_ASSERT( psa_crypto_init( ) );
-        mbedtls_psa_crypto_free( );
+        PSA_DONE( );
     }
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -166,7 +166,7 @@ void validate_module_init_generate_random( int count )
     {
         status = psa_crypto_init( );
         PSA_ASSERT( status );
-        mbedtls_psa_crypto_free( );
+        PSA_DONE( );
     }
     status = psa_generate_random( random, sizeof( random ) );
     TEST_EQUAL( status, PSA_ERROR_BAD_STATE );
@@ -186,7 +186,7 @@ void validate_module_init_key_based( int count )
     {
         status = psa_crypto_init( );
         PSA_ASSERT( status );
-        mbedtls_psa_crypto_free( );
+        PSA_DONE( );
     }
     psa_set_key_type( &attributes, PSA_KEY_TYPE_RAW_DATA );
     status = psa_import_key( &attributes, data, sizeof( data ), &handle );
@@ -212,7 +212,7 @@ void custom_entropy_sources( int sources_arg, int expected_init_status_arg )
     PSA_ASSERT( psa_generate_random( random, sizeof( random ) ) );
 
 exit:
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -252,7 +252,7 @@ void fake_entropy_source( int threshold,
     PSA_ASSERT( psa_generate_random( random, sizeof( random ) ) );
 
 exit:
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -280,6 +280,6 @@ void entropy_from_nv_seed( int seed_size_arg,
 
 exit:
     mbedtls_free( seed );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */

--- a/tests/suites/test_suite_psa_crypto_init.function
+++ b/tests/suites/test_suite_psa_crypto_init.function
@@ -1,11 +1,7 @@
 /* BEGIN_HEADER */
 #include <stdint.h>
 
-#if defined(MBEDTLS_PSA_CRYPTO_SPM)
-#include "spm/psa_defs.h"
-#endif
-#include "psa/crypto.h"
-
+#include "psa_helpers.function"
 /* Some tests in this module configure entropy sources. */
 #include "psa_crypto_invasive.h"
 

--- a/tests/suites/test_suite_psa_crypto_init.function
+++ b/tests/suites/test_suite_psa_crypto_init.function
@@ -1,7 +1,7 @@
 /* BEGIN_HEADER */
 #include <stdint.h>
 
-#include "psa_helpers.function"
+#include "psa_crypto_helpers.h"
 /* Some tests in this module configure entropy sources. */
 #include "psa_crypto_invasive.h"
 

--- a/tests/suites/test_suite_psa_crypto_persistent_key.function
+++ b/tests/suites/test_suite_psa_crypto_persistent_key.function
@@ -1,7 +1,9 @@
 /* BEGIN_HEADER */
 #include <stdint.h>
-#include "psa/crypto.h"
+
+#include "psa_helpers.function"
 #include "psa_crypto_storage.h"
+
 #include "mbedtls/md.h"
 
 #define PSA_KEY_STORAGE_MAGIC_HEADER "PSA\0KEY"

--- a/tests/suites/test_suite_psa_crypto_persistent_key.function
+++ b/tests/suites/test_suite_psa_crypto_persistent_key.function
@@ -108,6 +108,9 @@ void save_large_persistent_key( int data_too_large, int expected_status )
     TEST_EQUAL( psa_import_key( &attributes, data, data_length, &handle ),
                 expected_status );
 
+    if( expected_status == PSA_SUCCESS )
+        PSA_ASSERT( psa_destroy_key( handle ) );
+
 exit:
     mbedtls_free( data );
     PSA_DONE();
@@ -161,6 +164,8 @@ void persistent_key_destroy( int key_id_arg, int restart,
     PSA_ASSERT( psa_import_key( &attributes, second_data->x, second_data->len,
                                 &handle ) );
 
+    PSA_ASSERT( psa_destroy_key( handle ) );
+
 exit:
     PSA_DONE();
     psa_destroy_persistent_key( key_id );
@@ -205,6 +210,8 @@ void persistent_key_import( int key_id_arg, int type_arg, data_t *data,
     TEST_EQUAL( psa_get_key_type( &attributes ), type );
     TEST_EQUAL( psa_get_key_usage_flags( &attributes ), 0 );
     TEST_EQUAL( psa_get_key_algorithm( &attributes ), 0 );
+
+    PSA_ASSERT( psa_destroy_key( handle ) );
 
 exit:
     psa_reset_key_attributes( &attributes );

--- a/tests/suites/test_suite_psa_crypto_persistent_key.function
+++ b/tests/suites/test_suite_psa_crypto_persistent_key.function
@@ -110,7 +110,7 @@ void save_large_persistent_key( int data_too_large, int expected_status )
 
 exit:
     mbedtls_free( data );
-    mbedtls_psa_crypto_free();
+    PSA_DONE();
     psa_destroy_persistent_key( key_id );
 }
 /* END_CASE */
@@ -137,7 +137,7 @@ void persistent_key_destroy( int key_id_arg, int restart,
     if( restart )
     {
         psa_close_key( handle );
-        mbedtls_psa_crypto_free();
+        PSA_DONE();
         PSA_ASSERT( psa_crypto_init() );
         PSA_ASSERT( psa_open_key( key_id, &handle ) );
     }
@@ -152,7 +152,7 @@ void persistent_key_destroy( int key_id_arg, int restart,
     TEST_EQUAL( handle, 0 );
 
     /* Shutdown and restart */
-    mbedtls_psa_crypto_free();
+    PSA_DONE();
     PSA_ASSERT( psa_crypto_init() );
 
     /* Create another key in the same slot */
@@ -162,7 +162,7 @@ void persistent_key_destroy( int key_id_arg, int restart,
                                 &handle ) );
 
 exit:
-    mbedtls_psa_crypto_free();
+    PSA_DONE();
     psa_destroy_persistent_key( key_id );
 }
 /* END_CASE */
@@ -192,7 +192,7 @@ void persistent_key_import( int key_id_arg, int type_arg, data_t *data,
     if( restart )
     {
         psa_close_key( handle );
-        mbedtls_psa_crypto_free();
+        PSA_DONE();
         PSA_ASSERT( psa_crypto_init() );
         PSA_ASSERT( psa_open_key( key_id, &handle ) );
     }
@@ -209,7 +209,7 @@ void persistent_key_import( int key_id_arg, int type_arg, data_t *data,
 exit:
     psa_reset_key_attributes( &attributes );
     psa_destroy_persistent_key( key_id );
-    mbedtls_psa_crypto_free();
+    PSA_DONE();
 }
 /* END_CASE */
 
@@ -241,7 +241,7 @@ void import_export_persistent_key( data_t *data, int type_arg,
     if( restart )
     {
         psa_close_key( handle );
-        mbedtls_psa_crypto_free();
+        PSA_DONE();
         PSA_ASSERT( psa_crypto_init() );
         PSA_ASSERT( psa_open_key( key_id, &handle ) );
     }
@@ -276,7 +276,7 @@ void import_export_persistent_key( data_t *data, int type_arg,
 exit:
     psa_reset_key_attributes( &attributes );
     mbedtls_free( exported );
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
     psa_destroy_persistent_key( key_id );
 }
 /* END_CASE */

--- a/tests/suites/test_suite_psa_crypto_persistent_key.function
+++ b/tests/suites/test_suite_psa_crypto_persistent_key.function
@@ -1,7 +1,7 @@
 /* BEGIN_HEADER */
 #include <stdint.h>
 
-#include "psa_helpers.function"
+#include "psa_crypto_helpers.h"
 #include "psa_crypto_storage.h"
 
 #include "mbedtls/md.h"

--- a/tests/suites/test_suite_psa_crypto_slot_management.data
+++ b/tests/suites/test_suite_psa_crypto_slot_management.data
@@ -1,19 +1,31 @@
 Transient slot, check after closing
 transient_slot_lifecycle:0:0:PSA_KEY_TYPE_RAW_DATA:"0123456789abcdef0123456789abcdef":CLOSE_BY_CLOSE
 
+Transient slot, check after closing and restarting
+transient_slot_lifecycle:0:0:PSA_KEY_TYPE_RAW_DATA:"0123456789abcdef0123456789abcdef":CLOSE_BY_CLOSE_WITH_SHUTDOWN
+
 Transient slot, check after destroying
 transient_slot_lifecycle:0:0:PSA_KEY_TYPE_RAW_DATA:"0123456789abcdef0123456789abcdef":CLOSE_BY_DESTROY
 
-Transient slot, check after restart
+Transient slot, check after destroying and restarting
+transient_slot_lifecycle:0:0:PSA_KEY_TYPE_RAW_DATA:"0123456789abcdef0123456789abcdef":CLOSE_BY_DESTROY_WITH_SHUTDOWN
+
+Transient slot, check after restart with live handles
 transient_slot_lifecycle:0:0:PSA_KEY_TYPE_RAW_DATA:"0123456789abcdef0123456789abcdef":CLOSE_BY_SHUTDOWN
 
 Persistent slot, check after closing, id=min
 persistent_slot_lifecycle:PSA_KEY_LIFETIME_PERSISTENT:PSA_KEY_ID_USER_MIN:0:0:0:PSA_KEY_TYPE_RAW_DATA:"0123456789abcdef0123456789abcdef":CLOSE_BY_CLOSE
 
+Persistent slot, check after closing and restarting, id=min
+persistent_slot_lifecycle:PSA_KEY_LIFETIME_PERSISTENT:PSA_KEY_ID_USER_MIN:0:0:0:PSA_KEY_TYPE_RAW_DATA:"0123456789abcdef0123456789abcdef":CLOSE_BY_CLOSE
+
 Persistent slot, check after destroying, id=min
 persistent_slot_lifecycle:PSA_KEY_LIFETIME_PERSISTENT:PSA_KEY_ID_USER_MIN:0:0:0:PSA_KEY_TYPE_RAW_DATA:"0123456789abcdef0123456789abcdef":CLOSE_BY_DESTROY
 
-Persistent slot, check after restart, id=min
+Persistent slot, check after destroying and restarting, id=min
+persistent_slot_lifecycle:PSA_KEY_LIFETIME_PERSISTENT:PSA_KEY_ID_USER_MIN:0:0:0:PSA_KEY_TYPE_RAW_DATA:"0123456789abcdef0123456789abcdef":CLOSE_BY_DESTROY
+
+Persistent slot, check after restart with live handle, id=min
 persistent_slot_lifecycle:PSA_KEY_LIFETIME_PERSISTENT:PSA_KEY_ID_USER_MIN:0:0:0:PSA_KEY_TYPE_RAW_DATA:"0123456789abcdef0123456789abcdef":CLOSE_BY_SHUTDOWN
 
 Persistent slot, check after closing, id=max
@@ -29,6 +41,10 @@ Persistent slot: ECP keypair (ECDSA, exportable); close
 depends_on:MBEDTLS_ECDSA_C:MBEDTLS_ECP_DP_SECP256R1_ENABLED
 persistent_slot_lifecycle:PSA_KEY_LIFETIME_PERSISTENT:1:PSA_KEY_USAGE_EXPORT | PSA_KEY_USAGE_SIGN | PSA_KEY_USAGE_VERIFY:PSA_ALG_ECDSA_ANY:0:PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_CURVE_SECP256R1):"49c9a8c18c4b885638c431cf1df1c994131609b580d4fd43a0cab17db2f13eee":CLOSE_BY_CLOSE
 
+Persistent slot: ECP keypair (ECDSA, exportable); close+restart
+depends_on:MBEDTLS_ECDSA_C:MBEDTLS_ECP_DP_SECP256R1_ENABLED
+persistent_slot_lifecycle:PSA_KEY_LIFETIME_PERSISTENT:1:PSA_KEY_USAGE_EXPORT | PSA_KEY_USAGE_SIGN | PSA_KEY_USAGE_VERIFY:PSA_ALG_ECDSA_ANY:0:PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_CURVE_SECP256R1):"49c9a8c18c4b885638c431cf1df1c994131609b580d4fd43a0cab17db2f13eee":CLOSE_BY_CLOSE_WITH_SHUTDOWN
+
 Persistent slot: ECP keypair (ECDSA, exportable); restart
 depends_on:MBEDTLS_ECDSA_C:MBEDTLS_ECP_DP_SECP256R1_ENABLED
 persistent_slot_lifecycle:PSA_KEY_LIFETIME_PERSISTENT:1:PSA_KEY_USAGE_EXPORT | PSA_KEY_USAGE_SIGN | PSA_KEY_USAGE_VERIFY:PSA_ALG_ECDSA_ANY:0:PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_CURVE_SECP256R1):"49c9a8c18c4b885638c431cf1df1c994131609b580d4fd43a0cab17db2f13eee":CLOSE_BY_SHUTDOWN
@@ -36,6 +52,10 @@ persistent_slot_lifecycle:PSA_KEY_LIFETIME_PERSISTENT:1:PSA_KEY_USAGE_EXPORT | P
 Persistent slot: ECP keypair (ECDH+ECDSA, exportable); close
 depends_on:MBEDTLS_ECDH_C:MBEDTLS_SHA256_C:MBEDTLS_ECDSA_C:MBEDTLS_ECP_DP_SECP256R1_ENABLED
 persistent_slot_lifecycle:PSA_KEY_LIFETIME_PERSISTENT:1:PSA_KEY_USAGE_EXPORT | PSA_KEY_USAGE_SIGN | PSA_KEY_USAGE_VERIFY:PSA_ALG_KEY_AGREEMENT(PSA_ALG_ECDH, PSA_ALG_HKDF(PSA_ALG_SHA_256)):PSA_ALG_ECDSA_ANY:PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_CURVE_SECP256R1):"49c9a8c18c4b885638c431cf1df1c994131609b580d4fd43a0cab17db2f13eee":CLOSE_BY_CLOSE
+
+Persistent slot: ECP keypair (ECDH+ECDSA, exportable); close+restart
+depends_on:MBEDTLS_ECDH_C:MBEDTLS_SHA256_C:MBEDTLS_ECDSA_C:MBEDTLS_ECP_DP_SECP256R1_ENABLED
+persistent_slot_lifecycle:PSA_KEY_LIFETIME_PERSISTENT:1:PSA_KEY_USAGE_EXPORT | PSA_KEY_USAGE_SIGN | PSA_KEY_USAGE_VERIFY:PSA_ALG_KEY_AGREEMENT(PSA_ALG_ECDH, PSA_ALG_HKDF(PSA_ALG_SHA_256)):PSA_ALG_ECDSA_ANY:PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_CURVE_SECP256R1):"49c9a8c18c4b885638c431cf1df1c994131609b580d4fd43a0cab17db2f13eee":CLOSE_BY_CLOSE_WITH_SHUTDOWN
 
 Persistent slot: ECP keypair (ECDH+ECDSA, exportable); restart
 depends_on:MBEDTLS_ECDH_C:MBEDTLS_SHA256_C:MBEDTLS_ECDSA_C:MBEDTLS_ECP_DP_SECP256R1_ENABLED

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -6,9 +6,11 @@
 
 typedef enum
 {
-    CLOSE_BY_CLOSE,
-    CLOSE_BY_DESTROY,
-    CLOSE_BY_SHUTDOWN,
+    CLOSE_BY_CLOSE, /**< Close the handle(s). */
+    CLOSE_BY_DESTROY, /**< Destroy the handle(s). */
+    CLOSE_BY_SHUTDOWN, /**< Deinit and reinit without closing handles. */
+    CLOSE_BY_CLOSE_WITH_SHUTDOWN, /**< Close handle(s) then deinit/reinit. */
+    CLOSE_BY_DESTROY_WITH_SHUTDOWN, /**< Destroy handle(s) then deinit/reinit. */
 } close_method_t;
 
 typedef enum
@@ -62,6 +64,58 @@ static void psa_purge_key_storage( void )
 #define TEST_USES_KEY_ID( key_id ) ( (void) ( key_id ) )
 #endif /* MBEDTLS_PSA_CRYPTO_STORAGE_C */
 
+/** Apply \p close_method to invalidate the specified handles:
+ * close it, destroy it, or do nothing;
+ */
+static int invalidate_handle( close_method_t close_method,
+                              psa_key_handle_t handle )
+{
+    switch( close_method )
+    {
+        case CLOSE_BY_CLOSE:
+        case CLOSE_BY_CLOSE_WITH_SHUTDOWN:
+            PSA_ASSERT( psa_close_key( handle ) );
+            break;
+        case CLOSE_BY_DESTROY:
+        case CLOSE_BY_DESTROY_WITH_SHUTDOWN:
+            PSA_ASSERT( psa_destroy_key( handle ) );
+            break;
+        case CLOSE_BY_SHUTDOWN:
+            break;
+    }
+    return( 1 );
+exit:
+    return( 0 );
+}
+
+/** Restart the PSA subsystem if \p close_method says so. */
+static int invalidate_psa( close_method_t close_method )
+{
+    switch( close_method )
+    {
+        case CLOSE_BY_CLOSE:
+        case CLOSE_BY_DESTROY:
+            return( 1 );
+        case CLOSE_BY_CLOSE_WITH_SHUTDOWN:
+        case CLOSE_BY_DESTROY_WITH_SHUTDOWN:
+            /* All keys must have been closed. */
+            PSA_DONE( );
+            break;
+        case CLOSE_BY_SHUTDOWN:
+            /* Some keys may remain behind, and we're testing that this
+             * properly closes them. */
+            mbedtls_psa_crypto_free( );
+            break;
+    }
+
+    PSA_ASSERT( psa_crypto_init( ) );
+    ASSERT_PSA_PRISTINE( );
+    return( 1 );
+
+exit:
+    return( 0 );
+}
+
 /* END_HEADER */
 
 /* BEGIN_DEPENDENCIES
@@ -94,19 +148,10 @@ void transient_slot_lifecycle( int usage_arg, int alg_arg,
     TEST_EQUAL( psa_get_key_type( &attributes ), type );
 
     /* Do something that invalidates the handle. */
-    switch( close_method )
-    {
-        case CLOSE_BY_CLOSE:
-            PSA_ASSERT( psa_close_key( handle ) );
-            break;
-        case CLOSE_BY_DESTROY:
-            PSA_ASSERT( psa_destroy_key( handle ) );
-            break;
-        case CLOSE_BY_SHUTDOWN:
-            PSA_DONE( );
-            PSA_ASSERT( psa_crypto_init( ) );
-            break;
-    }
+    if( ! invalidate_handle( close_method, handle ) )
+        goto exit;
+    if( ! invalidate_psa( close_method ) )
+        goto exit;
 
     /* Test that the handle is now invalid. */
     TEST_EQUAL( psa_get_key_attributes( handle, &attributes ),
@@ -171,19 +216,11 @@ void persistent_slot_lifecycle( int lifetime_arg, int id_arg,
     TEST_EQUAL( psa_get_key_type( &attributes ), type );
 
     /* Do something that invalidates the handle. */
-    switch( close_method )
-    {
-        case CLOSE_BY_CLOSE:
-            PSA_ASSERT( psa_close_key( handle ) );
-            break;
-        case CLOSE_BY_DESTROY:
-            PSA_ASSERT( psa_destroy_key( handle ) );
-            break;
-        case CLOSE_BY_SHUTDOWN:
-            PSA_DONE( );
-            PSA_ASSERT( psa_crypto_init( ) );
-            break;
-    }
+    if( ! invalidate_handle( close_method, handle ) )
+        goto exit;
+    if( ! invalidate_psa( close_method ) )
+        goto exit;
+
     /* Test that the handle is now invalid. */
     TEST_EQUAL( psa_get_key_attributes( handle, &read_attributes ),
                 PSA_ERROR_INVALID_HANDLE );
@@ -196,6 +233,7 @@ void persistent_slot_lifecycle( int lifetime_arg, int id_arg,
     switch( close_method )
     {
         case CLOSE_BY_CLOSE:
+        case CLOSE_BY_CLOSE_WITH_SHUTDOWN:
         case CLOSE_BY_SHUTDOWN:
             PSA_ASSERT( psa_open_key( id, &handle ) );
             PSA_ASSERT( psa_get_key_attributes( handle, &read_attributes ) );
@@ -230,7 +268,9 @@ void persistent_slot_lifecycle( int lifetime_arg, int id_arg,
             }
             PSA_ASSERT( psa_close_key( handle ) );
             break;
+
         case CLOSE_BY_DESTROY:
+        case CLOSE_BY_DESTROY_WITH_SHUTDOWN:
             TEST_EQUAL( psa_open_key( id, &handle ),
                         PSA_ERROR_DOES_NOT_EXIST );
             break;

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -1,11 +1,7 @@
 /* BEGIN_HEADER */
 #include <stdint.h>
 
-#if defined(MBEDTLS_PSA_CRYPTO_SPM)
-#include "spm/psa_defs.h"
-#endif
-#include "psa/crypto.h"
-
+#include "psa_helpers.function"
 #include "psa_crypto_storage.h"
 
 typedef enum

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -228,6 +228,7 @@ void persistent_slot_lifecycle( int lifetime_arg, int id_arg,
                                             &reexported_length ),
                             PSA_ERROR_NOT_PERMITTED );
             }
+            PSA_ASSERT( psa_close_key( handle ) );
             break;
         case CLOSE_BY_DESTROY:
             TEST_EQUAL( psa_open_key( id, &handle ),
@@ -301,6 +302,8 @@ void create_existent( int lifetime_arg, int id_arg,
                                 &reexported_length ) );
     ASSERT_COMPARE( material1, sizeof( material1 ),
                     reexported, reexported_length );
+
+    PSA_ASSERT( psa_close_key( handle1 ) );
 
 exit:
     PSA_DONE( );
@@ -428,7 +431,7 @@ void copy_across_lifetimes( int source_lifetime_arg, int source_id_arg,
      * sure that the material is still alive. */
     if( target_lifetime != PSA_KEY_LIFETIME_VOLATILE )
     {
-        PSA_DONE( );
+        mbedtls_psa_crypto_free( );
         PSA_ASSERT( psa_crypto_init( ) );
         PSA_ASSERT( psa_open_key( target_id, &target_handle ) );
     }
@@ -462,6 +465,8 @@ void copy_across_lifetimes( int source_lifetime_arg, int source_id_arg,
                                     material->len, &length ),
                     PSA_ERROR_NOT_PERMITTED );
     }
+
+    PSA_ASSERT( psa_destroy_key( target_handle ) );
 
 exit:
     PSA_DONE( );
@@ -565,6 +570,10 @@ void copy_to_occupied( int source_lifetime_arg, int source_id_arg,
         ASSERT_COMPARE( target_material->x, target_material->len,
                         export_buffer, length );
     }
+
+    PSA_ASSERT( psa_destroy_key( source_handle ) );
+    if( target_handle != source_handle )
+        PSA_ASSERT( psa_destroy_key( target_handle ) );
 
 exit:
     PSA_DONE( );

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -103,7 +103,7 @@ void transient_slot_lifecycle( int usage_arg, int alg_arg,
             PSA_ASSERT( psa_destroy_key( handle ) );
             break;
         case CLOSE_BY_SHUTDOWN:
-            mbedtls_psa_crypto_free( );
+            PSA_DONE( );
             PSA_ASSERT( psa_crypto_init( ) );
             break;
     }
@@ -114,7 +114,7 @@ void transient_slot_lifecycle( int usage_arg, int alg_arg,
     TEST_EQUAL( psa_close_key( handle ), PSA_ERROR_INVALID_HANDLE );
 
 exit:
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -180,7 +180,7 @@ void persistent_slot_lifecycle( int lifetime_arg, int id_arg,
             PSA_ASSERT( psa_destroy_key( handle ) );
             break;
         case CLOSE_BY_SHUTDOWN:
-            mbedtls_psa_crypto_free( );
+            PSA_DONE( );
             PSA_ASSERT( psa_crypto_init( ) );
             break;
     }
@@ -236,7 +236,7 @@ void persistent_slot_lifecycle( int lifetime_arg, int id_arg,
     }
 
 exit:
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
     psa_purge_key_storage( );
     mbedtls_free( reexported );
 }
@@ -303,7 +303,7 @@ void create_existent( int lifetime_arg, int id_arg,
                     reexported, reexported_length );
 
 exit:
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
     psa_purge_key_storage( );
 }
 /* END_CASE */
@@ -322,7 +322,7 @@ void open_fail( int id_arg,
     TEST_EQUAL( handle, 0 );
 
 exit:
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -350,7 +350,7 @@ void create_fail( int lifetime_arg, int id_arg,
     TEST_EQUAL( handle, 0 );
 
 exit:
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 #if defined(MBEDTLS_PSA_CRYPTO_STORAGE_C)
     psa_purge_key_storage( );
 #endif
@@ -428,7 +428,7 @@ void copy_across_lifetimes( int source_lifetime_arg, int source_id_arg,
      * sure that the material is still alive. */
     if( target_lifetime != PSA_KEY_LIFETIME_VOLATILE )
     {
-        mbedtls_psa_crypto_free( );
+        PSA_DONE( );
         PSA_ASSERT( psa_crypto_init( ) );
         PSA_ASSERT( psa_open_key( target_id, &target_handle ) );
     }
@@ -464,7 +464,7 @@ void copy_across_lifetimes( int source_lifetime_arg, int source_id_arg,
     }
 
 exit:
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
     mbedtls_free( export_buffer );
 #if defined(MBEDTLS_PSA_CRYPTO_STORAGE_C)
     psa_purge_key_storage( );
@@ -567,7 +567,7 @@ void copy_to_occupied( int source_lifetime_arg, int source_id_arg,
     }
 
 exit:
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
     mbedtls_free( export_buffer );
 #if defined(MBEDTLS_PSA_CRYPTO_STORAGE_C)
     psa_purge_key_storage( );
@@ -609,7 +609,7 @@ void invalid_handle( )
     PSA_ASSERT( psa_close_key( handle1 ) );
 
 exit:
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
 }
 /* END_CASE */
 
@@ -657,7 +657,7 @@ void many_transient_handles( int max_handles_arg )
     PSA_ASSERT( psa_close_key( handles[i - 1] ) );
 
 exit:
-    mbedtls_psa_crypto_free( );
+    PSA_DONE( );
     mbedtls_free( handles );
 }
 /* END_CASE */

--- a/tests/suites/test_suite_psa_crypto_slot_management.function
+++ b/tests/suites/test_suite_psa_crypto_slot_management.function
@@ -1,7 +1,7 @@
 /* BEGIN_HEADER */
 #include <stdint.h>
 
-#include "psa_helpers.function"
+#include "psa_crypto_helpers.h"
 #include "psa_crypto_storage.h"
 
 typedef enum

--- a/tests/suites/test_suite_psa_its.function
+++ b/tests/suites/test_suite_psa_its.function
@@ -1,6 +1,8 @@
 /* BEGIN_HEADER */
 #include "../library/psa_crypto_its.h"
 
+#define PSA_ASSERT( expr ) TEST_EQUAL( ( expr ), PSA_SUCCESS )
+
 /* Internal definitions of the implementation, copied for the sake of
  * some of the tests and of the cleanup code. */
 #define PSA_ITS_STORAGE_PREFIX ""

--- a/tests/suites/test_suite_psa_its.function
+++ b/tests/suites/test_suite_psa_its.function
@@ -1,7 +1,7 @@
 /* BEGIN_HEADER */
 #include "../library/psa_crypto_its.h"
 
-#define PSA_ASSERT( expr ) TEST_EQUAL( ( expr ), PSA_SUCCESS )
+#include "psa_helpers.h"
 
 /* Internal definitions of the implementation, copied for the sake of
  * some of the tests and of the cleanup code. */


### PR DESCRIPTION
We have infrastructure in place to test that `mbedtls_psa_crypto_free` frees all resources (run the tests with a memory leak detector such as ASan). But in the real world this function is called rarely if ever. What matters is that functions like `psa_close_key` and `psa_destroy_key` free the resources used by the key.

This PR adds a check that the key slot array is empty before closing `mbedtls_psa_crypto_free` at the end of each test. A few tests call `mbedtls_psa_crypto_free` with open handles and verify (when run under ASan) that that this does free the resources occupied by those keys.

As a byproduct, this PR adds a function that Mbed Crypto users can call to know how many key slots are available, in use, etc.

Status: ready ~~successor to https://github.com/ARMmbed/mbed-crypto/pull/131 . The first new commit is 1287739ce9a9748846deb6d01cd35ce7a439f9d5 “Create PSA-specific helper function file”.~~