### PR TITLE
Add CMake option for explicitly link library to trusted_storage

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -1,7 +1,7 @@
 option(USE_STATIC_MBEDTLS_LIBRARY "Build mbed TLS static library." ON)
 option(USE_SHARED_MBEDTLS_LIBRARY "Build mbed TLS shared library." OFF)
 option(LINK_WITH_PTHREAD "Explicitly link mbed TLS library to pthread." OFF)
-option(LINK_WITH_TRUSTED_STORAGE "Explicitly link mbed TLS library to trusted_storage." ON)
+option(LINK_WITH_TRUSTED_STORAGE "Explicitly link mbed TLS library to trusted_storage." OFF)
 
 # Set the project root directory if it's not already defined, as may happen if
 # the library folder is included directly by a parent project, without

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -1,6 +1,7 @@
 option(USE_STATIC_MBEDTLS_LIBRARY "Build mbed TLS static library." ON)
 option(USE_SHARED_MBEDTLS_LIBRARY "Build mbed TLS shared library." OFF)
 option(LINK_WITH_PTHREAD "Explicitly link mbed TLS library to pthread." OFF)
+option(LINK_WITH_TRUSTED_STORAGE "Explicitly link mbed TLS library to trusted_storage." ON)
 
 # Set the project root directory if it's not already defined, as may happen if
 # the library folder is included directly by a parent project, without
@@ -123,6 +124,10 @@ endif(HAIKU)
 
 if(LINK_WITH_PTHREAD)
     set(libs ${libs} pthread)
+endif()
+
+if(LINK_WITH_TRUSTED_STORAGE)
+    set(libs ${libs} trusted_storage)
 endif()
 
 if (NOT USE_STATIC_MBEDTLS_LIBRARY AND NOT USE_SHARED_MBEDTLS_LIBRARY)


### PR DESCRIPTION
CMake option name: LINK_WITH_TRUSTED_STORAGE
Default value is `ON` since the default of mbedtls for `MBEDTLS_PSA_ITS_FILE_C` [is using ITS](https://github.com/ARMmbed/mbedtls/blob/ff645d9838f4797c726562d90c0a9ae5207ea86f/include/mbedtls/config.h#L2872).

This PR is based on https://github.com/ARMmbed/mbed-crypto/pull/180 with the addition of one commit. Please merge after it.

The new option assumes `trusted_storage` library exist and force `mbedcrypto` library to link with it. Any application/test uses emulated ITS (by defining `MBEDTLS_PSA_ITS_FILE_C`) should set this option to `OFF`.