### PR TITLE
Add pkgconfig files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ else()
     project("mbed TLS" C)
 endif()
 
+# Add CMake modules to the path
+SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
+
 # Set the project root directory.
 set(MBEDTLS_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/cmake/PkgBuildConfig.cmake
+++ b/cmake/PkgBuildConfig.cmake
@@ -1,0 +1,95 @@
+# pkg-config file generation
+#
+# Uses the following globals:
+# - PKG_BUILD_PREFIX: the build location (aka prefix). Defaults to CMAKE_INSTALL_PREFIX
+# - PKG_BUILD_LIBDIR: the libdir location. Defaults to ${prefix}/lib.
+# - PKG_BUILD_INCLUDEDIR: the includedir location. Defaults to ${prefix}/include.
+#
+function(pkg_build_config)
+    set(options)
+    set(oneValueArgs NAME DESCRIPTION VERSION FILENAME)
+    set(multiValueArgs LIBS PRIVATE_LIBS REQUIRES CFLAGS)
+
+    cmake_parse_arguments(PKGCONFIG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if (NOT DEFINED PKGCONFIG_FILENAME AND DEFINED PKGCONFIG_NAME)
+        set(PKGCONFIG_FILENAME ${PKGCONFIG_NAME})
+    endif()
+    if (NOT DEFINED PKGCONFIG_FILENAME)
+        message(FATAL_ERROR "Missing FILENAME argument")
+    endif()
+    set(PKGCONFIG_FILE "${PROJECT_BINARY_DIR}/${PKGCONFIG_FILENAME}.pc")
+
+    if (NOT DEFINED PKGCONFIG_DESCRIPTION)
+        message(FATAL_ERROR "Missing DESCRIPTION argument")
+    endif()
+
+    if (NOT DEFINED PKGCONFIG_VERSION)
+        message(FATAL_ERROR "Missing VERSION argument")
+    endif()
+
+    if (DEFINED PKG_BUILD_PREFIX)
+        set(PKGCONFIG_PREFIX ${PKG_BUILD_PREFIX})
+    else()
+        set(PKGCONFIG_PREFIX ${CMAKE_INSTALL_PREFIX})
+    endif()
+
+    if(DEFINED PKG_BUILD_LIBDIR)
+        if (IS_ABSOLUTE ${PKG_BUILD_LIBDIR})
+            set(PKGCONFIG_LIBDIR ${PKG_BUILD_LIBDIR})
+        else()
+            set(PKGCONFIG_LIBDIR "\${prefix}/${PKG_BUILD_LIBDIR}")
+        endif()
+    else()
+        set(PKGCONFIG_LIBDIR "\${prefix}/lib")
+    endif()
+
+    if(DEFINED PKG_BUILD_INCLUDEDIR)
+        if (IS_ABSOLUTE ${PKG_BUILD_INCLUDEDIR})
+            set(PKGCONFIG_INCLUDEDIR ${PKG_BUILD_INCLUDEDIR})
+        else()
+            set(PKGCONFIG_INCLUDEDIR "\${prefix}/${PKG_BUILD_INCLUDEDIR}")
+        endif()
+    else()
+        set(PKGCONFIG_INCLUDEDIR "\${prefix}/include")
+    endif()
+
+    file(WRITE "${PKGCONFIG_FILE}"
+        "prefix=${PKGCONFIG_PREFIX}\n"
+        "libdir=${PKGCONFIG_LIBDIR}\n"
+        "includedir=${PKGCONFIG_INCLUDEDIR}\n"
+        "\n"
+        "Name: ${PKGCONFIG_NAME}\n"
+        "Description: ${PKGCONFIG_DESCRIPTION}\n"
+        "Version: ${PKGCONFIG_VERSION}\n"
+    )
+
+    if(NOT DEFINED PKGCONFIG_LIBS)
+        set(PKGCONFIG_LIBS "-l${PKGCONFIG_NAME}")
+    else()
+        list(INSERT PKGCONFIG_LIBS 0 "-l${PKGCONFIG_NAME}")
+    endif()
+    list(REMOVE_DUPLICATES PKGCONFIG_LIBS)
+    string(REPLACE ";" " " PKGCONFIG_LIBS "${PKGCONFIG_LIBS}")
+    file(APPEND "${PKGCONFIG_FILE}" "Libs: -L\${libdir} ${PKGCONFIG_LIBS}\n")
+
+    if(DEFINED PKGCONFIG_PRIVATE_LIBS)
+        string(REPLACE ";" " " PKGCONFIG_PRIVATE_LIBS "${PKGCONFIG_PRIVATE_LIBS}")
+        file(APPEND "${PKGCONFIG_FILE}" "Libs.private: ${PKGCONFIG_PRIVATE_LIBS}\n")
+    endif()
+    if(DEFINED PKGCONFIG_REQUIRES)
+        list(REMOVE_DUPLICATES PKGCONFIG_REQUIRES)
+        string(REPLACE ";" " " PKGCONFIG_REQUIRES "${PKGCONFIG_REQUIRES}")
+        file(APPEND "${PKGCONFIG_FILE}" "Requires.private: ${PKGCONFIG_REQUIRES}\n")
+    endif()
+    if(DEFINED PKGCONFIG_CFLAGS)
+        string(REPLACE ";" " " PKGCONFIG_CFLAGS "${PKGCONFIG_CFLAGS}")
+    else()
+        set(PKGCONFIG_CFLAGS "")
+    endif()
+    file(APPEND "${PKGCONFIG_FILE}" "Cflags: -I\${includedir} ${PKGCONFIG_CFLAGS}\n")
+
+    install(FILES "${PKGCONFIG_FILE}"
+        DESTINATION "${PKGCONFIG_PREFIX}/${PKGCONFIG_LIBDIR}/pkgconfig"
+    )
+endfunction()

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -95,6 +95,10 @@ endif()
 
 list(APPEND src_crypto ${thirdparty_src})
 
+# Extract version from include/mbedtls/version.h
+file(STRINGS "${MBEDTLS_DIR}/include/mbedtls/version.h" MBEDTLS_VERSION_H REGEX "^#define *MBEDTLS_VERSION_STRING *\"[^\"]*\"$")
+string(REGEX REPLACE "^.*MBEDTLS_VERSION_STRING +\"([0-9.]*)\"$" "\\1" MBEDTLS_VERSION_STRING ${MBEDTLS_VERSION_H})
+
 if(CMAKE_COMPILER_IS_GNUCC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wmissing-declarations -Wmissing-prototypes")
 endif(CMAKE_COMPILER_IS_GNUCC)
@@ -157,7 +161,7 @@ endif(USE_STATIC_MBEDTLS_LIBRARY)
 
 if(USE_SHARED_MBEDTLS_LIBRARY)
     add_library(mbedcrypto SHARED ${src_crypto})
-    set_target_properties(mbedcrypto PROPERTIES VERSION 2.17.0 SOVERSION 3)
+    set_target_properties(mbedcrypto PROPERTIES VERSION ${MBEDTLS_VERSION_STRING} SOVERSION 3)
     target_link_libraries(mbedcrypto ${libs})
     target_include_directories(mbedcrypto
         PUBLIC ${MBEDTLS_DIR}/include/

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -130,6 +130,7 @@ endif(HAIKU)
 
 if(LINK_WITH_PTHREAD)
     set(libs ${libs} pthread)
+    list(APPEND mbedcrypto_PKGCONFIG_PRIVATE_LIBS -lpthread)
 endif()
 
 if(LINK_WITH_TRUSTED_STORAGE)
@@ -183,3 +184,15 @@ else()
         add_dependencies(lib mbedcrypto_static)
     endif()
 endif()
+
+include(PkgBuildConfig)
+
+set(PKG_BUILD_LIBDIR ${LIB_INSTALL_DIR})
+set(PKG_BUILD_INCLUDEDIR ${INCLUDE_INSTALL_DIR})
+pkg_build_config(NAME mbedcrypto
+    VERSION ${MBEDTLS_VERSION_STRING}
+    DESCRIPTION "The mbedTLS crypto library"
+    LIBS ${mbedcrypto_PKGCONFIG_LIBS}
+    PRIVATE_LIBS ${mbedcrypto_PKGCONFIG_PRIVATE_LIBS}
+    REQUIRES ${mbedcrypto_PKGCONFIG_REQUIRES}
+)


### PR DESCRIPTION
This adds support for automatically generating `pkgconfig` files for the mbedcrypto library.

Exctracted from https://github.com/ARMmbed/mbedtls/pull/1753.