### PR TITLE
Enable use of Mbed TLS and Mbed Crypto as a CMake subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ else()
     project("mbed TLS" C)
 endif()
 
+# Set the project root directory.
+set(MBEDTLS_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
 option(ENABLE_PROGRAMS "Build mbed TLS programs." ON)
 
 option(UNSAFE_BUILD "Allow unsafe builds. These builds ARE NOT SECURE." OFF)

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -2,6 +2,13 @@ option(USE_STATIC_MBEDTLS_LIBRARY "Build mbed TLS static library." ON)
 option(USE_SHARED_MBEDTLS_LIBRARY "Build mbed TLS shared library." OFF)
 option(LINK_WITH_PTHREAD "Explicitly link mbed TLS library to pthread." OFF)
 
+# Set the project root directory if it's not already defined, as may happen if
+# the library folder is included directly by a parent project, without
+# including the top level CMakeLists.txt.
+if(NOT DEFINED MBEDTLS_DIR)
+    set(MBEDTLS_DIR ${CMAKE_SOURCE_DIR})
+endif()
+
 set(src_crypto
     aes.c
     aesni.c
@@ -72,9 +79,9 @@ set(src_crypto
 if(USE_CRYPTO_SUBMODULE)
 set(src_crypto
     ${src_crypto}
-    ${CMAKE_SOURCE_DIR}/library/version.c
-    ${CMAKE_SOURCE_DIR}/library/version_features.c
-    ${CMAKE_SOURCE_DIR}/library/error.c
+    ${MBEDTLS_DIR}/library/version.c
+    ${MBEDTLS_DIR}/library/version_features.c
+    ${MBEDTLS_DIR}/library/error.c
 )
 else()
 set(src_crypto
@@ -133,8 +140,8 @@ if(USE_STATIC_MBEDTLS_LIBRARY)
     set_target_properties(${mbedcrypto_static_target} PROPERTIES OUTPUT_NAME mbedcrypto)
     target_link_libraries(${mbedcrypto_static_target} ${libs})
     target_include_directories(${mbedcrypto_static_target}
-        PUBLIC ${CMAKE_SOURCE_DIR}/include/
-        PUBLIC ${CMAKE_SOURCE_DIR}/crypto/include/)
+        PUBLIC ${MBEDTLS_DIR}/include/
+        PUBLIC ${MBEDTLS_DIR}/crypto/include/)
 
     install(TARGETS ${mbedcrypto_static_target}
             DESTINATION ${LIB_INSTALL_DIR}
@@ -146,8 +153,8 @@ if(USE_SHARED_MBEDTLS_LIBRARY)
     set_target_properties(mbedcrypto PROPERTIES VERSION 2.17.0 SOVERSION 3)
     target_link_libraries(mbedcrypto ${libs})
     target_include_directories(mbedcrypto
-        PUBLIC ${CMAKE_SOURCE_DIR}/include/
-        PUBLIC ${CMAKE_SOURCE_DIR}/crypto/include/)
+        PUBLIC ${MBEDTLS_DIR}/include/
+        PUBLIC ${MBEDTLS_DIR}/crypto/include/)
 
     install(TARGETS mbedcrypto
             DESTINATION ${LIB_INSTALL_DIR}

--- a/programs/test/cmake_subproject/.gitignore
+++ b/programs/test/cmake_subproject/.gitignore
@@ -1,0 +1,3 @@
+build
+Makefile
+cmake_subproject

--- a/programs/test/cmake_subproject/CMakeLists.txt
+++ b/programs/test/cmake_subproject/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 2.6)
+
+# We use the parent Mbed TLS directory as the MBEDTLS_DIR for this test. Other
+# projects that use Mbed TLS as a subproject are likely to add by their own
+# relative paths.
+set(MBEDTLS_DIR ../../../)
+
+# Add Mbed TLS as a subdirectory.
+add_subdirectory(${MBEDTLS_DIR} build)
+
+# Link against the Mbed Crypto library.
+set(libs
+    mbedcrypto
+)
+
+add_executable(cmake_subproject cmake_subproject.c)
+target_link_libraries(cmake_subproject ${libs})

--- a/programs/test/cmake_subproject/cmake_subproject.c
+++ b/programs/test/cmake_subproject/cmake_subproject.c
@@ -1,0 +1,56 @@
+/*
+ *  Simple program to test that CMake builds with Mbed TLS as a subdirectory
+ *  work correctly.
+ *
+ *  Copyright (C) 2006-2019, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "mbedtls/config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#if defined(MBEDTLS_PLATFORM_C)
+#include "mbedtls/platform.h"
+#else
+#include <stdio.h>
+#include <stdlib.h>
+#define mbedtls_fprintf         fprintf
+#define mbedtls_printf          printf
+#define mbedtls_exit            exit
+#define MBEDTLS_EXIT_SUCCESS    EXIT_SUCCESS
+#define MBEDTLS_EXIT_FAILURE    EXIT_FAILURE
+#endif /* MBEDTLS_PLATFORM_C */
+
+#include "mbedtls/version.h"
+
+/* The main reason to build this is for testing the CMake build, so the program
+ * doesn't need to do very much. It calls a single library function to ensure
+ * linkage works, but that is all. */
+int main()
+{
+    /* This version string is 18 bytes long, as advised by version.h. */
+    char version[18];
+
+    mbedtls_version_get_string_full( version );
+
+    mbedtls_printf( "Built against %s\n", version );
+
+    return( 0 );
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,7 +52,7 @@ function(add_test_suite suite_name)
     target_include_directories(${exe_name}
         PUBLIC ${MBEDTLS_DIR}/include/
         PUBLIC ${MBEDTLS_DIR}/crypto/include/
-        PRIVATE ${MBEDTLS_DIR}/crypto/library/)
+        PUBLIC ${MBEDTLS_DIR}/crypto/library/)
 
     if(${data_name} MATCHES ${SKIP_TEST_SUITES_REGEX})
         message(STATUS "The test suite ${data_name} will not be executed.")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,13 @@ set(libs
     mbedcrypto
 )
 
+# Set the project root directory if it's not already defined, as may happen if
+# the tests folder is included directly by a parent project, without including
+# the top level CMakeLists.txt.
+if(NOT DEFINED MBEDTLS_DIR)
+    set(MBEDTLS_DIR ${CMAKE_SOURCE_DIR})
+endif()
+
 find_package(Perl)
 if(NOT PERL_FOUND)
     message(FATAL_ERROR "Cannot build test suites without Perl")
@@ -43,9 +50,9 @@ function(add_test_suite suite_name)
     add_executable(${exe_name} test_suite_${data_name}.c)
     target_link_libraries(${exe_name} ${libs})
     target_include_directories(${exe_name}
-        PUBLIC ${CMAKE_SOURCE_DIR}/include/
-        PUBLIC ${CMAKE_SOURCE_DIR}/crypto/include/
-        PRIVATE ${CMAKE_SOURCE_DIR}/crypto/library/)
+        PUBLIC ${MBEDTLS_DIR}/include/
+        PUBLIC ${MBEDTLS_DIR}/crypto/include/
+        PRIVATE ${MBEDTLS_DIR}/crypto/library/)
 
     if(${data_name} MATCHES ${SKIP_TEST_SUITES_REGEX})
         message(STATUS "The test suite ${data_name} will not be executed.")

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -218,6 +218,11 @@ cleanup()
     git update-index --no-skip-worktree Makefile library/Makefile programs/Makefile tests/Makefile
     git checkout -- Makefile library/Makefile programs/Makefile tests/Makefile
 
+    # Remove any artifacts from the component_test_cmake_as_subdirectory test.
+    rm -rf programs/test/cmake_subproject/build
+    rm -f programs/test/cmake_subproject/Makefile
+    rm -f programs/test/cmake_subproject/cmake_subproject
+
     if [ -f "$CONFIG_BAK" ]; then
         mv "$CONFIG_BAK" "$CONFIG_H"
     fi
@@ -1043,6 +1048,19 @@ component_test_cmake_out_of_source () {
 
     cd "$MBEDTLS_ROOT_DIR"
     rm -rf "$OUT_OF_SOURCE_DIR"
+    unset MBEDTLS_ROOT_DIR
+}
+
+component_test_cmake_as_subdirectory () {
+    msg "build: cmake 'as-subdirectory' build"
+    MBEDTLS_ROOT_DIR="$PWD"
+
+    cd programs/test/cmake_subproject
+    cmake .
+    make
+    if_build_succeeded ./cmake_subproject
+
+    cd "$MBEDTLS_ROOT_DIR"
     unset MBEDTLS_ROOT_DIR
 }
 


### PR DESCRIPTION
Remove use of CMAKE_SOURCE_DIR in case mbedtls is built from within
another CMake project. Define MBEDTLS_DIR to ${CMAKE_CURRENT_SOURCE_DIR}
in the main CMakeLists.txt file and refer to that when defining target
include paths to enable mbedtls to be built as a sub project.

Fixes https://github.com/ARMmbed/mbedtls/issues/2609

Signed-off-by: Ashley Duncan <ashes.man@gmail.com>
Signed-off-by: Jaeden Amero <jaeden.amero@arm.com>