### PR TITLE
Add an alternarive full build component to all.sh

### DIFF
--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -602,11 +602,21 @@ component_test_full_cmake_clang () {
     CC=clang cmake -D CMAKE_BUILD_TYPE:String=Check -D ENABLE_TESTING=On .
     make
 
-    msg "test: main suites (full config)" # ~ 5s
+    msg "test: main suites (full config, clang)" # ~ 5s
     make test
 
-    msg "test: psa_constant_names (full config)" # ~ 1s
+    msg "test: psa_constant_names (full config, clang)" # ~ 1s
     record_status tests/scripts/test_psa_constant_names.py
+}
+
+component_test_full_make_gcc () {
+    msg "build: make, full config, gcc" # ~ 50s
+    scripts/config.pl full
+    scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # too slow for tests
+    make
+
+    msg "test: main suites (full config, gcc)" # ~ 5s
+    make test
 }
 
 component_build_deprecated () {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -609,13 +609,13 @@ component_test_full_cmake_clang () {
     record_status tests/scripts/test_psa_constant_names.py
 }
 
-component_test_full_make_gcc () {
-    msg "build: make, full config, gcc" # ~ 50s
+component_test_full_make_gcc_o0 () {
+    msg "build: make, full config, gcc -O0" # ~ 50s
     scripts/config.pl full
     scripts/config.pl unset MBEDTLS_MEMORY_BACKTRACE # too slow for tests
-    make
+    make CC=gcc CFLAGS='-O0'
 
-    msg "test: main suites (full config, gcc)" # ~ 5s
+    msg "test: main suites (full config, gcc -O0)" # ~ 5s
     make test
 }
 


### PR DESCRIPTION
This PR adds a component in `all.sh` that does the build formerly only performed in `basic-build-test.sh`, so that we don't have a build config, that we only run once per release.