### PR TITLE
EC keys written with as DER could be incorrectly formatted

### DIFF
--- a/include/mbedtls/asn1write.h
+++ b/include/mbedtls/asn1write.h
@@ -106,6 +106,23 @@ int mbedtls_asn1_write_raw_buffer( unsigned char **p, unsigned char *start,
  */
 int mbedtls_asn1_write_mpi( unsigned char **p, unsigned char *start,
                             const mbedtls_mpi *X );
+
+/**
+ * \brief           Write a arbitrary-precision number as an
+ *                  octet string (#MBEDTLS_ASN1_OCTET_STRING)
+ *                  in ASN.1 format.
+ *
+ * \note            This function works backwards in data buffer.
+ *
+ * \param p         The reference to the current position pointer.
+ * \param start     The start of the buffer, for bounds-checking.
+ * \param X         The MPI to write.
+ *
+ * \return          The number of bytes written to \p p on success.
+ * \return          A negative \c MBEDTLS_ERR_ASN1_XXX error code on failure.
+ */
+int mbedtls_asn1_write_mpi_to_octet_string( unsigned char **p, unsigned char *start,
+                                            const mbedtls_mpi *X );
 #endif /* MBEDTLS_BIGNUM_C */
 
 /**

--- a/include/mbedtls/asn1write.h
+++ b/include/mbedtls/asn1write.h
@@ -117,12 +117,15 @@ int mbedtls_asn1_write_mpi( unsigned char **p, unsigned char *start,
  * \param p         The reference to the current position pointer.
  * \param start     The start of the buffer, for bounds-checking.
  * \param X         The MPI to write.
+ * \param len       The intended number of octets of the resulting string.
+ *                  If the MPI results in less octets, leading zeros is
+ *                  added to fill the string.
  *
  * \return          The number of bytes written to \p p on success.
  * \return          A negative \c MBEDTLS_ERR_ASN1_XXX error code on failure.
  */
 int mbedtls_asn1_write_mpi_to_octet_string( unsigned char **p, unsigned char *start,
-                                            const mbedtls_mpi *X );
+                                            const mbedtls_mpi *X, size_t len );
 #endif /* MBEDTLS_BIGNUM_C */
 
 /**

--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -164,6 +164,30 @@ int mbedtls_asn1_write_mpi( unsigned char **p, unsigned char *start, const mbedt
 cleanup:
     return( ret );
 }
+
+int mbedtls_asn1_write_mpi_to_octet_string( unsigned char **p, unsigned char *start, const mbedtls_mpi *X )
+{
+    int ret;
+    size_t len = 0;
+
+    // Write the MPI
+    //
+    len = mbedtls_mpi_size( X );
+
+    if( *p < start || (size_t)( *p - start ) < len )
+        return( MBEDTLS_ERR_ASN1_BUF_TOO_SMALL );
+
+    (*p) -= len;
+    MBEDTLS_MPI_CHK( mbedtls_mpi_write_binary( X, *p, len ) );
+
+    MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_len( p, start, len ) );
+    MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_tag( p, start, MBEDTLS_ASN1_OCTET_STRING ) );
+
+    ret = (int) len;
+
+cleanup:
+    return( ret );
+}
 #endif /* MBEDTLS_BIGNUM_C */
 
 int mbedtls_asn1_write_null( unsigned char **p, unsigned char *start )

--- a/library/asn1write.c
+++ b/library/asn1write.c
@@ -184,7 +184,7 @@ int mbedtls_asn1_write_mpi_to_octet_string( unsigned char **p, unsigned char *st
     (*p) -= mpi_size;
     MBEDTLS_MPI_CHK( mbedtls_mpi_write_binary( X, *p, mpi_size ) );
 
-    for( i = 0; i < len - mpi_size; i++ )
+    for( i = 0; i < (int)(len - mpi_size); i++ )
     {
        (*p)--;
        **p = 0;

--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -425,7 +425,7 @@ int mbedtls_pk_write_key_der( mbedtls_pk_context *key, unsigned char *buf, size_
         len += par_len;
 
         /* privateKey */
-        MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_mpi_to_octet_string( &c, buf, &ec->d ) );
+        MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_mpi_to_octet_string( &c, buf, &ec->d, ec->d.n * 4 ) );
 
         /* version */
         MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_int( &c, buf, 1 ) );

--- a/library/pkwrite.c
+++ b/library/pkwrite.c
@@ -424,9 +424,8 @@ int mbedtls_pk_write_key_der( mbedtls_pk_context *key, unsigned char *buf, size_
                             MBEDTLS_ASN1_CONTEXT_SPECIFIC | MBEDTLS_ASN1_CONSTRUCTED | 0 ) );
         len += par_len;
 
-        /* privateKey: write as MPI then fix tag */
-        MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_mpi( &c, buf, &ec->d ) );
-        *c = MBEDTLS_ASN1_OCTET_STRING;
+        /* privateKey */
+        MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_mpi_to_octet_string( &c, buf, &ec->d ) );
 
         /* version */
         MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_int( &c, buf, 1 ) );


### PR DESCRIPTION
When writing EC keys using mbedtls_pk_write_key_der() the private
part of the key got incorrectly pre-pended with 0 if MSB of the
key was 1.

See issue:
https://github.com/ARMmbed/mbedtls/issues/1028