### PR TITLE
PSA Storage: Add psa_trusted_storage_linux persistent storage support for v1.0.0 APIs

### DIFF
--- a/library/psa_crypto_its.h
+++ b/library/psa_crypto_its.h
@@ -91,6 +91,7 @@ psa_status_t psa_its_set(psa_storage_uid_t uid,
  * \param[in] data_offset       The starting offset of the data requested
  * \param[in] data_length       the amount of data requested (and the minimum allocated size of the `p_data` buffer)
  * \param[out] p_data           The buffer where the data will be placed upon successful completion
+ * \param[out] p_data_length    The amount of data returned in the p_data buffer
  *
  *
  * \return      A status indicating the success/failure of the operation
@@ -106,7 +107,8 @@ psa_status_t psa_its_set(psa_storage_uid_t uid,
 psa_status_t psa_its_get(psa_storage_uid_t uid,
                          uint32_t data_offset,
                          uint32_t data_length,
-                         void *p_data);
+                         void *p_data,
+                         size_t *p_data_length );
 
 /**
  * \brief Retrieve the metadata about the provided uid

--- a/library/psa_crypto_storage.c
+++ b/library/psa_crypto_storage.c
@@ -96,12 +96,15 @@ static psa_status_t psa_crypto_storage_load( const psa_key_file_id_t key,
     psa_status_t status;
     psa_storage_uid_t data_identifier = psa_its_identifier_of_slot( key );
     struct psa_storage_info_t data_identifier_info;
+    size_t data_length = 0;
 
     status = psa_its_get_info( data_identifier, &data_identifier_info );
     if( status  != PSA_SUCCESS )
         return( status );
 
-    status = psa_its_get( data_identifier, 0, (uint32_t) data_size, data );
+    status = psa_its_get( data_identifier, 0, (uint32_t) data_size, data, &data_length );
+    if( data_size  != data_length )
+        return( PSA_ERROR_STORAGE_FAILURE );
 
     return( status );
 }

--- a/library/psa_its_file.c
+++ b/library/psa_its_file.c
@@ -44,7 +44,9 @@
 #include <stdio.h>
 #include <string.h>
 
+#if !defined(PSA_ITS_STORAGE_PREFIX)
 #define PSA_ITS_STORAGE_PREFIX ""
+#endif
 
 #define PSA_ITS_STORAGE_FILENAME_PATTERN "%08lx%08lx"
 #define PSA_ITS_STORAGE_SUFFIX ".psa_its"
@@ -137,7 +139,8 @@ psa_status_t psa_its_get_info( psa_storage_uid_t uid,
 psa_status_t psa_its_get( psa_storage_uid_t uid,
                           uint32_t data_offset,
                           uint32_t data_length,
-                          void *p_data )
+                          void *p_data,
+                          size_t *p_data_length )
 {
     psa_status_t status;
     FILE *stream = NULL;
@@ -172,6 +175,8 @@ psa_status_t psa_its_get( psa_storage_uid_t uid,
     if( n != data_length )
         goto exit;
     status = PSA_SUCCESS;
+    if( p_data_length != NULL )
+        *p_data_length = n;
 
 exit:
     if( stream != NULL )

--- a/tests/suites/test_suite_psa_its.function
+++ b/tests/suites/test_suite_psa_its.function
@@ -69,6 +69,7 @@ void set_get_remove( int uid_arg, int flags_arg, data_t *data )
     uint32_t flags = flags_arg;
     struct psa_storage_info_t info;
     unsigned char *buffer = NULL;
+    size_t ret_len = 0;
 
     ASSERT_ALLOC( buffer, data->len );
 
@@ -77,8 +78,8 @@ void set_get_remove( int uid_arg, int flags_arg, data_t *data )
     PSA_ASSERT( psa_its_get_info( uid, &info ) );
     TEST_ASSERT( info.size == data->len );
     TEST_ASSERT( info.flags == flags );
-    PSA_ASSERT( psa_its_get( uid, 0, data->len, buffer ) );
-    ASSERT_COMPARE( data->x, data->len, buffer, data->len );
+    PSA_ASSERT( psa_its_get( uid, 0, data->len, buffer, &ret_len ) );
+    ASSERT_COMPARE( data->x, data->len, buffer, ret_len );
 
     PSA_ASSERT( psa_its_remove( uid ) );
 
@@ -98,6 +99,7 @@ void set_overwrite( int uid_arg,
     uint32_t flags2 = flags2_arg;
     struct psa_storage_info_t info;
     unsigned char *buffer = NULL;
+    size_t ret_len = 0;
 
     ASSERT_ALLOC( buffer, MAX( data1->len, data2->len ) );
 
@@ -105,15 +107,16 @@ void set_overwrite( int uid_arg,
     PSA_ASSERT( psa_its_get_info( uid, &info ) );
     TEST_ASSERT( info.size == data1->len );
     TEST_ASSERT( info.flags == flags1 );
-    PSA_ASSERT( psa_its_get( uid, 0, data1->len, buffer ) );
-    ASSERT_COMPARE( data1->x, data1->len, buffer, data1->len );
+    PSA_ASSERT( psa_its_get( uid, 0, data1->len, buffer, &ret_len ) );
+    ASSERT_COMPARE( data1->x, data1->len, buffer, ret_len );
 
     PSA_ASSERT( psa_its_set_wrap( uid, data2->len, data2->x, flags2 ) );
     PSA_ASSERT( psa_its_get_info( uid, &info ) );
     TEST_ASSERT( info.size == data2->len );
     TEST_ASSERT( info.flags == flags2 );
-    PSA_ASSERT( psa_its_get( uid, 0, data2->len, buffer ) );
-    ASSERT_COMPARE( data2->x, data2->len, buffer, data2->len );
+    ret_len = 0;
+    PSA_ASSERT( psa_its_get( uid, 0, data2->len, buffer, &ret_len ) );
+    ASSERT_COMPARE( data2->x, data2->len, buffer, ret_len );
 
     PSA_ASSERT( psa_its_remove( uid ) );
 
@@ -130,6 +133,7 @@ void set_multiple( int first_id, int count )
     psa_storage_uid_t uid;
     char stored[40];
     char retrieved[40];
+    size_t ret_len = 0;
 
     memset( stored, '.', sizeof( stored ) );
     for( uid = uid0; uid < uid0 + count; uid++ )
@@ -143,11 +147,11 @@ void set_multiple( int first_id, int count )
     {
         mbedtls_snprintf( stored, sizeof( stored ),
                           "Content of file 0x%08lx", (unsigned long) uid );
-        PSA_ASSERT( psa_its_get( uid, 0, sizeof( stored ), retrieved ) );
-        ASSERT_COMPARE( retrieved, sizeof( stored ),
+        PSA_ASSERT( psa_its_get( uid, 0, sizeof( stored ), retrieved, &ret_len ) );
+        ASSERT_COMPARE( retrieved, ret_len,
                         stored, sizeof( stored ) );
         PSA_ASSERT( psa_its_remove( uid ) );
-        TEST_ASSERT( psa_its_get( uid, 0, 0, NULL ) ==
+        TEST_ASSERT( psa_its_get( uid, 0, 0, NULL, NULL ) ==
                      PSA_ERROR_DOES_NOT_EXIST );
     }
 
@@ -171,7 +175,7 @@ void nonexistent( int uid_arg, int create_and_remove )
     TEST_ASSERT( psa_its_remove( uid ) == PSA_ERROR_DOES_NOT_EXIST );
     TEST_ASSERT( psa_its_get_info( uid, &info ) ==
                  PSA_ERROR_DOES_NOT_EXIST );
-    TEST_ASSERT( psa_its_get( uid, 0, 0, NULL ) ==
+    TEST_ASSERT( psa_its_get( uid, 0, 0, NULL, NULL ) ==
                  PSA_ERROR_DOES_NOT_EXIST );
 
 exit:
@@ -190,6 +194,7 @@ void get_at( int uid_arg, data_t *data,
     size_t length = length_arg >= 0 ? length_arg : 0;
     unsigned char *trailer;
     size_t i;
+    size_t ret_len = 0;
 
     ASSERT_ALLOC( buffer, length + 16 );
     trailer = buffer + length;
@@ -197,11 +202,11 @@ void get_at( int uid_arg, data_t *data,
 
     PSA_ASSERT( psa_its_set_wrap( uid, data->len, data->x, 0 ) );
 
-    status = psa_its_get( uid, offset, length_arg, buffer );
+    status = psa_its_get( uid, offset, length_arg, buffer, &ret_len );
     TEST_ASSERT( status == (psa_status_t) expected_status );
     if( status == PSA_SUCCESS )
-        ASSERT_COMPARE( data->x + offset, length,
-                        buffer, length );
+        ASSERT_COMPARE( data->x + offset, (size_t) length_arg,
+                        buffer, ret_len );
     for( i = 0; i < 16; i++ )
         TEST_ASSERT( trailer[i] == '-' );
     PSA_ASSERT( psa_its_remove( uid ) );


### PR DESCRIPTION
This PR should be squashed and merged. The following is offered as the squash commit message:

```
Add psa_trusted_storage_linux persistent storage support for v1.0.0 APIs

The following provides more information on this PR:
- PSA stands for Platform Security Architecture.
- Add support for use of psa_trusted_storage_api internal-trusted_storage.h v1.0.0
  as the interface to the psa_trusted_storage_linux backend (i.e. for persistent
  storage when MBEDTLS_PSA_ITS_FILE_C is not defined). This requires changes
  to psa_crypto_its.h and psa_crypto_storage.c to migrate to the new API.
- Add MBEDTLS_PSA_ITS_FILE_C_INCLUDE_TEST to config.h to build
  useful storage related tests (e.g. test_suite_psa_its and 
  test_suite_psa_crypto_persistent_key) even when MBEDTLS_PSA_ITS_FILE_C 
  is not defined. This is used by the psa_trusted_storage_linux
  mbed_crypto_psa_storage_config.h for example.
- Add MBEDTLS_PSA_ITS_FILE_C_STORAGE_PREFIX in config.h so the
  file storage directory can be specified. It can also be specified in the
  following way:
      make CFLAGS="-DMBEDTLS_PSA_ITS_FILE_C_STORAGE_PREFIX='\"/home/username/\"'"
  (Note the inclusion of the trailing '/' in the prefix path.)
- Add CMake option for explicitly link library to trusted_storage
    option name: LINK_WITH_TRUSTED_STORAGE
    default value: ON
```