### PR TITLE
Remove double underscores from macro and add a check for it

### DIFF
--- a/include/psa/crypto_values.h
+++ b/include/psa/crypto_values.h
@@ -1015,15 +1015,15 @@
  * \return              The corresponding AEAD algorithm with the default
  *                      tag length for that algorithm.
  */
-#define PSA_ALG_AEAD_WITH_DEFAULT_TAG_LENGTH(aead_alg)                  \
-    (                                                                   \
-        PSA__ALG_AEAD_WITH_DEFAULT_TAG_LENGTH__CASE(aead_alg, PSA_ALG_CCM) \
-        PSA__ALG_AEAD_WITH_DEFAULT_TAG_LENGTH__CASE(aead_alg, PSA_ALG_GCM) \
-        PSA__ALG_AEAD_WITH_DEFAULT_TAG_LENGTH__CASE(aead_alg, PSA_ALG_CHACHA20_POLY1305) \
+#define PSA_ALG_AEAD_WITH_DEFAULT_TAG_LENGTH(aead_alg)                   \
+    (                                                                    \
+        PSA_ALG_AEAD_WITH_DEFAULT_TAG_LENGTH_CASE(aead_alg, PSA_ALG_CCM) \
+        PSA_ALG_AEAD_WITH_DEFAULT_TAG_LENGTH_CASE(aead_alg, PSA_ALG_GCM) \
+        PSA_ALG_AEAD_WITH_DEFAULT_TAG_LENGTH_CASE(aead_alg, PSA_ALG_CHACHA20_POLY1305) \
         0)
-#define PSA__ALG_AEAD_WITH_DEFAULT_TAG_LENGTH__CASE(aead_alg, ref)      \
-    PSA_ALG_AEAD_WITH_TAG_LENGTH(aead_alg, 0) ==                        \
-    PSA_ALG_AEAD_WITH_TAG_LENGTH(ref, 0) ?  \
+#define PSA_ALG_AEAD_WITH_DEFAULT_TAG_LENGTH_CASE(aead_alg, ref)         \
+    PSA_ALG_AEAD_WITH_TAG_LENGTH(aead_alg, 0) ==                         \
+    PSA_ALG_AEAD_WITH_TAG_LENGTH(ref, 0) ?                               \
     ref :
 
 #define PSA_ALG_RSA_PKCS1V15_SIGN_BASE          ((psa_algorithm_t)0x10020000)

--- a/tests/scripts/check-names.sh
+++ b/tests/scripts/check-names.sh
@@ -57,11 +57,14 @@ for THING in actual-macros enum-consts; do
     printf "Names of $THING: "
     test -r $THING
     BAD=$( grep -E -v '^(MBEDTLS|PSA)_[0-9A-Z_]*[0-9A-Z]$' $THING || true )
-    if [ "x$BAD" = "x" ]; then
+    UNDERSCORES=$( grep -E '.*__.*' $THING || true )
+
+    if [ "x$BAD" = "x" ] && [ "x$UNDERSCORES" = "x" ]; then
         echo "PASS"
     else
         echo "FAIL"
         echo "$BAD"
+        echo "$UNDERSCORES"
         FAIL=1
     fi
 done

--- a/tests/scripts/test_psa_constant_names.py
+++ b/tests/scripts/test_psa_constant_names.py
@@ -162,6 +162,7 @@ class Inputs:
     # PSA_ALG_ECDH and PSA_ALG_FFDH are excluded for now as the script
     # currently doesn't support them. Deprecated errors are also excluded.
     _excluded_names = set(['PSA_ALG_AEAD_WITH_DEFAULT_TAG_LENGTH',
+                           'PSA_ALG_AEAD_WITH_DEFAULT_TAG_LENGTH_CASE',
                            'PSA_ALG_FULL_LENGTH_MAC',
                            'PSA_ALG_ECDH',
                            'PSA_ALG_FFDH',


### PR DESCRIPTION
This PR addresses issue https://github.com/ARMmbed/mbed-crypto/issues/171.
It removes the double underscore from a macro, adds an exception for it in "test_psa_constant_names", and introduces a check for double underscores in check-names.sh.