### PR TITLE
MPI: Add stack-local limb storage to MPI objects.

### DIFF
--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -84,6 +84,24 @@
 
 #define MBEDTLS_MPI_MAX_BITS                              ( 8 * MBEDTLS_MPI_MAX_SIZE )    /**< Maximum number of bits for usable MPIs. */
 
+#if !defined(MBEDTLS_MPI_LOCAL_LIMB_SIZE)
+/*
+ * Maximum stack storage per MPI object for limbs, expressed in bytes. MPIs
+ * which can be wholly expressed in this number of bytes will not make any
+ * heap allocation calls.
+ *
+ * Result is an array of ( MBEDTLS_MPI_LOCAL_LIMB_SIZE / sizeof(mbedtls_mpi_uint) )
+ * limbs allocated within each mbedtls_mpi structure.
+ *
+ * Note: Calculations typically need multiple MPIs to exist simultaneously,
+ * depending on the exact calculation performed. As such, this figure is
+ * related to, but does not entirely determine, the amount of required stack
+ * space a particular call requires.
+ */
+#define MBEDTLS_MPI_LOCAL_LIMB_SIZE                       32       /**< Maximum number of bytes for local limb storage. */
+#endif /* !MBEDTLS_MPI_LOCAL_LIMB_SIZE */
+
+
 /*
  * When reading from files with mbedtls_mpi_read_file() and writing to files with
  * mbedtls_mpi_write_file() the buffer should have space
@@ -176,6 +194,9 @@
     #endif /* !MBEDTLS_NO_UDBL_DIVISION */
 #endif /* !MBEDTLS_HAVE_INT64 */
 
+
+#define MBEDTLS_MPI_LOCAL_LIMBS                ( MBEDTLS_MPI_LOCAL_LIMB_SIZE / sizeof(mbedtls_mpi_uint) )  /**< Maximum number of limbs for local limb storage. */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -185,9 +206,11 @@ extern "C" {
  */
 typedef struct mbedtls_mpi
 {
-    int s;              /*!<  integer sign      */
-    size_t n;           /*!<  total # of limbs  */
-    mbedtls_mpi_uint *p;          /*!<  pointer to limbs  */
+    int s;                /*!<  integer sign              */
+    int els;              /*!<  extenal limb storage flag */
+    size_t n;             /*!<  total # of limbs          */
+    mbedtls_mpi_uint *p;  /*!<  pointer to limbs          */
+    mbedtls_mpi_uint l[MBEDTLS_MPI_LOCAL_LIMBS]; /*!<  local limb buffer */
 }
 mbedtls_mpi;
 

--- a/include/mbedtls/config.h
+++ b/include/mbedtls/config.h
@@ -1975,6 +1975,7 @@
 /* MPI / BIGNUM options */
 //#define MBEDTLS_MPI_WINDOW_SIZE            6 /**< Maximum windows size used. */
 //#define MBEDTLS_MPI_MAX_SIZE            1024 /**< Maximum number of bytes for usable MPIs. */
+//#define MBEDTLS_MPI_LOCAL_LIMB_SIZE       32 /**< Maximum number of bytes for local limb storage. */
 
 /* CTR_DRBG options */
 //#define MBEDTLS_CTR_DRBG_ENTROPY_LEN               48 /**< Amount of entropy used per seed by default (48 with SHA-512, 32 with SHA-256) */

--- a/library/dhm.c
+++ b/library/dhm.c
@@ -127,7 +127,18 @@ cleanup:
 void mbedtls_dhm_init( mbedtls_dhm_context *ctx )
 {
     DHM_VALIDATE( ctx != NULL );
-    memset( ctx, 0, sizeof( mbedtls_dhm_context ) );
+
+    ctx->len = 0;
+    mbedtls_mpi_init( &ctx->P  );
+    mbedtls_mpi_init( &ctx->G  );
+    mbedtls_mpi_init( &ctx->X  );
+    mbedtls_mpi_init( &ctx->GX );
+    mbedtls_mpi_init( &ctx->GY );
+    mbedtls_mpi_init( &ctx->K  );
+    mbedtls_mpi_init( &ctx->RP );
+    mbedtls_mpi_init( &ctx->Vi );
+    mbedtls_mpi_init( &ctx->Vf );
+    mbedtls_mpi_init( &ctx->pX );
 }
 
 /*

--- a/programs/test/query_config.c
+++ b/programs/test/query_config.c
@@ -1644,6 +1644,14 @@ int query_config( const char *config )
     }
 #endif /* MBEDTLS_MPI_MAX_SIZE */
 
+#if defined(MBEDTLS_MPI_LOCAL_LIMB_SIZE)
+    if( strcmp( "MBEDTLS_MPI_LOCAL_LIMB_SIZE", config ) == 0 )
+    {
+        MACRO_EXPANSION_TO_STR( MBEDTLS_MPI_LOCAL_LIMB_SIZE );
+        return( 0 );
+    }
+#endif /* MBEDTLS_MPI_LOCAL_LIMB_SIZE */
+
 #if defined(MBEDTLS_CTR_DRBG_ENTROPY_LEN)
     if( strcmp( "MBEDTLS_CTR_DRBG_ENTROPY_LEN", config ) == 0 )
     {


### PR DESCRIPTION
This allows for a small chunk of memory to be added to each mbedtls_mpi
structure instantiation, the amount of which is adjustable via a new
compile-time parameter MBEDTLS_MPI_LOCAL_LIMB_SIZE. If a given MPI can
fit wholly within this chunk of memory (which will typically reside on
the stack), no heap allocation calls for that MPI will be made. Should,
however, an MPI require more space or grow beyond the extents provided
by that chunk, then an allocation call will be made as usual and limb
storage will be diverted appropriately. The default size of stack-local
storage to be reserved is 32 bytes (i.e., 256 bits).

This is particularly useful for elliptic curve operations: a 10%
reduction to execution time was observed for operations against the
secp256{r,k}1 curves with a minor (temporary) increase in the
required amount of stack space. To maintain the current behavior of
always using heap allocation regardless of MPI size, the library can
be compiled with MBEDTLS_MPI_LOCAL_LIMB_SIZE defined to 0.

I have tested this change with the existing test suite. I believe existing
tests adequately cover this change and that no new tests would be
required.

I've made this change for a performance-sensitive project that I'm
currently working on, and am submitting this pull request in hopes the
change would be useful for mbedtls/mbed-crypto upstream. My mbed
username is also 'areading', and I accept the Contributor License Agreement.

If this commit is in line with mbedTLS project goals and is a worthwhile
candidate for inclusion into the upstream development, I would be happy to
backport this into versions 2.16 or 2.7 as well, if deemed appropriate.