### PR TITLE
Return right error code.

### DIFF
--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -2755,7 +2755,7 @@ psa_status_t psa_asymmetric_encrypt( psa_key_handle_t handle,
         mbedtls_rsa_context *rsa = slot->data.rsa;
         int ret;
         if( output_size < mbedtls_rsa_get_len( rsa ) )
-            return( PSA_ERROR_INVALID_ARGUMENT );
+            return( PSA_ERROR_BUFFER_TOO_SMALL );
 #if defined(MBEDTLS_PKCS1_V15)
         if( alg == PSA_ALG_RSA_PKCS1V15_CRYPT )
         {


### PR DESCRIPTION
Fixes : [#126](https://github.com/ARMmbed/mbed-crypto/issues/126)

When running psa-arch-tests API - 0.9 on the crypto library one of the tests fails which expects a right return code from psa_asymmetric_encrypt when the size of output buffer supplied is inadequate.

These psa-arch-tests are PSA compliance tests which are run against the mbed-crypto library.

Please refer 
* [Jenkins failed job](https://jenkins-internal.mbed.com/blue/organizations/jenkins/mbed-crypto-pr-ci-testing/detail/dev%2Fjainvikas8%2Fci-testing-development/1/pipeline/41)
* [Jenkins passed job](https://jenkins-internal.mbed.com/blue/organizations/jenkins/mbed-crypto-pr-ci-testing/detail/dev%2Fjainvikas8%2Fci-testing-development/2/pipeline/41)

Further, the test can be run on your local Linux machine with the help of this [script](https://gist.github.com/jainvikas8/5d02731a487cdfd87d0633c01c260390).

So returning PSA_ERROR_BUFFER_TOO_SMALL error code passes this test.

This fix is a pre-requisite to make psa-arch-tests run as a CI for any raised PR job.

