### PR TITLE
Fix undefined shift in asn1 parsing

### DIFF
--- a/library/asn1parse.c
+++ b/library/asn1parse.c
@@ -163,7 +163,7 @@ int mbedtls_asn1_get_int( unsigned char **p,
     *val = 0;
     while( len-- > 0 )
     {
-        *val = ( *val << 8 ) | **p;
+        *val = ( ((unsigned int) *val) << 8 ) | **p;
         (*p)++;
     }
 


### PR DESCRIPTION
Found by oss-fuzz
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=18102

This is similar to a previous fix some time ago :
https://github.com/ARMmbed/mbedtls/pull/1625/files#diff-8d3acce410d251c6ead39efd401db23eR3316
