### PR TITLE
ECDH: add missing f_rng parameter validation to mbedtls_ecdh_calc_secret

### DIFF
--- a/library/ecdh.c
+++ b/library/ecdh.c
@@ -705,6 +705,7 @@ int mbedtls_ecdh_calc_secret( mbedtls_ecdh_context *ctx, size_t *olen,
     ECDH_VALIDATE_RET( ctx != NULL );
     ECDH_VALIDATE_RET( olen != NULL );
     ECDH_VALIDATE_RET( buf != NULL );
+    ECDH_VALIDATE_RET( f_rng != NULL );
 
 #if defined(MBEDTLS_ECP_RESTARTABLE)
     restart_enabled = ctx->restart_enabled;


### PR DESCRIPTION
Internal reference: IOTSSL-2853
Since `NULL` `p_rng` is a valid and used case, only `f_rng` validation to one place was added.