### PR TITLE
Fix misuse of signed ints in the HAVEGE module

### DIFF
--- a/include/mbedtls/havege.h
+++ b/include/mbedtls/havege.h
@@ -31,6 +31,7 @@
 #endif
 
 #include <stddef.h>
+#include <stdint.h>
 
 #define MBEDTLS_HAVEGE_COLLECT_SIZE 1024
 
@@ -43,9 +44,9 @@ extern "C" {
  */
 typedef struct mbedtls_havege_state
 {
-    int PT1, PT2, offset[2];
-    int pool[MBEDTLS_HAVEGE_COLLECT_SIZE];
-    int WALK[8192];
+    uint32_t PT1, PT2, offset[2];
+    uint32_t pool[MBEDTLS_HAVEGE_COLLECT_SIZE];
+    uint32_t WALK[8192];
 }
 mbedtls_havege_state;
 

--- a/library/havege.c
+++ b/library/havege.c
@@ -38,6 +38,7 @@
 #include "mbedtls/timing.h"
 #include "mbedtls/platform_util.h"
 
+#include <stdint.h>
 #include <string.h>
 
 /* ------------------------------------------------------------------------
@@ -54,7 +55,7 @@
  * ------------------------------------------------------------------------
  */
 
-#define SWAP(X,Y) { int *T = (X); (X) = (Y); (Y) = T; }
+#define SWAP(X,Y) { uint32_t *T = (X); (X) = (Y); (Y) = T; }
 
 #define TST1_ENTER if( PTEST & 1 ) { PTEST ^= 3; PTEST >>= 1;
 #define TST2_ENTER if( PTEST & 1 ) { PTEST ^= 3; PTEST >>= 1;
@@ -77,7 +78,7 @@
     PTX = (PT1 >> 18) & 7;                              \
     PT1 &= 0x1FFF;                                      \
     PT2 &= 0x1FFF;                                      \
-    CLK = (int) mbedtls_timing_hardclock();                            \
+    CLK = (uint32_t) mbedtls_timing_hardclock();        \
                                                         \
     i = 0;                                              \
     A = &WALK[PT1    ]; RES[i++] ^= *A;                 \
@@ -100,7 +101,7 @@
                                                         \
     IN = (*A >> (5)) ^ (*A << (27)) ^ CLK;              \
     *A = (*B >> (6)) ^ (*B << (26)) ^ CLK;              \
-    *B = IN; CLK = (int) mbedtls_timing_hardclock();                   \
+    *B = IN; CLK = (uint32_t) mbedtls_timing_hardclock();       \
     *C = (*C >> (7)) ^ (*C << (25)) ^ CLK;              \
     *D = (*D >> (8)) ^ (*D << (24)) ^ CLK;              \
                                                         \
@@ -158,10 +159,11 @@
  */
 static void havege_fill( mbedtls_havege_state *hs )
 {
-    int i, n = 0;
-    int  U1,  U2, *A, *B, *C, *D;
-    int PT1, PT2, *WALK, RES[16];
-    int PTX, PTY, CLK, PTEST, IN;
+    size_t n = 0;
+    unsigned i;
+    uint32_t  U1,  U2, *A, *B, *C, *D;
+    uint32_t PT1, PT2, *WALK, RES[16];
+    uint32_t PTX, PTY, CLK, PTEST, IN;
 
     WALK = hs->WALK;
     PT1  = hs->PT1;
@@ -212,7 +214,7 @@ void mbedtls_havege_free( mbedtls_havege_state *hs )
  */
 int mbedtls_havege_random( void *p_rng, unsigned char *buf, size_t len )
 {
-    int val;
+    uint32_t val;
     size_t use_len;
     mbedtls_havege_state *hs = (mbedtls_havege_state *) p_rng;
     unsigned char *p = buf;
@@ -220,8 +222,8 @@ int mbedtls_havege_random( void *p_rng, unsigned char *buf, size_t len )
     while( len > 0 )
     {
         use_len = len;
-        if( use_len > sizeof(int) )
-            use_len = sizeof(int);
+        if( use_len > sizeof( val ) )
+            use_len = sizeof( val );
 
         if( hs->offset[1] >= MBEDTLS_HAVEGE_COLLECT_SIZE )
             havege_fill( hs );

--- a/library/havege.c
+++ b/library/havege.c
@@ -160,7 +160,7 @@
 static void havege_fill( mbedtls_havege_state *hs )
 {
     size_t n = 0;
-    unsigned i;
+    size_t i;
     uint32_t  U1,  U2, *A, *B, *C, *D;
     uint32_t PT1, PT2, *WALK, RES[16];
     uint32_t PTX, PTY, CLK, PTEST, IN;


### PR DESCRIPTION
The elements of the HAVEGE state are manipulated with bitwise operations, with the expectations that the elements are 32-bit unsigned integers (or larger). But they are declared as `int`, and so the code has undefined behavior. Clang with Asan correctly points out some shifts that reach the sign bit.

Since these are supposed to be 32-bit unsigned integers, declare them as `uint32_t`.

This is technically an API break, since the type `mbedtls_havege_state` is exposed in a public header. However normal applications should not be affected.

Fix https://github.com/ARMmbed/mbedtls/issues/2598

PR extracted from https://github.com/ARMmbed/mbed-crypto/pull/144 which combined this with other things needed to pass Clang+Asan with all configuration options.

When this PR is merged, it'll break the build in mbedtls due to the incompatible change in `havege.h` (this is what I mean by the label "needs: preceding PR"). https://github.com/ARMmbed/mbedtls/pull/2699 will be needed to repair the build, so the merge of these two PRs should be coordinated.
