### PR TITLE
Check for zero length and NULL buffer pointer.

### DIFF
--- a/library/platform_util.c
+++ b/library/platform_util.c
@@ -72,7 +72,10 @@ static void * (* const volatile memset_func)( void *, int, size_t ) = memset;
 
 void mbedtls_platform_zeroize( void *buf, size_t len )
 {
-    memset_func( buf, 0, len );
+    MBEDTLS_INTERNAL_VALIDATE( len == 0 || buf != NULL );
+
+    if( len > 0 )
+        memset_func( buf, 0, len );
 }
 #endif /* MBEDTLS_PLATFORM_ZEROIZE_ALT */
 


### PR DESCRIPTION
In reference to issue https://github.com/ARMmbed/mbed-crypto/issues/49

Backport to 2.16: https://github.com/ARMmbed/mbedtls/pull/2793

After [analysis](https://github.com/ARMmbed/mbedtls/pull/2794) this turned out not to be applicable to 2.7.