### PR TITLE
CTR_DRBG: grab a nonce from the entropy source if needed

### DIFF
--- a/include/mbedtls/ctr_drbg.h
+++ b/include/mbedtls/ctr_drbg.h
@@ -169,14 +169,19 @@ extern "C" {
 typedef struct mbedtls_ctr_drbg_context
 {
     unsigned char counter[16];  /*!< The counter (V). */
-    int reseed_counter;         /*!< The reseed counter. */
+    int reseed_counter;         /*!< The reseed counter.
+                                 * This is the number of requests that have
+                                 * been made since the last (re)seeding,
+                                 * minus one. */
     int prediction_resistance;  /*!< This determines whether prediction
                                      resistance is enabled, that is
                                      whether to systematically reseed before
                                      each random generation. */
     size_t entropy_len;         /*!< The amount of entropy grabbed on each
-                                     seed or reseed operation. */
-    int reseed_interval;        /*!< The reseed interval. */
+                                     seed or reseed operation, in bytes. */
+    int reseed_interval;        /*!< The reseed interval.
+                                 * This is the maximum number of requests
+                                 * that can be made between reseedings. */
 
     mbedtls_aes_context aes_ctx;        /*!< The AES context. */
 

--- a/include/mbedtls/ctr_drbg.h
+++ b/include/mbedtls/ctr_drbg.h
@@ -147,6 +147,24 @@
 extern "C" {
 #endif
 
+#if MBEDTLS_CTR_DRBG_ENTROPY_LEN >= MBEDTLS_CTR_DRBG_KEYSIZE * 3 / 2
+/** The default length of the nonce read from the entropy source.
+ *
+ * This is \c 0 because a single read from the entropy source is sufficient
+ * to include a nonce.
+ * See the documentation of mbedtls_ctr_drbg_seed() for more information.
+ */
+#define MBEDTLS_CTR_DRBG_ENTROPY_NONCE_LEN 0
+#else
+/** The default length of the nonce read from the entropy source.
+ *
+ * This is half of the default entropy length because a single read from
+ * the entropy source does not provide enough material to form a nonce.
+ * See the documentation of mbedtls_ctr_drbg_seed() for more information.
+ */
+#define MBEDTLS_CTR_DRBG_ENTROPY_NONCE_LEN ( MBEDTLS_CTR_DRBG_ENTROPY_LEN + 1 ) / 2
+#endif
+
 /**
  * \brief          The CTR_DRBG context structure.
  */
@@ -216,20 +234,9 @@ void mbedtls_ctr_drbg_init( mbedtls_ctr_drbg_context *ctx );
  *   by the key size and entropy length according to NIST SP 800-90A §10.2.1;
  * - Half the entropy length otherwise.
  * You can override it by calling mbedtls_ctr_drbg_set_nonce_len().
- */
-#if MBEDTLS_CTR_DRBG_ENTROPY_LEN >= MBEDTLS_CTR_DRBG_KEYSIZE * 3 / 2
-/** With the default entropy length, the entropy nonce length is \c 0.
- */
-#elif MBEDTLS_CTR_DRBG_ENTROPY_LEN & 1
-/** With the default entropy length, the entropy nonce length is
- * (#MBEDTLS_CTR_DRBG_ENTROPY_LEN + 1) / 2.
- */
-#else
-/** With the default entropy length, the entropy nonce length is
- * #MBEDTLS_CTR_DRBG_ENTROPY_LEN / 2.
- */
-#endif
-/**
+ * With the default entropy length, the entropy nonce length is
+ * #MBEDTLS_CTR_DRBG_ENTROPY_NONCE_LEN.
+ *
  * You can provide a nonce and personalization string in addition to the
  * entropy source, to make this instantiation as unique as possible.
  * See SP 800-90A §8.6.7 for more details about nonces.
@@ -240,7 +247,7 @@ void mbedtls_ctr_drbg_init( mbedtls_ctr_drbg_context *ctx );
  * - A string obtained by calling \p f_entropy function for the entropy
  *   length.
  */
-#if MBEDTLS_CTR_DRBG_ENTROPY_LEN >= MBEDTLS_CTR_DRBG_KEYSIZE * 3 / 2
+#if MBEDTLS_CTR_DRBG_ENTROPY_NONCE_LEN == 0
 /**
  * - If mbedtls_ctr_drbg_set_nonce_len() has been called, a string
  *   obtained by calling \p f_entropy function for the specified length.

--- a/include/mbedtls/ctr_drbg.h
+++ b/include/mbedtls/ctr_drbg.h
@@ -301,11 +301,6 @@ void mbedtls_ctr_drbg_set_prediction_resistance( mbedtls_ctr_drbg_context *ctx,
  *
  * The default value is #MBEDTLS_CTR_DRBG_ENTROPY_LEN.
  *
- * \note                mbedtls_ctr_drbg_seed() always sets the entropy length
- *                      to #MBEDTLS_CTR_DRBG_ENTROPY_LEN, so this function
- *                      only has an effect when it is called after
- *                      mbedtls_ctr_drbg_seed().
- *
  * \note                The security strength of CTR_DRBG is bounded by the
  *                      entropy length. Thus:
  *                      - When using AES-256

--- a/include/mbedtls/ctr_drbg.h
+++ b/include/mbedtls/ctr_drbg.h
@@ -278,6 +278,13 @@ void mbedtls_ctr_drbg_init( mbedtls_ctr_drbg_context *ctx );
  *                      (maximum achievable strength when using AES-256).
  *
  * \param ctx           The CTR_DRBG context to seed.
+ *                      It must have been initialized with
+ *                      mbedtls_ctr_drbg_init().
+ *                      After a successful call to mbedtls_ctr_drbg_seed(),
+ *                      you may not call mbedtls_ctr_drbg_seed() again on
+ *                      the same context unless you call
+ *                      mbedtls_ctr_drbg_free() and mbedtls_ctr_drbg_init()
+ *                      again first.
  * \param f_entropy     The entropy callback, taking as arguments the
  *                      \p p_entropy context, the buffer to fill, and the
  *                      length of the buffer.

--- a/include/mbedtls/hmac_drbg.h
+++ b/include/mbedtls/hmac_drbg.h
@@ -139,7 +139,7 @@ void mbedtls_hmac_drbg_init( mbedtls_hmac_drbg_context *ctx );
  *                      Note that SHA-256 is just as efficient as SHA-224.
  *                      The security strength can be reduced if a smaller
  *                      entropy length is set with
- *                      mbedtls_hmac_drbg_set_entropy_len() afterwards.
+ *                      mbedtls_hmac_drbg_set_entropy_len().
  *
  * \note                The default entropy length is the security strength
  *                      (converted from bits to bytes). You can override
@@ -222,14 +222,9 @@ void mbedtls_hmac_drbg_set_prediction_resistance( mbedtls_hmac_drbg_context *ctx
 
 /**
  * \brief               This function sets the amount of entropy grabbed on each
- *                      reseed.
+ *                      seed or reseed.
  *
- * The default value is set by mbedtls_hmac_drbg_seed().
- *
- * \note                mbedtls_hmac_drbg_seed() always sets the entropy length
- *                      to the default value based on the chosen MD algorithm,
- *                      so this function only has an effect if it is called
- *                      after mbedtls_hmac_drbg_seed().
+ * See the documentation of mbedtls_hmac_drbg_seed() for the default value.
  *
  * \param ctx           The HMAC_DRBG context.
  * \param len           The amount of entropy to grab, in bytes.

--- a/library/ctr_drbg.c
+++ b/library/ctr_drbg.c
@@ -732,6 +732,7 @@ int mbedtls_ctr_drbg_self_test( int verbose )
 
     test_offset = 0;
     mbedtls_ctr_drbg_set_entropy_len( &ctx, 32 );
+    mbedtls_ctr_drbg_set_nonce_len( &ctx, 0 );
     CHK( mbedtls_ctr_drbg_seed( &ctx,
                                 ctr_drbg_self_test_entropy,
                                 (void *) entropy_source_pr,
@@ -756,6 +757,7 @@ int mbedtls_ctr_drbg_self_test( int verbose )
 
     test_offset = 0;
     mbedtls_ctr_drbg_set_entropy_len( &ctx, 32 );
+    mbedtls_ctr_drbg_set_nonce_len( &ctx, 0 );
     CHK( mbedtls_ctr_drbg_seed( &ctx,
                                 ctr_drbg_self_test_entropy,
                                 (void *) entropy_source_nopr,

--- a/library/ctr_drbg.c
+++ b/library/ctr_drbg.c
@@ -382,14 +382,13 @@ exit:
 }
 
 /* CTR_DRBG_Instantiate with derivation function (SP 800-90A &sect;10.2.1.3.2)
- * mbedtls_ctr_drbg_seed_entropy_len(ctx, f_entropy, p_entropy,
- *                                   custom, len, entropy_len)
+ * mbedtls_ctr_drbg_seed(ctx, f_entropy, p_entropy, custom, len)
  * implements
  * CTR_DRBG_Instantiate(entropy_input, nonce, personalization_string,
  *                      security_strength) -> initial_working_state
  * with inputs
  *   custom[:len] = nonce || personalization_string
- * where entropy_input comes from f_entropy for entropy_len bytes
+ * where entropy_input comes from f_entropy for ctx->entropy_len bytes
  * and with outputs
  *   ctx = initial_working_state
  */

--- a/library/ctr_drbg.c
+++ b/library/ctr_drbg.c
@@ -357,10 +357,10 @@ void mbedtls_ctr_drbg_update( mbedtls_ctr_drbg_context *ctx,
  * and with output
  *   ctx contains new_working_state
  */
-int mbedtls_ctr_drbg_reseed_internal( mbedtls_ctr_drbg_context *ctx,
-                                      const unsigned char *additional,
-                                      size_t len,
-                                      size_t nonce_len )
+static int mbedtls_ctr_drbg_reseed_internal( mbedtls_ctr_drbg_context *ctx,
+                                             const unsigned char *additional,
+                                             size_t len,
+                                             size_t nonce_len )
 {
     unsigned char seed[MBEDTLS_CTR_DRBG_MAX_SEED_INPUT];
     size_t seedlen = 0;

--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -686,12 +686,13 @@ int main( int argc, char *argv[] )
         mbedtls_ctr_drbg_context ctr_drbg;
 
         mbedtls_ctr_drbg_init( &ctr_drbg );
-
         if( mbedtls_ctr_drbg_seed( &ctr_drbg, myrand, NULL, NULL, 0 ) != 0 )
             mbedtls_exit(1);
         TIME_AND_TSC( "CTR_DRBG (NOPR)",
                 mbedtls_ctr_drbg_random( &ctr_drbg, buf, BUFSIZE ) );
+        mbedtls_ctr_drbg_free( &ctr_drbg );
 
+        mbedtls_ctr_drbg_init( &ctr_drbg );
         if( mbedtls_ctr_drbg_seed( &ctr_drbg, myrand, NULL, NULL, 0 ) != 0 )
             mbedtls_exit(1);
         mbedtls_ctr_drbg_set_prediction_resistance( &ctr_drbg, MBEDTLS_CTR_DRBG_PR_ON );

--- a/tests/suites/test_suite_ctr_drbg.data
+++ b/tests/suites/test_suite_ctr_drbg.data
@@ -1071,6 +1071,11 @@ depends_on:MBEDTLS_CTR_DRBG_USE_128_BIT_KEY
 ctr_drbg_validate_pr:"d4f1f4ae08bcb3e1":"5d4041942bcf68864a4997d8171f1f9fef55a769b7eaf03fe082029bb32a2b9d8239e865c0a42e14b964b9c09de85a20":"":"":"4155320287eedcf7d484c2c2a1e2eb64b9c9ce77c87202a1ae1616c7a5cfd1c687c7a0bfcc85bda48fdd4629fd330c22d0a76076f88fc7cd04037ee06b7af602"
 
 CTR_DRBG entropy usage (entropy_nonce_len=0 by default)
+depends_on:!DEFAULT_ENTROPY_NONCE
+ctr_drbg_entropy_usage:-1
+
+CTR_DRBG entropy usage (entropy_nonce_len=entropy_len/2 by default)
+depends_on:DEFAULT_ENTROPY_NONCE
 ctr_drbg_entropy_usage:-1
 
 CTR_DRBG entropy usage (entropy_nonce_len=0)

--- a/tests/suites/test_suite_ctr_drbg.data
+++ b/tests/suites/test_suite_ctr_drbg.data
@@ -1070,8 +1070,14 @@ CTR_DRBG CAVS 14.3 (AES-128 use df,True,128,64,0,0) #0
 depends_on:MBEDTLS_CTR_DRBG_USE_128_BIT_KEY
 ctr_drbg_validate_pr:"d4f1f4ae08bcb3e1":"5d4041942bcf68864a4997d8171f1f9fef55a769b7eaf03fe082029bb32a2b9d8239e865c0a42e14b964b9c09de85a20":"":"":"4155320287eedcf7d484c2c2a1e2eb64b9c9ce77c87202a1ae1616c7a5cfd1c687c7a0bfcc85bda48fdd4629fd330c22d0a76076f88fc7cd04037ee06b7af602"
 
-CTR_DRBG entropy usage
-ctr_drbg_entropy_usage:
+CTR_DRBG entropy usage (entropy_nonce_len=0 by default)
+ctr_drbg_entropy_usage:-1
+
+CTR_DRBG entropy usage (entropy_nonce_len=0)
+ctr_drbg_entropy_usage:0
+
+CTR_DRBG entropy usage (entropy_nonce_len=7)
+ctr_drbg_entropy_usage:7
 
 CTR_DRBG write/update seed file [#1]
 ctr_drbg_seed_file:"data_files/ctr_drbg_seed":0

--- a/tests/suites/test_suite_ctr_drbg.data
+++ b/tests/suites/test_suite_ctr_drbg.data
@@ -1070,12 +1070,7 @@ CTR_DRBG CAVS 14.3 (AES-128 use df,True,128,64,0,0) #0
 depends_on:MBEDTLS_CTR_DRBG_USE_128_BIT_KEY
 ctr_drbg_validate_pr:"d4f1f4ae08bcb3e1":"5d4041942bcf68864a4997d8171f1f9fef55a769b7eaf03fe082029bb32a2b9d8239e865c0a42e14b964b9c09de85a20":"":"":"4155320287eedcf7d484c2c2a1e2eb64b9c9ce77c87202a1ae1616c7a5cfd1c687c7a0bfcc85bda48fdd4629fd330c22d0a76076f88fc7cd04037ee06b7af602"
 
-CTR_DRBG entropy usage (entropy_nonce_len=0 by default)
-depends_on:!DEFAULT_ENTROPY_NONCE
-ctr_drbg_entropy_usage:-1
-
-CTR_DRBG entropy usage (entropy_nonce_len=entropy_len/2 by default)
-depends_on:DEFAULT_ENTROPY_NONCE
+CTR_DRBG entropy usage (default entropy_nonce_len)
 ctr_drbg_entropy_usage:-1
 
 CTR_DRBG entropy usage (entropy_nonce_len=0)
@@ -1083,6 +1078,14 @@ ctr_drbg_entropy_usage:0
 
 CTR_DRBG entropy usage (entropy_nonce_len=7)
 ctr_drbg_entropy_usage:7
+
+CTR_DRBG entropy strength: 128 bits
+depends_on:MBEDTLS_CTR_DRBG_USE_128_BIT_KEY
+ctr_drbg_entropy_strength:128
+
+CTR_DRBG entropy strength: 256 bits
+depends_on:!MBEDTLS_CTR_DRBG_USE_128_BIT_KEY
+ctr_drbg_entropy_strength:256
 
 CTR_DRBG write/update seed file [#1]
 ctr_drbg_seed_file:"data_files/ctr_drbg_seed":0

--- a/tests/suites/test_suite_ctr_drbg.function
+++ b/tests/suites/test_suite_ctr_drbg.function
@@ -190,7 +190,7 @@ void ctr_drbg_validate_reseed_first( data_t * add_init, data_t * entropy,
 
 
 /* BEGIN_CASE */
-void ctr_drbg_entropy_usage(  )
+void ctr_drbg_entropy_usage( int entropy_nonce_len )
 {
     unsigned char out[16];
     unsigned char add[16];
@@ -206,9 +206,14 @@ void ctr_drbg_entropy_usage(  )
     memset( out, 0, sizeof( out ) );
     memset( add, 0, sizeof( add ) );
 
+    if( entropy_nonce_len >= 0 )
+        TEST_ASSERT( mbedtls_ctr_drbg_set_nonce_len( &ctx, entropy_nonce_len ) == 0 );
+
     /* Init must use entropy */
     TEST_ASSERT( mbedtls_ctr_drbg_seed( &ctx, mbedtls_test_entropy_func, entropy, NULL, 0 ) == 0 );
     expected_idx += MBEDTLS_CTR_DRBG_ENTROPY_LEN;
+    if( entropy_nonce_len >= 0 )
+        expected_idx += entropy_nonce_len;
     TEST_EQUAL( test_offset_idx, expected_idx );
 
     /* By default, PR is off and reseed_interval is large,

--- a/tests/suites/test_suite_ctr_drbg.function
+++ b/tests/suites/test_suite_ctr_drbg.function
@@ -197,7 +197,7 @@ void ctr_drbg_entropy_usage(  )
     unsigned char entropy[1024];
     mbedtls_ctr_drbg_context ctx;
     size_t i, reps = 10;
-    size_t last_idx;
+    size_t expected_idx = 0;
 
     mbedtls_ctr_drbg_init( &ctx );
     test_offset_idx = 0;
@@ -207,20 +207,19 @@ void ctr_drbg_entropy_usage(  )
     memset( add, 0, sizeof( add ) );
 
     /* Init must use entropy */
-    last_idx = test_offset_idx;
     TEST_ASSERT( mbedtls_ctr_drbg_seed( &ctx, mbedtls_test_entropy_func, entropy, NULL, 0 ) == 0 );
-    TEST_ASSERT( last_idx < test_offset_idx );
+    expected_idx += MBEDTLS_CTR_DRBG_ENTROPY_LEN;
+    TEST_EQUAL( test_offset_idx, expected_idx );
 
     /* By default, PR is off and reseed_interval is large,
      * so the next few calls should not use entropy */
-    last_idx = test_offset_idx;
     for( i = 0; i < reps; i++ )
     {
         TEST_ASSERT( mbedtls_ctr_drbg_random( &ctx, out, sizeof( out ) - 4 ) == 0 );
         TEST_ASSERT( mbedtls_ctr_drbg_random_with_add( &ctx, out, sizeof( out ) - 4,
                                                 add, sizeof( add ) ) == 0 );
     }
-    TEST_ASSERT( last_idx == test_offset_idx );
+    TEST_EQUAL( test_offset_idx, expected_idx );
 
     /* While at it, make sure we didn't write past the requested length */
     TEST_ASSERT( out[sizeof( out ) - 4] == 0 );
@@ -232,17 +231,17 @@ void ctr_drbg_entropy_usage(  )
      * so the next call should reseed */
     mbedtls_ctr_drbg_set_reseed_interval( &ctx, 2 * reps );
     TEST_ASSERT( mbedtls_ctr_drbg_random( &ctx, out, sizeof( out ) ) == 0 );
-    TEST_ASSERT( last_idx < test_offset_idx );
+    expected_idx += MBEDTLS_CTR_DRBG_ENTROPY_LEN;
+    TEST_EQUAL( test_offset_idx, expected_idx );
 
     /* The new few calls should not reseed */
-    last_idx = test_offset_idx;
     for( i = 0; i < reps / 2; i++ )
     {
         TEST_ASSERT( mbedtls_ctr_drbg_random( &ctx, out, sizeof( out ) ) == 0 );
         TEST_ASSERT( mbedtls_ctr_drbg_random_with_add( &ctx, out, sizeof( out ) ,
                                                 add, sizeof( add ) ) == 0 );
     }
-    TEST_ASSERT( last_idx == test_offset_idx );
+    TEST_EQUAL( test_offset_idx, expected_idx );
 
     /* Call update with too much data (sizeof entropy > MAX(_SEED)_INPUT).
      * Make sure it's detected as an error and doesn't cause memory
@@ -253,18 +252,19 @@ void ctr_drbg_entropy_usage(  )
     /* Now enable PR, so the next few calls should all reseed */
     mbedtls_ctr_drbg_set_prediction_resistance( &ctx, MBEDTLS_CTR_DRBG_PR_ON );
     TEST_ASSERT( mbedtls_ctr_drbg_random( &ctx, out, sizeof( out ) ) == 0 );
-    TEST_ASSERT( last_idx < test_offset_idx );
+    expected_idx += MBEDTLS_CTR_DRBG_ENTROPY_LEN;
+    TEST_EQUAL( test_offset_idx, expected_idx );
 
     /* Finally, check setting entropy_len */
     mbedtls_ctr_drbg_set_entropy_len( &ctx, 42 );
-    last_idx = test_offset_idx;
     TEST_ASSERT( mbedtls_ctr_drbg_random( &ctx, out, sizeof( out ) ) == 0 );
-    TEST_ASSERT( test_offset_idx - last_idx == 42 );
+    expected_idx += 42;
+    TEST_EQUAL( test_offset_idx, expected_idx );
 
     mbedtls_ctr_drbg_set_entropy_len( &ctx, 13 );
-    last_idx = test_offset_idx;
     TEST_ASSERT( mbedtls_ctr_drbg_random( &ctx, out, sizeof( out ) ) == 0 );
-    TEST_ASSERT( test_offset_idx - last_idx == 13 );
+    expected_idx += 13;
+    TEST_EQUAL( test_offset_idx, expected_idx );
 
 exit:
     mbedtls_ctr_drbg_free( &ctx );

--- a/tests/suites/test_suite_ctr_drbg.function
+++ b/tests/suites/test_suite_ctr_drbg.function
@@ -3,14 +3,6 @@
 #include "mbedtls/ctr_drbg.h"
 #include "string.h"
 
-/* mbedtls_ctr_drbg_seed() grabs a nonce by default if the entropy
- * length is smaller than 3/2 times the maximum security strength. */
-#if MBEDTLS_CTR_DRBG_ENTROPY_LEN >= MBEDTLS_CTR_DRBG_KEYSIZE * 3 / 2
-#undef DEFAULT_ENTROPY_NONCE
-#else
-#define DEFAULT_ENTROPY_NONCE
-#endif
-
 /* Modes for ctr_drbg_validate */
 enum reseed_mode
 {
@@ -196,7 +188,37 @@ void ctr_drbg_validate_reseed_first( data_t * add_init, data_t * entropy,
 }
 /* END_CASE */
 
+/* BEGIN_CASE */
+void ctr_drbg_entropy_strength( int expected_bit_strength )
+{
+    unsigned char entropy[/*initial entropy*/ MBEDTLS_CTR_DRBG_ENTROPY_LEN +
+                          /*nonce*/     MBEDTLS_CTR_DRBG_ENTROPY_NONCE_LEN +
+                          /*reseed*/          MBEDTLS_CTR_DRBG_ENTROPY_LEN];
+    mbedtls_ctr_drbg_context ctx;
+    size_t last_idx;
+    size_t byte_strength = expected_bit_strength / 8;
 
+    mbedtls_ctr_drbg_init( &ctx );
+    test_offset_idx = 0;
+    test_max_idx = sizeof( entropy );
+    memset( entropy, 0, sizeof( entropy ) );
+
+    /* The initial seeding must grab at least byte_strength bytes of entropy
+     * for the entropy input and byte_strength/2 bytes for a nonce. */
+    TEST_ASSERT( mbedtls_ctr_drbg_seed( &ctx,
+                                        mbedtls_test_entropy_func, entropy,
+                                        NULL, 0 ) == 0 );
+    TEST_ASSERT( test_offset_idx >= ( byte_strength * 3 + 1 ) / 2 );
+    last_idx = test_offset_idx;
+
+    /* A reseed must grab at least byte_strength bytes of entropy. */
+    TEST_ASSERT( mbedtls_ctr_drbg_reseed( &ctx, NULL, 0 ) == 0 );
+    TEST_ASSERT( test_offset_idx - last_idx >= byte_strength );
+
+exit:
+    mbedtls_ctr_drbg_free( &ctx );
+}
+/* END_CASE */
 
 /* BEGIN_CASE */
 void ctr_drbg_entropy_usage( int entropy_nonce_len )
@@ -224,11 +246,7 @@ void ctr_drbg_entropy_usage( int entropy_nonce_len )
     if( entropy_nonce_len >= 0 )
         expected_idx += entropy_nonce_len;
     else
-    {
-#if defined(DEFAULT_ENTROPY_NONCE)
-        expected_idx += ( MBEDTLS_CTR_DRBG_ENTROPY_LEN + 1 ) / 2;
-#endif
-    }
+        expected_idx += MBEDTLS_CTR_DRBG_ENTROPY_NONCE_LEN;
     TEST_EQUAL( test_offset_idx, expected_idx );
 
     /* By default, PR is off and reseed_interval is large,

--- a/tests/suites/test_suite_ctr_drbg.function
+++ b/tests/suites/test_suite_ctr_drbg.function
@@ -45,6 +45,7 @@ static void ctr_drbg_validate_internal( int reseed_mode, data_t * nonce,
     /* CTR_DRBG_Instantiate(entropy[:entropy->len], nonce, perso, <ignored>)
      * where nonce||perso = nonce[nonce->len] */
     mbedtls_ctr_drbg_set_entropy_len( &ctx, entropy_chunk_len );
+    mbedtls_ctr_drbg_set_nonce_len( &ctx, 0 );
     TEST_ASSERT( mbedtls_ctr_drbg_seed(
                      &ctx,
                      mbedtls_test_entropy_func, entropy->x,

--- a/tests/suites/test_suite_ctr_drbg.function
+++ b/tests/suites/test_suite_ctr_drbg.function
@@ -3,6 +3,14 @@
 #include "mbedtls/ctr_drbg.h"
 #include "string.h"
 
+/* mbedtls_ctr_drbg_seed() grabs a nonce by default if the entropy
+ * length is smaller than 3/2 times the maximum security strength. */
+#if MBEDTLS_CTR_DRBG_ENTROPY_LEN >= MBEDTLS_CTR_DRBG_KEYSIZE * 3 / 2
+#undef DEFAULT_ENTROPY_NONCE
+#else
+#define DEFAULT_ENTROPY_NONCE
+#endif
+
 /* Modes for ctr_drbg_validate */
 enum reseed_mode
 {
@@ -215,6 +223,12 @@ void ctr_drbg_entropy_usage( int entropy_nonce_len )
     expected_idx += MBEDTLS_CTR_DRBG_ENTROPY_LEN;
     if( entropy_nonce_len >= 0 )
         expected_idx += entropy_nonce_len;
+    else
+    {
+#if defined(DEFAULT_ENTROPY_NONCE)
+        expected_idx += ( MBEDTLS_CTR_DRBG_ENTROPY_LEN + 1 ) / 2;
+#endif
+    }
     TEST_EQUAL( test_offset_idx, expected_idx );
 
     /* By default, PR is off and reseed_interval is large,

--- a/tests/suites/test_suite_hmac_drbg.function
+++ b/tests/suites/test_suite_hmac_drbg.function
@@ -37,7 +37,9 @@ void hmac_drbg_entropy_usage( int md_alg )
     const mbedtls_md_info_t *md_info;
     mbedtls_hmac_drbg_context ctx;
     entropy_ctx entropy;
-    size_t last_len, i, reps = 10;
+    size_t i, reps = 10;
+    size_t default_entropy_len;
+    size_t expected_consumed_entropy = 0;
 
     mbedtls_hmac_drbg_init( &ctx );
     memset( buf, 0, sizeof( buf ) );
@@ -48,23 +50,29 @@ void hmac_drbg_entropy_usage( int md_alg )
 
     md_info = mbedtls_md_info_from_type( md_alg );
     TEST_ASSERT( md_info != NULL );
+    if( mbedtls_md_get_size( md_info ) <= 20 )
+        default_entropy_len = 16;
+    else if( mbedtls_md_get_size( md_info ) <= 28 )
+        default_entropy_len = 24;
+    else
+        default_entropy_len = 32;
 
     /* Init must use entropy */
-    last_len = entropy.len;
     TEST_ASSERT( mbedtls_hmac_drbg_seed( &ctx, md_info, mbedtls_test_entropy_func, &entropy,
                                  NULL, 0 ) == 0 );
-    TEST_ASSERT( entropy.len < last_len );
+    /* default_entropy_len of entropy, plus half as much for the nonce */
+    expected_consumed_entropy += default_entropy_len * 3 / 2;
+    TEST_EQUAL( sizeof( buf )  - entropy.len, expected_consumed_entropy );
 
     /* By default, PR is off and reseed_interval is large,
      * so the next few calls should not use entropy */
-    last_len = entropy.len;
     for( i = 0; i < reps; i++ )
     {
         TEST_ASSERT( mbedtls_hmac_drbg_random( &ctx, out, sizeof( out ) - 4 ) == 0 );
         TEST_ASSERT( mbedtls_hmac_drbg_random_with_add( &ctx, out, sizeof( out ) - 4,
                                                 buf, 16 ) == 0 );
     }
-    TEST_ASSERT( entropy.len == last_len );
+    TEST_EQUAL( sizeof( buf )  - entropy.len, expected_consumed_entropy );
 
     /* While at it, make sure we didn't write past the requested length */
     TEST_ASSERT( out[sizeof( out ) - 4] == 0 );
@@ -76,33 +84,34 @@ void hmac_drbg_entropy_usage( int md_alg )
      * so the next call should reseed */
     mbedtls_hmac_drbg_set_reseed_interval( &ctx, 2 * reps );
     TEST_ASSERT( mbedtls_hmac_drbg_random( &ctx, out, sizeof( out ) ) == 0 );
-    TEST_ASSERT( entropy.len < last_len );
+    expected_consumed_entropy += default_entropy_len;
+    TEST_EQUAL( sizeof( buf )  - entropy.len, expected_consumed_entropy );
 
     /* The new few calls should not reseed */
-    last_len = entropy.len;
     for( i = 0; i < reps / 2; i++ )
     {
         TEST_ASSERT( mbedtls_hmac_drbg_random( &ctx, out, sizeof( out ) ) == 0 );
         TEST_ASSERT( mbedtls_hmac_drbg_random_with_add( &ctx, out, sizeof( out ) ,
                                                 buf, 16 ) == 0 );
     }
-    TEST_ASSERT( entropy.len == last_len );
+    TEST_EQUAL( sizeof( buf )  - entropy.len, expected_consumed_entropy );
 
     /* Now enable PR, so the next few calls should all reseed */
     mbedtls_hmac_drbg_set_prediction_resistance( &ctx, MBEDTLS_HMAC_DRBG_PR_ON );
     TEST_ASSERT( mbedtls_hmac_drbg_random( &ctx, out, sizeof( out ) ) == 0 );
-    TEST_ASSERT( entropy.len < last_len );
+    expected_consumed_entropy += default_entropy_len;
+    TEST_EQUAL( sizeof( buf )  - entropy.len, expected_consumed_entropy );
 
     /* Finally, check setting entropy_len */
     mbedtls_hmac_drbg_set_entropy_len( &ctx, 42 );
-    last_len = entropy.len;
     TEST_ASSERT( mbedtls_hmac_drbg_random( &ctx, out, sizeof( out ) ) == 0 );
-    TEST_ASSERT( (int) last_len - entropy.len == 42 );
+    expected_consumed_entropy += 42;
+    TEST_EQUAL( sizeof( buf )  - entropy.len, expected_consumed_entropy );
 
     mbedtls_hmac_drbg_set_entropy_len( &ctx, 13 );
-    last_len = entropy.len;
     TEST_ASSERT( mbedtls_hmac_drbg_random( &ctx, out, sizeof( out ) ) == 0 );
-    TEST_ASSERT( (int) last_len - entropy.len == 13 );
+    expected_consumed_entropy += 13;
+    TEST_EQUAL( sizeof( buf )  - entropy.len, expected_consumed_entropy );
 
 exit:
     mbedtls_hmac_drbg_free( &ctx );

--- a/tests/suites/test_suite_psa_crypto_init.data
+++ b/tests/suites/test_suite_psa_crypto_init.data
@@ -34,14 +34,24 @@ fake_entropy_source:MBEDTLS_ENTROPY_BLOCK_SIZE:0:0:0:0:PSA_ERROR_INSUFFICIENT_EN
 Fake entropy: less than the block size
 fake_entropy_source:MBEDTLS_ENTROPY_BLOCK_SIZE:MBEDTLS_ENTROPY_BLOCK_SIZE - 1:-1:-1:-1:PSA_ERROR_INSUFFICIENT_ENTROPY
 
+Fake entropy: not enough for a nonce
+depends_on:ENTROPY_NONCE_LEN != 0
+fake_entropy_source:MBEDTLS_ENTROPY_BLOCK_SIZE:ENTROPY_NONCE_LEN - 1:-1:-1:-1:PSA_ERROR_INSUFFICIENT_ENTROPY
+
 Fake entropy: one block eventually
+depends_on:ENTROPY_NONCE_LEN == 0
 fake_entropy_source:MBEDTLS_ENTROPY_BLOCK_SIZE:0:0:0:MBEDTLS_ENTROPY_BLOCK_SIZE:PSA_SUCCESS
 
 Fake entropy: one block in two steps
+depends_on:ENTROPY_NONCE_LEN == 0
 fake_entropy_source:MBEDTLS_ENTROPY_BLOCK_SIZE:MBEDTLS_ENTROPY_BLOCK_SIZE - 1:1:-1:-1:PSA_SUCCESS
 
 Fake entropy: more than one block in two steps
+depends_on:ENTROPY_NONCE_LEN == 0
 fake_entropy_source:MBEDTLS_ENTROPY_BLOCK_SIZE:MBEDTLS_ENTROPY_BLOCK_SIZE - 1:MBEDTLS_ENTROPY_BLOCK_SIZE - 1:-1:-1:PSA_SUCCESS
+
+Fake entropy: two blocks eventually
+fake_entropy_source:MBEDTLS_ENTROPY_BLOCK_SIZE:0:MBEDTLS_ENTROPY_BLOCK_SIZE:0:MBEDTLS_ENTROPY_BLOCK_SIZE:PSA_SUCCESS
 
 NV seed only: less than minimum
 entropy_from_nv_seed:MBEDTLS_ENTROPY_MIN_PLATFORM - 1:PSA_ERROR_INSUFFICIENT_ENTROPY

--- a/tests/suites/test_suite_psa_crypto_init.function
+++ b/tests/suites/test_suite_psa_crypto_init.function
@@ -11,6 +11,12 @@
 #define ENTROPY_MIN_NV_SEED_SIZE                                        \
     MAX(MBEDTLS_ENTROPY_MIN_PLATFORM, MBEDTLS_ENTROPY_BLOCK_SIZE)
 
+/* PSA crypto uses the CTR_DRBG module. In some configurations, it needs
+ * to read from the entropy source twice: once for the initial entropy
+ * and once for a nonce. */
+#include "mbedtls/ctr_drbg.h"
+#define ENTROPY_NONCE_LEN MBEDTLS_CTR_DRBG_ENTROPY_NONCE_LEN
+
 typedef struct
 {
     size_t threshold; /* Minimum bytes to make mbedtls_entropy_func happy */


### PR DESCRIPTION
CTR_DRBG grabs as many bytes of entropy for the initial seeding as for reseeds. This is not compliant with NIST SP 800-90A when the entropy length is too small to cover both the entropy itself and a nonce, unless the caller passes a nonce in the `custom` parameter.

Fix this by making a second call to the entropy function to grab enough entropy for a random nonce (half the entropy length, per SP 800-90A).

To maximize backward compatibility, do not make a second call to the entropy function if the entropy length is sufficient to cover a nonce. Thus the only combination of boolean compile-time option that leads to making a second call to the entropy function is:
```
!MBEDTLS_CTR_DRBG_USE_AES_128 && (!MBEDTLS_SHA512_C || MBEDTLS_ENTROPY_FORCE_SHA256)
```
An alternative design choice would be to always grab a nonce whose length is half the entropy length, like the HMAC_DRBG module does. This would be a simpler design but I preferred this solution which only adds a few bytes of code and which has less risk of breaking someone's workflow.

Test run on a merge of this PR and #291 to get coverage of relevant compilation settings that are currently not covered: https://jenkins-internal.mbed.com/job/mbedtls-psa-release-new/592/ → passed except for some Mbed OS jobs which are also failing in this PR.

Some commits in this PR are minor bugs which I've fixed in the backports of #299 (https://github.com/ARMmbed/mbedtls/pull/2894 and https://github.com/ARMmbed/mbedtls/pull/2895):
* The fixup commits for “xxx_DRBG: support set_entropy_len() before seed()” in this PR are documentation updates that I missed in the last commit of #299. The ones in `ctr_drbg.h` and `hmac_drbg.h` needs to be backported, and I did so in the backport PRs  which have not been merged yet. The one in `ctr_drbg.c` was already present in a suitably modified form in the 2.16 backport of #299 and is not applicable to 2.7.
* "Note that mbedtls_ctr_drbg_seed() must not be called twice" is a follow-up to #287 which I added to the backports of #299.
* "Fix CTR_DRBG benchmark" fixes a bug that this PR revealed. I backported this fix in the backports of #299 and side-ported it in the Mbed OS benchmark in https://github.com/ARMmbed/mbed-os-example-tls/pull/262.

The rest of the PR is a behavior change that should not be backported, and some very minor test improvements that do not need to be backported.

Internal ref: IOTCRYPT-180
