### PR TITLE
Add docker-based test scripts

### DIFF
--- a/tests/docker/bionic/Dockerfile
+++ b/tests/docker/bionic/Dockerfile
@@ -1,0 +1,59 @@
+# Dockerfile
+#
+# Purpose
+# -------
+# Defines a Docker container suitable to build and run all tests (all.sh),
+# except for those that use a proprietary toolchain.
+
+# Copyright (C) 2006-2019, Arm Limited (or its affiliates), All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This file is part of Mbed TLS (https://tls.mbed.org)
+
+FROM ubuntu:bionic
+
+ARG MAKEFLAGS_PARALLEL=""
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt update \
+    && apt -y install software-properties-common \
+    && rm -rf /var/lib/apt/lists
+
+RUN add-apt-repository -y ppa:team-gcc-arm-embedded/ppa
+
+RUN apt-get update \
+    && apt-get -y install \
+    build-essential \
+    clang \
+    cmake \
+    doxygen \
+    gcc-arm-none-eabi \
+    gcc-mingw-w64-i686 \
+    gcc-multilib \
+    g++-multilib \
+    gdb \
+    git \
+    graphviz \
+    python \
+    python3-pip \
+    python3 \
+    pylint3 \
+    valgrind \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install --no-cache-dir \
+    mbed-host-tests \
+    mock

--- a/tests/make-in-docker.sh
+++ b/tests/make-in-docker.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -eu
+
+# make-in-docker.sh
+#
+# Purpose
+# -------
+# This runs make in a Docker container.
+#
+# See also:
+# - scripts/docker_env.sh for general Docker prerequisites and other information.
+
+# Copyright (C) 2006-2019, Arm Limited (or its affiliates), All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This file is part of Mbed TLS (https://tls.mbed.org)
+
+source tests/scripts/docker_env.sh
+
+run_in_docker make $@

--- a/tests/scripts/all-in-docker.sh
+++ b/tests/scripts/all-in-docker.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -eu
+
+# all-in-docker.sh
+#
+# Purpose
+# -------
+# This runs all.sh (except for armcc) in a Docker container.
+#
+# Notes for users
+# ---------------
+# See docker_env.sh for prerequisites and other information.
+#
+# See also all.sh for notes about invocation of that script.
+
+# Copyright (C) 2006-2019, Arm Limited (or its affiliates), All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This file is part of Mbed TLS (https://tls.mbed.org)
+
+source tests/scripts/docker_env.sh
+
+# Run tests that are possible with openly available compilers
+run_in_docker tests/scripts/all.sh \
+    --no-armcc \
+    $@

--- a/tests/scripts/basic-in-docker.sh
+++ b/tests/scripts/basic-in-docker.sh
@@ -1,0 +1,50 @@
+#!/bin/bash -eu
+
+# basic-in-docker.sh
+#
+# Purpose
+# -------
+# This runs a rough equivalent of the travis.yml in a Docker container.
+# The tests are run for both clang and gcc.
+#
+# Notes for users
+# ---------------
+# See docker_env.sh for prerequisites and other information.
+
+# Copyright (C) 2006-2019, Arm Limited (or its affiliates), All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This file is part of Mbed TLS (https://tls.mbed.org)
+
+source tests/scripts/docker_env.sh
+
+run_in_docker tests/scripts/recursion.pl library/*.c
+run_in_docker tests/scripts/check-generated-files.sh
+run_in_docker tests/scripts/check-doxy-blocks.pl
+run_in_docker tests/scripts/check-names.sh
+run_in_docker tests/scripts/check-files.py
+run_in_docker tests/scripts/doxygen.sh
+
+for compiler in clang gcc; do
+    run_in_docker -e CC=${compiler} cmake -D CMAKE_BUILD_TYPE:String="Check" .
+    run_in_docker -e CC=${compiler} make
+    run_in_docker -e CC=${compiler} make test
+    run_in_docker programs/test/selftest
+    run_in_docker -e OSSL_NO_DTLS=1 tests/compat.sh
+    run_in_docker tests/ssl-opt.sh -e '\(DTLS\|SCSV\).*openssl'
+    run_in_docker tests/scripts/test-ref-configs.pl
+    run_in_docker tests/scripts/curves.pl
+    run_in_docker tests/scripts/key-exchanges.pl
+done

--- a/tests/scripts/docker_env.sh
+++ b/tests/scripts/docker_env.sh
@@ -1,0 +1,88 @@
+#!/bin/bash -eu
+
+# docker_env.sh
+#
+# Purpose
+# -------
+#
+# This is a helper script to enable running tests under a Docker container,
+# thus making it easier to get set up as well as isolating test dependencies
+# (which include legacy/insecure configurations of openssl and gnutls).
+#
+# Notes for users
+# ---------------
+# This script expects a Linux x86_64 system with a recent version of Docker
+# installed and available for use, as well as http/https access. If a proxy
+# server must be used, invoke this script with the usual environment variables
+# (http_proxy and https_proxy) set appropriately.
+#
+# Running this script directly will check for Docker availability and set up
+# the Docker image.
+
+# Copyright (C) 2006-2019, Arm Limited (or its affiliates), All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This file is part of Mbed TLS (https://tls.mbed.org)
+
+
+# default values, can be overridden by the environment
+: ${MBEDCRYPTO_DOCKER_GUEST:=bionic}
+
+
+DOCKER_IMAGE_TAG="armmbed/mbedcrypto-test:${MBEDCRYPTO_DOCKER_GUEST}"
+
+# Make sure docker is available
+if ! which docker > /dev/null; then
+    echo "Docker is required but doesn't seem to be installed. See https://www.docker.com/ to get started"
+    exit 1
+fi
+
+# Figure out if we need to 'sudo docker'
+if groups | grep docker > /dev/null; then
+    DOCKER="docker"
+else
+    echo "Using sudo to invoke docker since you're not a member of the docker group..."
+    DOCKER="sudo docker"
+fi
+
+# Build the Docker image
+echo "Getting docker image up to date (this may take a few minutes)..."
+${DOCKER} image build \
+    -t ${DOCKER_IMAGE_TAG} \
+    --cache-from=${DOCKER_IMAGE_TAG} \
+    --build-arg MAKEFLAGS_PARALLEL="-j $(nproc)" \
+    ${http_proxy+--build-arg http_proxy=${http_proxy}} \
+    ${https_proxy+--build-arg https_proxy=${https_proxy}} \
+    tests/docker/${MBEDCRYPTO_DOCKER_GUEST}
+
+run_in_docker()
+{
+    ENV_ARGS=""
+    while [ "$1" == "-e" ]; do
+        ENV_ARGS="${ENV_ARGS} $1 $2"
+        shift 2
+    done
+
+    ${DOCKER} container run -it --rm \
+        --cap-add SYS_PTRACE \
+        --user "$(id -u):$(id -g)" \
+        --volume $PWD:$PWD \
+        --workdir $PWD \
+        -e MAKEFLAGS \
+        -e PYLINTHOME=/tmp/.pylintd \
+        ${ENV_ARGS} \
+        ${DOCKER_IMAGE_TAG} \
+        $@
+}


### PR DESCRIPTION
Enable running tests under Docker. This makes it easier to spin up an environment with all dependencies.
* tests/docker/bionic/Dockerfile: Definition for the docker image.
* tests/scripts/docker_env.sh: New helper script that creates the Docker image and has a function to run a command in the Docker container.
* tests/docker/all-in-docker.sh: Wrapper for all.sh under Docker.
* tests/docker/basic-in-docker.sh: Script that runs the same commands as .travis.yml, in Docker.
* tests/make-in-docker.sh: Wrapper to run make in Docker.

Design and implementation are a port of ARMmbed/mbedtls#2314, but with the SSL-specific bits removed.

This resolves #135.