### PR TITLE
Check `len` against buffers size upper bound in PSA tests

### DIFF
--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -736,6 +736,11 @@ int asn1_skip_integer( unsigned char **p, const unsigned char *end,
     TEST_EQUAL( mbedtls_asn1_get_tag( p, end, &len,
                                       MBEDTLS_ASN1_INTEGER ),
                 0 );
+
+    /* Check if the retrieved length doesn't extend the actual buffer's size.
+     * It is assumed here, that end >= p, which validates casting to size_t. */
+    TEST_ASSERT( len <= (size_t)( end - *p) );
+
     /* Tolerate a slight departure from DER encoding:
      * - 0 may be represented by an empty string or a 1-byte string.
      * - The sign bit may be used as a value bit. */


### PR DESCRIPTION
In `asn1_skip_integer()`, in `test_suite_psa_crypto.function` suite, a buffer is accessed at an index based on `len` - taken from itself. There is a lower bound check done on the `len` value, but none for the upper bound.

This PR adds the upper bound check for the value used for the lookup.