### PR TITLE
Remove extra mbedtls_ecp_group_free()

### DIFF
--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -836,7 +836,6 @@ int mbedtls_ecp_group_load( mbedtls_ecp_group *grp, mbedtls_ecp_group_id id )
 #endif /* MBEDTLS_ECP_DP_CURVE448_ENABLED */
 
         default:
-            mbedtls_ecp_group_free( grp );
             return( MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE );
     }
 }

--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -836,7 +836,7 @@ int mbedtls_ecp_group_load( mbedtls_ecp_group *grp, mbedtls_ecp_group_id id )
 #endif /* MBEDTLS_ECP_DP_CURVE448_ENABLED */
 
         default:
-            grp->id = 0;
+            grp->id = MBEDTLS_ECP_DP_NONE;
             return( MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE );
     }
 }

--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -836,6 +836,7 @@ int mbedtls_ecp_group_load( mbedtls_ecp_group *grp, mbedtls_ecp_group_id id )
 #endif /* MBEDTLS_ECP_DP_CURVE448_ENABLED */
 
         default:
+            grp->id = id;
             return( MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE );
     }
 }

--- a/library/ecp_curves.c
+++ b/library/ecp_curves.c
@@ -836,7 +836,7 @@ int mbedtls_ecp_group_load( mbedtls_ecp_group *grp, mbedtls_ecp_group_id id )
 #endif /* MBEDTLS_ECP_DP_CURVE448_ENABLED */
 
         default:
-            grp->id = id;
+            grp->id = 0;
             return( MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE );
     }
 }


### PR DESCRIPTION
The call `mbedtls_ecp_group_free()` is unneccessary since the `grp` is already freed at the top of the function.