### PR TITLE
Changelog assembly script

### DIFF
--- a/ChangeLog.d/README
+++ b/ChangeLog.d/README
@@ -1,0 +1,21 @@
+This directory contains changelog entries that have not yet been merged
+to the changelog file (../ChangeLog.md).
+
+A changelog entry file must have the extension *.md and must have the
+following format:
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+### Section title
+
+* Change descritpion.
+* Another change description.
+
+### Another section title
+
+* Yet another change description.
+* Yet again another change description.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+See STANDARD_SECTIONS in ../scripts/assemble_changelog.py for
+recognized section titles.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,11 +18,11 @@
 
 ### Performance improvements
 
-* Remove a useless call to mbedtls_ecp_group_free(). Contributed by Alexander Krizhanovsky in #210.
+* Remove a useless call to `mbedtls_ecp_group_free()`. Contributed by Alexander Krizhanovsky in #210.
 * Speed up PBKDF2 by caching the digest calculation. Contributed by Jack Lloyd and Fortanix Inc in #277.
 
 ### Other changes
 
-* Remove the technical possibility to define custom md_info structures, which was exposed only in an internal header.
+* Remove the technical possibility to define custom `mbedtls_md_info` structures, which was exposed only in an internal header.
 
 ## Mbed Crypto 2.0.0

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,28 @@
+# Mbed Crypto change history
+
+## Unreleased changes
+
+### Interface changes
+
+* In the PSA API, forbid zero-length keys. To pass a zero-length input to a key derivation function, use a buffer instead (this is now always possible).
+
+### New features
+
+* Key derivation inputs in the PSA API can now either come from a key object or from a buffer regardless of the step type.
+
+### Bug fixes
+
+* Fix a buffer overflow in the PSA HMAC code when using a long key with an unsupported algorithm. Fixes #254.
+* Fix `mbedtls_asn1_get_int` to support any number of leading zeros.
+* Fix `mbedtls_asn1_get_bitstring_null` to correctly parse bitstrings of at most 2 bytes.
+
+### Performance improvements
+
+* Remove a useless call to mbedtls_ecp_group_free(). Contributed by Alexander Krizhanovsky in #210.
+* Speed up PBKDF2 by caching the digest calculation. Contributed by Jack Lloyd and Fortanix Inc in #277.
+
+### Other changes
+
+* Remove the technical possibility to define custom md_info structures, which was exposed only in an internal header.
+
+## Mbed Crypto 2.0.0

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,24 +5,40 @@
 ### Interface changes
 
 * In the PSA API, forbid zero-length keys. To pass a zero-length input to a key derivation function, use a buffer instead (this is now always possible).
+* Rename `psa_asymmetric_sign()` to `psa_sign_hash()` and `psa_asymmetric_verify()` to `psa_verify_hash()`.
+
+### Default behavior changes
+
+* The initial seeding of a CTR\_DRBG instance makes a second call to the entropy function to obtain entropy for a nonce if the entropy size is less than 3/2 times the key size. In case you want to disable the extra call to grab entropy, you can call `mbedtls_ctr_drbg_set_nonce_len()` to force the nonce length to 0.
 
 ### New features
 
 * Key derivation inputs in the PSA API can now either come from a key object or from a buffer regardless of the step type.
+* The CTR_DRBG module can grab a nonce from the entropy source during the initial seeding. The default nonce length is chosen based on the key size to achieve the security strength defined by NIST SP 800-90A. You can change it with `mbedtls_ctr_drbg_set_nonce_len()`.
+* Add ENUMERATED tag support to the ASN.1 module. Contributed by msopiha-linaro in #307.
+
+### Security
+
+* Enforce that `mbedtls_entropy_func()` gathers a total of `MBEDTLS_ENTROPY_BLOCK_SIZE` bytes or more from strong sources. In the default configuration, on a platform with a single entropy source, the entropy module formerly only grabbed 32 bytes, which is good enough for security if the source is genuinely strong, but less than the expected 64 bytes (size of the entropy accumulator).
 
 ### Bug fixes
 
 * Fix a buffer overflow in the PSA HMAC code when using a long key with an unsupported algorithm. Fixes #254.
-* Fix `mbedtls_asn1_get_int` to support any number of leading zeros.
+* Fix `mbedtls_asn1_get_int` to support any number of leading zeros. Credit to OSS-Fuzz for finding a bug in an intermediate version of the fix.
 * Fix `mbedtls_asn1_get_bitstring_null` to correctly parse bitstrings of at most 2 bytes.
+* `mbedtls_ctr_drbg_set_entropy_len()` and `mbedtls_hmac_drbg_set_entropy_len()` now work if you call them before `mbedtls_ctr_drbg_seed()` or `mbedtls_hmac_drbg_seed()`.
+* Fix some false-positive uninitialized variable warnings. Fix contributed by apple-ihack-geek in ARMmbed/mbedtls#2663.
 
 ### Performance improvements
 
 * Remove a useless call to `mbedtls_ecp_group_free()`. Contributed by Alexander Krizhanovsky in #210.
 * Speed up PBKDF2 by caching the digest calculation. Contributed by Jack Lloyd and Fortanix Inc in #277.
+* Small performance improvement of `mbedtls_mpi_div_mpi()`. Contributed by Alexander Krizhanovsky in #308.
 
 ### Other changes
 
 * Remove the technical possibility to define custom `mbedtls_md_info` structures, which was exposed only in an internal header.
+* `psa_close_key(0)` and `psa_destroy_key(0)` now succeed (doing nothing, as before).
+* Variables containing error codes are now initialized to an error code rather than success, so that coding mistakes or memory corruption tends to cause functions to return this error code rather than a success. There are no known instances where this changes the behavior of the library: this is merely a robustness improvement. #323
 
 ## Mbed Crypto 2.0.0

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -28,11 +28,9 @@ import sys
 
 class InputFormatError(Exception):
     def __init__(self, filename, line_number, message, *args, **kwargs):
-        self.filename = filename
-        self.line_number = line_number
-        self.message = message.format(*args, **kwargs)
-    def __str__(self):
-        return '{}:{}: {}'.format(self.filename, self.line_number, self.message)
+        message = '{}:{}: {}'.format(filename, line_number,
+                                     message.format(*args, **kwargs))
+        super().__init__(message)
 
 STANDARD_SECTIONS = (
     b'Interface changes',

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -172,10 +172,9 @@ class ChangeLog:
             for line in self.trailer:
                 out.write(line)
 
-def finish_output(files_to_remove, changelog, output_file):
+def finish_output(changelog, output_file):
     """Write the changelog to the output file.
 
-    Remove the specified input files.
     """
     if os.path.exists(output_file) and not os.path.isfile(output_file):
         # The output is a non-regular file (e.g. pipe). Write to it directly.
@@ -185,11 +184,12 @@ def finish_output(files_to_remove, changelog, output_file):
         # then move it into place atomically.
         output_temp = output_file + '.tmp'
     changelog.write(output_temp)
-    for filename in files_to_remove:
-        sys.stderr.write('Removing ' + filename + '\n')
-        #os.remove(filename)
     if output_temp != output_file:
         os.rename(output_temp, output_file)
+
+def remove_merged_entries(files_to_remove):
+    for filename in files_to_remove:
+        os.remove(filename)
 
 def merge_entries(options):
     """Merge changelog entries into the changelog file.
@@ -208,8 +208,9 @@ def merge_entries(options):
     for filename in files_to_merge:
         with open(filename, 'rb') as input_file:
             changelog.add_file(input_file)
-    files_to_remove = [] if options.keep_entries else files_to_merge
-    finish_output(files_to_remove, changelog, options.output)
+    finish_output(changelog, options.output)
+    if not options.keep_entries:
+        remove_merged_entries(files_to_merge)
 
 def set_defaults(options):
     """Add default values for missing options."""

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -113,7 +113,7 @@ class ChangeLog:
             elif level == 3 and level_2_seen == 1:
                 current_section = content
                 self.section_content.setdefault(content, [])
-            elif level_2_seen == 1 and current_section != None:
+            elif level_2_seen == 1 and current_section is not None:
                 if line.strip():
                     self.section_content[current_section].append(line)
             elif level_2_seen <= 1:

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -232,18 +232,23 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('--dir', '-d', metavar='DIR',
                         default='ChangeLog.d',
-                        help='Directory to read entries from (default: ChangeLog.d)')
+                        help='Directory to read entries from'
+                             ' (default: ChangeLog.d)')
     parser.add_argument('--input', '-i', metavar='FILE',
                         default='ChangeLog.md',
-                        help='Existing changelog file to read from and augment (default: ChangeLog.md)')
+                        help='Existing changelog file to read from and augment'
+                             ' (default: ChangeLog.md)')
     parser.add_argument('--keep-entries',
                         action='store_true', dest='keep_entries', default=None,
-                        help='Keep the files containing entries (default: remove them if --output/-o is not specified)')
+                        help='Keep the files containing entries'
+                             ' (default: remove them if --output/-o is not specified)')
     parser.add_argument('--no-keep-entries',
                         action='store_false', dest='keep_entries',
-                        help='Remove the files containing entries after they are merged (default: remove them if --output/-o is not specified)')
+                        help='Remove the files containing entries after they are merged'
+                             ' (default: remove them if --output/-o is not specified)')
     parser.add_argument('--output', '-o', metavar='FILE',
-                        help='Output changelog file (default: overwrite the input)')
+                        help='Output changelog file'
+                             ' (default: overwrite the input)')
     options = parser.parse_args()
     set_defaults(options)
     merge_entries(options)

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+
+"""Assemble Mbed Crypto change log entries into the change log file.
+"""
+
+# Copyright (C) 2019, Arm Limited, All Rights Reserved
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This file is part of Mbed Crypto (https://tls.mbed.org)
+
+import argparse
+import glob
+import os
+import re
+import sys
+
+class InputFormatError(Exception):
+    def __init__(self, filename, line_number, message, *args, **kwargs):
+        self.filename = filename
+        self.line_number = line_number
+        self.message = message.format(*args, **kwargs)
+    def __str__(self):
+        return '{}:{}: {}'.format(self.filename, self.line_number, self.message)
+
+STANDARD_SECTIONS = (
+    b'Interface changes',
+    b'Default behavior changes',
+    b'Requirement changes',
+    b'New deprecations',
+    b'Removals',
+    b'New features',
+    b'Security',
+    b'Bug fixes',
+    b'Performance improvements',
+    b'Other changes',
+)
+
+class ChangeLog:
+    """An Mbed Crypto changelog.
+
+    A changelog is a file in Markdown format. Each level 2 section title
+    starts a version, and versions are sorted in reverse chronological
+    order. Lines with a level 2 section title must start with '##'.
+
+    Within a version, there are multiple sections, each devoted to a kind
+    of change: bug fix, feature request, etc. Section titles should match
+    entries in STANDARD_SECTIONS exactly.
+
+    Within each section, each separate change should be on a line starting
+    with a '*' bullet. There may be blank lines surrounding titles, but
+    there should not be any blank line inside a section.
+    """
+
+    _title_re = re.compile(br'#*')
+    def title_level(self, line):
+        """Determine whether the line is a title.
+
+        Return (level, content) where level is the Markdown section level
+        (1 for '#', 2 for '##', etc.) and content is the section title
+        without leading or trailing whitespace. For a non-title line,
+        the level is 0.
+        """
+        level = re.match(self._title_re, line).end()
+        return level, line[level:].strip()
+
+    def add_sections(self, *sections):
+        """Add the specified section titles to the list of known sections.
+
+        Sections will be printed back out in the order they were added.
+        """
+        for section in sections:
+            if section not in self.section_content:
+                self.section_list.append(section)
+                self.section_content[section] = []
+
+    def __init__(self, input_stream):
+        """Create a changelog object.
+
+        Read lines from input_stream, which is typically a file opened
+        for reading.
+        """
+        level_2_seen = 0
+        current_section = None
+        self.header = []
+        self.section_list = []
+        self.section_content = {}
+        self.add_sections(*STANDARD_SECTIONS)
+        self.trailer = []
+        for line in input_stream:
+            level, content = self.title_level(line)
+            if level == 2:
+                level_2_seen += 1
+                if level_2_seen <= 1:
+                    self.header.append(line)
+                else:
+                    self.trailer.append(line)
+            elif level == 3 and level_2_seen == 1:
+                current_section = content
+                self.add_sections(current_section)
+            elif level_2_seen == 1 and current_section != None:
+                if line.strip():
+                    self.section_content[current_section].append(line)
+            elif level_2_seen <= 1:
+                self.header.append(line)
+            else:
+                self.trailer.append(line)
+
+    def add_file(self, input_stream):
+        """Add changelog entries from a file.
+
+        Read lines from input_stream, which is typically a file opened
+        for reading. These lines must contain a series of level 3
+        Markdown sections with recognized titles. The corresponding
+        content is injected into the respective sections in the changelog.
+        The section titles must be either one of the hard-coded values
+        in assemble_changelog.py or already present in ChangeLog.md.
+        """
+        filename = input_stream.name
+        current_section = None
+        for line_number, line in enumerate(input_stream, 1):
+            if not line.strip():
+                continue
+            level, content = self.title_level(line)
+            if level == 3:
+                current_section = content
+                if current_section not in self.section_content:
+                    raise InputFormatError(filename, line_number,
+                                           'Section {} is not recognized',
+                                           str(current_section)[1:])
+            elif level == 0:
+                if current_section is None:
+                    raise InputFormatError(filename, line_number,
+                                           'Missing section title at the beginning of the file')
+                self.section_content[current_section].append(line)
+            else:
+                raise InputFormatError(filename, line_number,
+                                       'Only level 3 headers (###) are permitted')
+
+    def write(self, filename):
+        """Write the changelog to the specified file.
+        """
+        with open(filename, 'wb') as out:
+            for line in self.header:
+                out.write(line)
+            for section in self.section_list:
+                lines = self.section_content[section]
+                while lines and not lines[0].strip():
+                    del lines[0]
+                while lines and not lines[-1].strip():
+                    del lines[-1]
+                if not lines:
+                    continue
+                out.write(b'### ' + section + b'\n\n')
+                for line in lines:
+                    out.write(line)
+                out.write(b'\n')
+            for line in self.trailer:
+                out.write(line)
+
+def finish_output(files_to_remove, changelog, output_file):
+    """Write the changelog to the output file.
+
+    Remove the specified input files.
+    """
+    if os.path.exists(output_file) and not os.path.isfile(output_file):
+        # The output is a non-regular file (e.g. pipe). Write to it directly.
+        output_temp = output_file
+    else:
+        # The output is a regular file. Write to a temporary file,
+        # then move it into place atomically.
+        output_temp = output_file + '.tmp'
+    changelog.write(output_temp)
+    for filename in files_to_remove:
+        sys.stderr.write('Removing ' + filename + '\n')
+        #os.remove(filename)
+    if output_temp != output_file:
+        os.rename(output_temp, output_file)
+
+def merge_entries(options):
+    """Merge changelog entries into the changelog file.
+
+    Read the changelog file from options.input.
+    Read entries to merge from the directory options.dir.
+    Write the new changelog to options.output.
+    Remove the merged entries if options.keep_entries is false.
+    """
+    with open(options.input, 'rb') as input_file:
+        changelog = ChangeLog(input_file)
+    files_to_merge = glob.glob(os.path.join(options.dir, '*.md'))
+    if not files_to_merge:
+        sys.stderr.write('There are no pending changelog entries.\n')
+        return
+    for filename in files_to_merge:
+        with open(filename, 'rb') as input_file:
+            changelog.add_file(input_file)
+    files_to_remove = [] if options.keep_entries else files_to_merge
+    finish_output(files_to_remove, changelog, options.output)
+
+def set_defaults(options):
+    """Add default values for missing options."""
+    output_file = getattr(options, 'output', None)
+    if output_file is None:
+        options.output = options.input
+    if getattr(options, 'keep_entries', None) is None:
+        options.keep_entries = (output_file is not None)
+
+def main():
+    """Command line entry point."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--dir', '-d', metavar='DIR',
+                        default='ChangeLog.d',
+                        help='Directory to read entries from (default: ChangeLog.d)')
+    parser.add_argument('--input', '-i', metavar='FILE',
+                        default='ChangeLog.md',
+                        help='Existing changelog file to read from and augment (default: ChangeLog.md)')
+    parser.add_argument('--keep-entries',
+                        action='store_true', dest='keep_entries', default=None,
+                        help='Keep the files containing entries (default: remove them if --output/-o is not specified)')
+    parser.add_argument('--no-keep-entries',
+                        action='store_false', dest='keep_entries',
+                        help='Remove the files containing entries after they are merged (default: remove them if --output/-o is not specified)')
+    parser.add_argument('--output', '-o', metavar='FILE',
+                        help='Output changelog file (default: overwrite the input)')
+    options = parser.parse_args()
+    set_defaults(options)
+    merge_entries(options)
+
+if __name__ == '__main__':
+    main()

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -84,9 +84,10 @@ class ChangeLog:
         return level, line[level:].strip()
 
     # Only accept dotted version numbers (e.g. "3.1", not "3").
-    # Refuse ".x" in a version number: this indicates a version that is
-    # not yet released.
-    _version_number_re = re.compile(br'[0-9]\.[0-9][0-9.]+([^.]|\.[^0-9x])')
+    # Refuse ".x" in a version number where x is a letter: this indicates
+    # a version that is not yet released. Something like "3.1a" is accepted.
+    _version_number_re = re.compile(br'[0-9]+\.[0-9A-Za-z.]+')
+    _incomplete_version_number_re = re.compile(br'.*\.[A-Za-z]')
 
     def section_is_released_version(self, title):
         """Whether this section is for a released version.
@@ -98,7 +99,11 @@ class ChangeLog:
         # that follows a particular pattern. These criteria may be revised
         # as needed in future versions of this script.
         version_number = re.search(self._version_number_re, title)
-        return bool(version_number)
+        if version_number:
+            return not re.search(self._incomplete_version_number_re,
+                                 version_number.group(0))
+        else:
+            return False
 
     def unreleased_version_title(self):
         """The title to use if creating a new section for an unreleased version."""

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -88,8 +88,9 @@ class ChangeLog:
     def __init__(self, input_stream):
         """Create a changelog object.
 
-        Read lines from input_stream, which is typically a file opened
-        for reading.
+        Populate the changelog object from the content of the file
+        input_stream. This is typically a file opened for reading, but
+        can be any generator returning the lines to read.
         """
         level_2_seen = 0
         current_section = None
@@ -125,7 +126,9 @@ class ChangeLog:
         Markdown sections with recognized titles. The corresponding
         content is injected into the respective sections in the changelog.
         The section titles must be either one of the hard-coded values
-        in assemble_changelog.py or already present in ChangeLog.md.
+        in STANDARD_SECTIONS in assemble_changelog.py or already present
+        in ChangeLog.md. Section titles must match byte-for-byte except that
+        leading or trailing whitespace is ignored.
         """
         filename = input_stream.name
         current_section = None

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -168,10 +168,6 @@ class ChangeLog:
             for line in self.header:
                 out.write(line)
             for section, lines in self.section_content.items():
-                while lines and not lines[0].strip():
-                    del lines[0]
-                while lines and not lines[-1].strip():
-                    del lines[-1]
                 if not lines:
                     continue
                 out.write(b'### ' + section + b'\n\n')

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -92,13 +92,22 @@ class ChangeLog:
         input_stream. This is typically a file opened for reading, but
         can be any generator returning the lines to read.
         """
-        level_2_seen = 0
-        current_section = None
         self.header = []
         self.section_list = []
         self.section_content = {}
         self.add_sections(*STANDARD_SECTIONS)
         self.trailer = []
+        self.read_main_file(input_stream)
+
+    def read_main_file(self, input_stream):
+        """Populate the changelog object from the content of the file.
+
+        This method is only intended to be called as part of the constructor
+        of the class and may not act sensibly on an object that is already
+        partially populated.
+        """
+        level_2_seen = 0
+        current_section = None
         for line in input_stream:
             level, content = self.title_level(line)
             if level == 2:


### PR DESCRIPTION
This is a first go at tooling to assemble a changelog file for Mbed Crypto.

`scripts/assemble_changelog.py` reads changelog entries from `ChangeLog.d/*.md` and merges them into `ChangeLog.md`. Currently the script is independent from git but I expect future versions to determine the merge order by analyzing the git history.
