### PR TITLE
psa: Use PSA as an entropy source on PSA NSPEs

### DIFF
--- a/include/mbedtls/entropy_poll.h
+++ b/include/mbedtls/entropy_poll.h
@@ -54,6 +54,15 @@ extern "C" {
                                 unsigned char *output, size_t len, size_t *olen );
 #endif
 
+#if defined(MBEDTLS_PSA_CRYPTO_C) && defined(COMPONENT_NSPE)
+/**
+ * \brief           Entropy poll callback that uses PSA SPE as an entropy
+ *                  source.
+ */
+int mbedtls_psa_entropy_poll( void *data, unsigned char *output,
+                              size_t len, size_t *olen );
+#endif
+
 #if !defined(MBEDTLS_NO_PLATFORM_ENTROPY)
 /**
  * \brief           Platform-specific entropy poll callback

--- a/library/entropy.c
+++ b/library/entropy.c
@@ -89,6 +89,15 @@ void mbedtls_entropy_init( mbedtls_entropy_context *ctx )
                                 1, MBEDTLS_ENTROPY_SOURCE_STRONG );
 #endif
 
+    /* Use PSA generate random as an entropy source for Mbed TLS DRBGs on PSA
+     * NSPE. This provides a backwards compatible (with pre-PSA Crypto API
+     * applications) source of entropy on PSA NSPE targets. */
+#if defined(MBEDTLS_PSA_CRYPTO_C) && defined(COMPONENT_NSPE)
+    mbedtls_entropy_add_source( ctx, mbedtls_psa_entropy_poll, NULL,
+                                MBEDTLS_ENTROPY_BLOCK_SIZE,
+                                MBEDTLS_ENTROPY_SOURCE_STRONG );
+#endif
+
 #if !defined(MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES)
 #if !defined(MBEDTLS_NO_PLATFORM_ENTROPY)
     mbedtls_entropy_add_source( ctx, mbedtls_platform_entropy_poll, NULL,

--- a/library/entropy_poll.c
+++ b/library/entropy_poll.c
@@ -30,6 +30,10 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#if defined(MBEDTLS_PSA_CRYPTO_C)
+#include "psa/crypto.h"
+#endif
+
 #include <string.h>
 
 #if defined(MBEDTLS_ENTROPY_C)
@@ -171,6 +175,27 @@ int mbedtls_null_entropy_poll( void *data,
         return( 0 );
 
     *olen = sizeof(unsigned char);
+
+    return( 0 );
+}
+#endif
+
+#if defined(MBEDTLS_PSA_CRYPTO_C) && defined(COMPONENT_NSPE)
+int mbedtls_psa_entropy_poll( void *data, unsigned char *output,
+                              size_t len, size_t *olen )
+{
+    (void) data;
+    psa_status_t status;
+
+    *olen = 0;
+
+    status = psa_generate_random(output, len);
+    if (status != PSA_SUCCESS)
+    {
+        return( MBEDTLS_ERR_ENTROPY_SOURCE_FAILED );
+    }
+
+    *olen = len;
 
     return( 0 );
 }


### PR DESCRIPTION
For NSPEs that still run Mbed TLS DRBG code, without any other source of
NS entropy, it's useful to use a PSA SPE as a source of entropy. For
example, a PSA SPE may have exclusive access to a hardware TRNG, leaving
the PSA NSPE with no source of entropy. In order to provide backwards
compatibility with applications that use Mbed TLS DRBG code, make the
PSA random generator be a source of entropy for the PSA NSPE.