### PR TITLE
Fix some possibly-undefined variable warnings

### DIFF
--- a/library/entropy.c
+++ b/library/entropy.c
@@ -258,7 +258,7 @@ int mbedtls_entropy_update_manual( mbedtls_entropy_context *ctx,
  */
 static int entropy_gather_internal( mbedtls_entropy_context *ctx )
 {
-    int ret, i, have_one_strong = 0;
+    int ret = 0, i, have_one_strong = 0;
     unsigned char buf[MBEDTLS_ENTROPY_MAX_GATHER];
     size_t olen;
 

--- a/library/entropy.c
+++ b/library/entropy.c
@@ -258,7 +258,9 @@ int mbedtls_entropy_update_manual( mbedtls_entropy_context *ctx,
  */
 static int entropy_gather_internal( mbedtls_entropy_context *ctx )
 {
-    int ret = 0, i, have_one_strong = 0;
+    int ret = MBEDTLS_ERR_ENTROPY_SOURCE_FAILED;
+    int i;
+    int have_one_strong = 0;
     unsigned char buf[MBEDTLS_ENTROPY_MAX_GATHER];
     size_t olen;
 

--- a/library/hmac_drbg.c
+++ b/library/hmac_drbg.c
@@ -74,7 +74,7 @@ int mbedtls_hmac_drbg_update_ret( mbedtls_hmac_drbg_context *ctx,
     unsigned char rounds = ( additional != NULL && add_len != 0 ) ? 2 : 1;
     unsigned char sep[1];
     unsigned char K[MBEDTLS_MD_MAX_SIZE];
-    int ret;
+    int ret = 0;
 
     for( sep[0] = 0; sep[0] < rounds; sep[0]++ )
     {

--- a/library/hmac_drbg.c
+++ b/library/hmac_drbg.c
@@ -74,7 +74,7 @@ int mbedtls_hmac_drbg_update_ret( mbedtls_hmac_drbg_context *ctx,
     unsigned char rounds = ( additional != NULL && add_len != 0 ) ? 2 : 1;
     unsigned char sep[1];
     unsigned char K[MBEDTLS_MD_MAX_SIZE];
-    int ret = 0;
+    int ret = MBEDTLS_ERR_MD_BAD_INPUT_DATA;
 
     for( sep[0] = 0; sep[0] < rounds; sep[0]++ )
     {


### PR DESCRIPTION
Forward port of https://github.com/ARMmbed/mbedtls/pull/2663 contributed by @apple-ihack-geek. The runtime behavior was always correct, but some compilers warned that they weren't sure about it.