### PR TITLE
Correct version number in storage format spec

### DIFF
--- a/docs/architecture/mbed-crypto-storage-specification.md
+++ b/docs/architecture/mbed-crypto-storage-specification.md
@@ -161,21 +161,21 @@ The library integration and the PSA platform integration use different sets of f
 
 It would simplify things to always have a 32-bit owner, with a nonzero value, and thus reserve the range 0–0xffffffff for internal library use.
 
-Mbed Crypto 1.0.1
+Mbed Crypto 1.1.0
 -----------------
 
-Tags: TBD
+Tags: mbedcrypto-1.1.0
 
-Released in May 2019. <br>
+Released in early June 2019. <br>
 Integrated in Mbed OS 5.13.
 
 Identical to [1.0.0](#mbed-crypto-1.0.0) except for some changes in the key file format.
 
-### Key file format for 1.0.1
+### Key file format for 1.1.0
 
 The key file format is identical to [1.0.0](#key-file-format-for-1.0.0), except for the following changes:
 
-* A new policy field, marked as [NEW:1.0.1] below.
+* A new policy field, marked as [NEW:1.1.0] below.
 * The encoding of key types, algorithms and key material has changed, therefore the storage format is not compatible (despite using the same value in the version field so far).
 
 A self-contained description of the file layout follows.
@@ -189,7 +189,7 @@ The layout of a key file is:
 * type (4 bytes): `psa_key_type_t` value
 * policy usage flags (4 bytes): `psa_key_usage_t` value
 * policy usage algorithm (4 bytes): `psa_algorithm_t` value
-* policy enrollment algorithm (4 bytes): `psa_algorithm_t` value [NEW:1.0.1]
+* policy enrollment algorithm (4 bytes): `psa_algorithm_t` value [NEW:1.1.0]
 * key material length (4 bytes)
 * key material: output of `psa_export_key`
 * Any trailing data is rejected on load.


### PR DESCRIPTION
This release turned out to be 1.1.0, not 1.0.1.