### PR TITLE
Prevent dead code warning

### DIFF
--- a/library/ecp.c
+++ b/library/ecp.c
@@ -2004,8 +2004,10 @@ static unsigned char ecp_pick_window_size( const mbedtls_ecp_group *grp,
      * Make sure w is within bounds.
      * (The last test is useful only for very small curves in the test suite.)
      */
+#if( MBEDTLS_ECP_WINDOW_SIZE < 6 )
     if( w > MBEDTLS_ECP_WINDOW_SIZE )
         w = MBEDTLS_ECP_WINDOW_SIZE;
+#endif
     if( w >= grp->nbits )
         w = 2;
 


### PR DESCRIPTION
The window size variable in `ecp_pick_window_size()` can take values 4, 5 or 6, but we clamp it not to exceed the value of `MBEDTLS_ECP_WINDOW_SIZE`. If that is 6 (default) or higher, the
static analyzer will point out that the test: `w > MBEDTLS_ECP_WINDOW_SIZE` always evaluates to false.

This commit removes the test for the cases of the window size large enough to fit all the potential values of the variable.

The issue was found by Coverity and fixed the same way @pkolbus has fixed a similar problem in: https://github.com/ARMmbed/mbedtls/pull/2317