### PR TITLE
Test a build without any asymmetric cryptography

### DIFF
--- a/configs/config-symmetric-only.h
+++ b/configs/config-symmetric-only.h
@@ -1,0 +1,99 @@
+/**
+ * \file config-symmetric-only.h
+ *
+ * \brief Configuration without any asymmetric cryptography.
+ */
+/*
+ *  Copyright (C) 2019, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+
+#ifndef MBEDTLS_CONFIG_H
+#define MBEDTLS_CONFIG_H
+
+/* System support */
+//#define MBEDTLS_HAVE_ASM
+#define MBEDTLS_HAVE_TIME
+#define MBEDTLS_HAVE_TIME_DATE
+
+/* Mbed Crypto feature support */
+#define MBEDTLS_CIPHER_MODE_CBC
+#define MBEDTLS_CIPHER_MODE_CFB
+#define MBEDTLS_CIPHER_MODE_CTR
+#define MBEDTLS_CIPHER_MODE_OFB
+#define MBEDTLS_CIPHER_MODE_XTS
+#define MBEDTLS_CIPHER_PADDING_PKCS7
+#define MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS
+#define MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN
+#define MBEDTLS_CIPHER_PADDING_ZEROS
+#define MBEDTLS_ERROR_STRERROR_DUMMY
+#define MBEDTLS_FS_IO
+#define MBEDTLS_ENTROPY_NV_SEED
+#define MBEDTLS_SELF_TEST
+#define MBEDTLS_USE_PSA_CRYPTO
+#define MBEDTLS_VERSION_FEATURES
+
+/* Mbed Crypto modules */
+#define MBEDTLS_AES_C
+#define MBEDTLS_ARC4_C
+#define MBEDTLS_ASN1_PARSE_C
+#define MBEDTLS_ASN1_WRITE_C
+#define MBEDTLS_BASE64_C
+#define MBEDTLS_BLOWFISH_C
+#define MBEDTLS_CAMELLIA_C
+#define MBEDTLS_ARIA_C
+#define MBEDTLS_CCM_C
+#define MBEDTLS_CHACHA20_C
+#define MBEDTLS_CHACHAPOLY_C
+#define MBEDTLS_CIPHER_C
+#define MBEDTLS_CMAC_C
+#define MBEDTLS_CTR_DRBG_C
+#define MBEDTLS_DES_C
+#define MBEDTLS_ENTROPY_C
+#define MBEDTLS_ERROR_C
+#define MBEDTLS_GCM_C
+//#define MBEDTLS_HAVEGE_C
+#define MBEDTLS_HKDF_C
+#define MBEDTLS_HMAC_DRBG_C
+#define MBEDTLS_NIST_KW_C
+#define MBEDTLS_MD_C
+#define MBEDTLS_MD2_C
+#define MBEDTLS_MD4_C
+#define MBEDTLS_MD5_C
+#define MBEDTLS_OID_C
+#define MBEDTLS_PEM_PARSE_C
+#define MBEDTLS_PEM_WRITE_C
+#define MBEDTLS_PKCS5_C
+#define MBEDTLS_PKCS12_C
+#define MBEDTLS_PLATFORM_C
+#define MBEDTLS_POLY1305_C
+#define MBEDTLS_PSA_CRYPTO_C
+#define MBEDTLS_PSA_CRYPTO_SE_C
+#define MBEDTLS_PSA_CRYPTO_STORAGE_C
+#define MBEDTLS_PSA_ITS_FILE_C
+#define MBEDTLS_RIPEMD160_C
+#define MBEDTLS_SHA1_C
+#define MBEDTLS_SHA256_C
+#define MBEDTLS_SHA512_C
+//#define MBEDTLS_THREADING_C
+#define MBEDTLS_TIMING_C
+#define MBEDTLS_VERSION_C
+#define MBEDTLS_XTEA_C
+
+#include "check_config.h"
+
+#endif /* MBEDTLS_CONFIG_H */

--- a/include/mbedtls/psa_util.h
+++ b/include/mbedtls/psa_util.h
@@ -230,9 +230,11 @@ static inline int mbedtls_psa_get_ecc_oid_from_id(
             *oid_len = MBEDTLS_OID_SIZE( MBEDTLS_OID_EC_GRP_BP512R1 );
             return( 0 );
 #endif /* MBEDTLS_ECP_DP_BP512R1_ENABLED */
+        default:
+            (void) oid;
+            (void) oid_len;
+            return( -1 );
     }
-
-     return( -1 );
 }
 
 #define MBEDTLS_PSA_MAX_EC_PUBKEY_LENGTH 1

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -2003,6 +2003,7 @@ exit:
 /* Message digests */
 /****************************************************************/
 
+#if defined(MBEDTLS_RSA_C) || defined(MBEDTLS_ECDSA_DETERMINISTIC)
 static const mbedtls_md_info_t *mbedtls_md_info_from_psa( psa_algorithm_t alg )
 {
     switch( alg )
@@ -2043,6 +2044,7 @@ static const mbedtls_md_info_t *mbedtls_md_info_from_psa( psa_algorithm_t alg )
             return( NULL );
     }
 }
+#endif
 
 psa_status_t psa_hash_abort( psa_hash_operation_t *operation )
 {

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -876,6 +876,7 @@ component_test_se_default () {
 
 component_test_se_full () {
     msg "build: full config + MBEDTLS_PSA_CRYPTO_SE_C"
+    scripts/config.pl full
     scripts/config.pl set MBEDTLS_PSA_CRYPTO_SE_C
     make CC=gcc CFLAGS='-Werror -Wall -Wextra -O2 -fsanitize=address' LDFLAGS='-fsanitize=address'
 

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -877,6 +877,7 @@ component_test_se_default () {
 component_test_se_full () {
     msg "build: full config + MBEDTLS_PSA_CRYPTO_SE_C"
     scripts/config.pl full
+    scripts/config.pl unset MBEDTLS_MEMORY_BUFFER_ALLOC_C
     scripts/config.pl set MBEDTLS_PSA_CRYPTO_SE_C
     make CC=gcc CFLAGS='-Werror -Wall -Wextra -O2 -fsanitize=address' LDFLAGS='-fsanitize=address'
 

--- a/tests/scripts/test-ref-configs.pl
+++ b/tests/scripts/test-ref-configs.pl
@@ -50,6 +50,15 @@ sub abort {
     exit 1;
 }
 
+# Create a seedfile for configurations that enable MBEDTLS_ENTROPY_NV_SEED.
+# For test purposes, this doesn't have to be cryptographically random.
+if (!-e "tests/seedfile" || -s "tests/seedfile" < 64) {
+    local *SEEDFILE;
+    open SEEDFILE, ">tests/seedfile" or die;
+    print SEEDFILE "*" x 64 or die;
+    close SEEDFILE or die;
+}
+
 while( my ($conf, $data) = each %configs ) {
     system( "cp $config_h.bak $config_h" ) and die;
     system( "make clean" ) and die;

--- a/tests/scripts/test-ref-configs.pl
+++ b/tests/scripts/test-ref-configs.pl
@@ -17,6 +17,8 @@ use warnings;
 use strict;
 
 my %configs = (
+    'config-symmetric-only.h' => {
+    },
     'config-suite-b.h' => {
     },
 );

--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -894,6 +894,8 @@ static int exported_key_sanity_check( psa_key_type_t type, size_t bits,
                               "No sanity check for public key type=0x%08lx",
                               (unsigned long) type );
             test_fail( message, __LINE__, __FILE__ );
+            (void) p;
+            (void) end;
             return( 0 );
         }
     }

--- a/tests/suites/test_suite_psa_crypto_se_driver_hal.function
+++ b/tests/suites/test_suite_psa_crypto_se_driver_hal.function
@@ -565,16 +565,17 @@ static int check_persistent_data( psa_key_lifetime_t lifetime,
     psa_storage_uid_t uid = file_uid_for_lifetime( lifetime );
     struct psa_storage_info_t info;
     uint8_t *loaded = NULL;
+    int ok = 0;
 
     PSA_ASSERT( psa_its_get_info( uid, &info ) );
     ASSERT_ALLOC( loaded, info.size );
     PSA_ASSERT( psa_its_get( uid, 0, info.size, loaded, NULL ) );
     ASSERT_COMPARE( expected_data, size, loaded, info.size );
-    return( 1 );
+    ok = 1;
 
 exit:
     mbedtls_free( loaded );
-    return( 0 );
+    return( ok );
 }
 
 /* Check that a function's return status is "smoke-free", i.e. that


### PR DESCRIPTION
Fix #296.

Also fix two bugs that the tests revealed: `component_test_se_full` wasn't using the full config, and there was a memory leak in an SE HAL test (fix duplicated in https://github.com/ARMmbed/mbed-crypto/pull/304).