### PR TITLE
Enable 64-bit bignum limbs and add optimized multiplication for Aarch64

### DIFF
--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -129,7 +129,8 @@
         defined(__ppc64__) || defined(__powerpc64__)  || \
         defined(__ia64__)  || defined(__alpha__)      || \
         ( defined(__sparc__) && defined(__arch64__) ) || \
-        defined(__s390x__) || defined(__mips64) )
+        defined(__s390x__) || defined(__mips64)       || \
+        defined(__aarch64__) )
         #if !defined(MBEDTLS_HAVE_INT64)
             #define MBEDTLS_HAVE_INT64
         #endif /* MBEDTLS_HAVE_INT64 */
@@ -140,8 +141,9 @@
             typedef unsigned int mbedtls_t_udbl __attribute__((mode(TI)));
             #define MBEDTLS_HAVE_UDBL
         #endif /* !MBEDTLS_NO_UDBL_DIVISION */
-    #elif defined(__aarch64__)
+    #elif defined(__ARMCC_VERSION) && defined(__aarch64__)
         /*
+         * __ARMCC_VERSION is defined for both armcc and armclang and
          * __aarch64__ is only defined by armclang when compiling 64-bit code
          */
         #if !defined(MBEDTLS_HAVE_INT64)

--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -140,9 +140,8 @@
             typedef unsigned int mbedtls_t_udbl __attribute__((mode(TI)));
             #define MBEDTLS_HAVE_UDBL
         #endif /* !MBEDTLS_NO_UDBL_DIVISION */
-    #elif defined(__ARMCC_VERSION) && defined(__aarch64__)
+    #elif defined(__aarch64__)
         /*
-         * __ARMCC_VERSION is defined for both armcc and armclang and
          * __aarch64__ is only defined by armclang when compiling 64-bit code
          */
         #if !defined(MBEDTLS_HAVE_INT64)

--- a/include/mbedtls/bn_mul.h
+++ b/include/mbedtls/bn_mul.h
@@ -198,6 +198,30 @@
 
 #endif /* AMD64 */
 
+#if defined(__aarch64__)
+
+#define MULADDC_INIT                \
+    asm(
+
+#define MULADDC_CORE                \
+        "ldr x4, [%3], #8   \n\t"   \
+        "ldr x5, [%4]       \n\t"   \
+        "mul x6, x4, %6     \n\t"   \
+        "umulh x7, x4, %6   \n\t"   \
+        "adds x5, x5, x6    \n\t"   \
+        "adc x7, x7, xzr    \n\t"   \
+        "adds x5, x5, %5    \n\t"   \
+        "adc %0, x7, xzr    \n\t"   \
+        "str x5, [%1], #8   \n\t"
+
+#define MULADDC_STOP                            \
+         : "+r" (c),  "=r" (d), "=r" (s)        \
+         : "r" (s), "r" (d), "r" (c), "r" (b)   \
+         : "x4", "x5", "x6", "x7", "cc"         \
+    );
+
+#endif /* Aarch64 */
+
 #if defined(__mc68020__) || defined(__mcpu32__)
 
 #define MULADDC_INIT                    \

--- a/include/mbedtls/bn_mul.h
+++ b/include/mbedtls/bn_mul.h
@@ -204,20 +204,20 @@
     asm(
 
 #define MULADDC_CORE                \
-        "ldr x4, [%3], #8   \n\t"   \
-        "ldr x5, [%4]       \n\t"   \
-        "mul x6, x4, %6     \n\t"   \
-        "umulh x7, x4, %6   \n\t"   \
+        "ldr x4, [%2], #8   \n\t"   \
+        "ldr x5, [%1]       \n\t"   \
+        "mul x6, x4, %3     \n\t"   \
+        "umulh x7, x4, %3   \n\t"   \
         "adds x5, x5, x6    \n\t"   \
         "adc x7, x7, xzr    \n\t"   \
-        "adds x5, x5, %5    \n\t"   \
+        "adds x5, x5, %0    \n\t"   \
         "adc %0, x7, xzr    \n\t"   \
         "str x5, [%1], #8   \n\t"
 
-#define MULADDC_STOP                            \
-         : "+r" (c),  "=r" (d), "=r" (s)        \
-         : "r" (s), "r" (d), "r" (c), "r" (b)   \
-         : "x4", "x5", "x6", "x7", "cc"         \
+#define MULADDC_STOP                        \
+         : "+r" (c),  "+r" (d), "+r" (s)    \
+         : "r" (b)                          \
+         : "x4", "x5", "x6", "x7", "cc"     \
     );
 
 #endif /* Aarch64 */


### PR DESCRIPTION
This was ARMmbed/mbedtls#1964. The CLA was approved and @yanesca and @Patater reviewed this.