### PR TITLE
Remove a redundant function call

### DIFF
--- a/library/bignum.c
+++ b/library/bignum.c
@@ -2410,8 +2410,6 @@ static int mpi_miller_rabin( const mbedtls_mpi *X, size_t rounds,
     MBEDTLS_MPI_CHK( mbedtls_mpi_copy( &R, &W ) );
     MBEDTLS_MPI_CHK( mbedtls_mpi_shift_r( &R, s ) );
 
-    i = mbedtls_mpi_bitlen( X );
-
     for( i = 0; i < rounds; i++ )
     {
         /*


### PR DESCRIPTION
Remove a call to `mbedtls_mpi_bitlen()` since the returned value is
overwritten in the line after. This is redundant since da31fa137a1183d3feed5981af6d05c550a8c005.
Fixes https://github.com/ARMmbed/mbedtls/issues/2377.

Reported by irwir