### PR TITLE
Make RSA-alt keys useable for cert signing

### DIFF
--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -190,6 +190,8 @@ typedef int (*mbedtls_pk_rsa_alt_sign_func)( void *ctx,
                     int mode, mbedtls_md_type_t md_alg, unsigned int hashlen,
                     const unsigned char *hash, unsigned char *sig );
 typedef size_t (*mbedtls_pk_rsa_alt_key_len_func)( void *ctx );
+typedef int (*mbedtls_pk_rsa_alt_write_pubkey_func)( void *ctx, unsigned char **p,
+                    unsigned char *start );
 #endif /* MBEDTLS_PK_RSA_ALT_SUPPORT */
 
 /**
@@ -309,6 +311,29 @@ int mbedtls_pk_setup_rsa_alt( mbedtls_pk_context *ctx, void * key,
                          mbedtls_pk_rsa_alt_decrypt_func decrypt_func,
                          mbedtls_pk_rsa_alt_sign_func sign_func,
                          mbedtls_pk_rsa_alt_key_len_func key_len_func );
+
+/**
+ * \brief           Initialize an RSA-alt context, including public-key-writing function
+ *
+ * \param ctx       Context to initialize. It must not have been set
+ *                  up yet (type #MBEDTLS_PK_NONE).
+ * \param key       RSA key pointer
+ * \param decrypt_func  Decryption function
+ * \param sign_func     Signing function
+ * \param key_len_func  Function returning key length in bytes
+ * \param write_pubkey_func  Public key data-writing function (optional, may be NULL)
+ *
+ * \return          0 on success, or MBEDTLS_ERR_PK_BAD_INPUT_DATA if the
+ *                  context wasn't already initialized as RSA_ALT.
+ *
+ * \note            This function replaces \c mbedtls_pk_setup() for RSA-alt.
+ */
+int mbedtls_pk_setup_rsa_alt2( mbedtls_pk_context *ctx, void * key,
+                         mbedtls_pk_rsa_alt_decrypt_func decrypt_func,
+                         mbedtls_pk_rsa_alt_sign_func sign_func,
+                         mbedtls_pk_rsa_alt_key_len_func key_len_func,
+                         mbedtls_pk_rsa_alt_write_pubkey_func write_pubkey_func);
+
 #endif /* MBEDTLS_PK_RSA_ALT_SUPPORT */
 
 /**

--- a/include/mbedtls/pk_internal.h
+++ b/include/mbedtls/pk_internal.h
@@ -106,6 +106,11 @@ struct mbedtls_pk_info_t
     /** Interface with the debug module */
     void (*debug_func)( const void *ctx, mbedtls_pk_debug_item *items );
 
+#if defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
+    /** Write public key in ASN.1 (only used for RSA-alt keys, so far) */
+    int (*write_pubkey_func)( void *ctx, uint8_t **p, uint8_t *start);
+#endif /* MBEDTLS_PK_RSA_ALT_SUPPORT */
+
 };
 #if defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
 /* Container for RSA-alt */
@@ -115,6 +120,7 @@ typedef struct
     mbedtls_pk_rsa_alt_decrypt_func decrypt_func;
     mbedtls_pk_rsa_alt_sign_func sign_func;
     mbedtls_pk_rsa_alt_key_len_func key_len_func;
+    mbedtls_pk_rsa_alt_write_pubkey_func write_pubkey_func;
 } mbedtls_rsa_alt_context;
 #endif
 

--- a/library/pk.c
+++ b/library/pk.c
@@ -190,10 +190,11 @@ int mbedtls_pk_setup_opaque( mbedtls_pk_context *ctx, const psa_key_handle_t key
 /*
  * Initialize an RSA-alt context
  */
-int mbedtls_pk_setup_rsa_alt( mbedtls_pk_context *ctx, void * key,
+int mbedtls_pk_setup_rsa_alt2( mbedtls_pk_context *ctx, void * key,
                          mbedtls_pk_rsa_alt_decrypt_func decrypt_func,
                          mbedtls_pk_rsa_alt_sign_func sign_func,
-                         mbedtls_pk_rsa_alt_key_len_func key_len_func )
+                         mbedtls_pk_rsa_alt_key_len_func key_len_func,
+                         mbedtls_pk_rsa_alt_write_pubkey_func write_pubkey_func)
 {
     mbedtls_rsa_alt_context *rsa_alt;
     const mbedtls_pk_info_t *info = &mbedtls_rsa_alt_info;
@@ -213,8 +214,16 @@ int mbedtls_pk_setup_rsa_alt( mbedtls_pk_context *ctx, void * key,
     rsa_alt->decrypt_func = decrypt_func;
     rsa_alt->sign_func = sign_func;
     rsa_alt->key_len_func = key_len_func;
+    rsa_alt->write_pubkey_func = write_pubkey_func;
 
     return( 0 );
+}
+int mbedtls_pk_setup_rsa_alt( mbedtls_pk_context *ctx, void * key,
+                         mbedtls_pk_rsa_alt_decrypt_func decrypt_func,
+                         mbedtls_pk_rsa_alt_sign_func sign_func,
+                         mbedtls_pk_rsa_alt_key_len_func key_len_func )
+{
+    return mbedtls_pk_setup_rsa_alt2(ctx, key, decrypt_func, sign_func, key_len_func, NULL);
 }
 #endif /* MBEDTLS_PK_RSA_ALT_SUPPORT */
 

--- a/library/pk_wrap.c
+++ b/library/pk_wrap.c
@@ -214,6 +214,9 @@ const mbedtls_pk_info_t mbedtls_rsa_info = {
     NULL,
 #endif
     rsa_debug,
+#if defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
+    NULL,
+#endif
 };
 #endif /* MBEDTLS_RSA_C */
 
@@ -441,6 +444,9 @@ const mbedtls_pk_info_t mbedtls_eckey_info = {
     eckey_rs_free,
 #endif
     eckey_debug,
+#if defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
+    NULL,
+#endif
 };
 
 /*
@@ -473,6 +479,9 @@ const mbedtls_pk_info_t mbedtls_eckeydh_info = {
     NULL,
 #endif
     eckey_debug,            /* Same underlying key structure */
+#if defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
+    NULL,
+#endif
 };
 #endif /* MBEDTLS_ECP_C */
 
@@ -741,6 +750,9 @@ const mbedtls_pk_info_t mbedtls_ecdsa_info = {
     ecdsa_rs_free,
 #endif
     eckey_debug,        /* Compatible key structures */
+#if defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
+    NULL,
+#endif
 };
 #endif /* MBEDTLS_ECDSA_C */
 
@@ -794,6 +806,14 @@ static int rsa_alt_decrypt_wrap( void *ctx,
 
     return( rsa_alt->decrypt_func( rsa_alt->key,
                 MBEDTLS_RSA_PRIVATE, olen, input, output, osize ) );
+}
+
+static int rsa_alt_write_pubkey_wrap( void *ctx, uint8_t **p, uint8_t *start)
+{
+    mbedtls_rsa_alt_context *rsa_alt = (mbedtls_rsa_alt_context *) ctx;
+    if( rsa_alt->write_pubkey_func == NULL)
+        return( MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE );
+    return( rsa_alt->write_pubkey_func(rsa_alt->key, p, start) );
 }
 
 #if defined(MBEDTLS_RSA_C)
@@ -867,6 +887,7 @@ const mbedtls_pk_info_t mbedtls_rsa_alt_info = {
     NULL,
 #endif
     NULL,
+    rsa_alt_write_pubkey_wrap,
 };
 
 #endif /* MBEDTLS_PK_RSA_ALT_SUPPORT */
@@ -1049,6 +1070,9 @@ const mbedtls_pk_info_t mbedtls_pk_opaque_info = {
     NULL, /* restart free - not relevant */
 #endif
     NULL, /* debug - could be done later, or even left NULL */
+#if defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
+    NULL, /* write pubkey */
+#endif
 };
 
 #endif /* MBEDTLS_USE_PSA_CRYPTO */

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -3,6 +3,7 @@
 
 /* For error codes */
 #include "mbedtls/asn1.h"
+#include "mbedtls/asn1write.h"
 #include "mbedtls/base64.h"
 #include "mbedtls/ecp.h"
 #include "mbedtls/rsa.h"
@@ -76,6 +77,44 @@ size_t mbedtls_rsa_key_len_func( void *ctx )
     return( ((const mbedtls_rsa_context *) ctx)->len );
 }
 #endif /* MBEDTLS_RSA_C */
+
+#if defined(MBEDTLS_RSA_C) && defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
+int mbedtls_rsa_write_pubkey_func( void *ctx, unsigned char **p, unsigned char *start )
+{
+    mbedtls_rsa_context *rsa = ctx;
+
+    /* Copied from pk_write_rsa_pubkey() in pkwrite.c: */
+    int ret;
+    size_t len = 0;
+    mbedtls_mpi T;
+
+    mbedtls_mpi_init( &T );
+
+    /* Export E */
+    if ( ( ret = mbedtls_rsa_export( rsa, NULL, NULL, NULL, NULL, &T ) ) != 0 ||
+         ( ret = mbedtls_asn1_write_mpi( p, start, &T ) ) < 0 )
+        goto end_of_export;
+    len += ret;
+
+    /* Export N */
+    if ( ( ret = mbedtls_rsa_export( rsa, &T, NULL, NULL, NULL, NULL ) ) != 0 ||
+         ( ret = mbedtls_asn1_write_mpi( p, start, &T ) ) < 0 )
+        goto end_of_export;
+    len += ret;
+
+end_of_export:
+
+    mbedtls_mpi_free( &T );
+    if( ret < 0 )
+        return( ret );
+
+    MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_len( p, start, len ) );
+    MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_tag( p, start, MBEDTLS_ASN1_CONSTRUCTED |
+                                                 MBEDTLS_ASN1_SEQUENCE ) );
+
+    return( (int) len );
+}
+#endif /* MBEDTLS_PK_RSA_ALT_SUPPORT */
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 
@@ -1159,8 +1198,9 @@ void pk_rsa_alt(  )
     TEST_ASSERT( mbedtls_rsa_copy( &raw, mbedtls_pk_rsa( rsa ) ) == 0 );
 
     /* Initialize PK RSA_ALT context */
-    TEST_ASSERT( mbedtls_pk_setup_rsa_alt( &alt, (void *) &raw,
-                 mbedtls_rsa_decrypt_func, mbedtls_rsa_sign_func, mbedtls_rsa_key_len_func ) == 0 );
+    TEST_ASSERT( mbedtls_pk_setup_rsa_alt2( &alt, (void *) &raw,
+                 mbedtls_rsa_decrypt_func, mbedtls_rsa_sign_func,
+                 mbedtls_rsa_key_len_func, mbedtls_rsa_write_pubkey_func ) == 0 );
 
     /* Test administrative functions */
     TEST_ASSERT( mbedtls_pk_can_do( &alt, MBEDTLS_PK_RSA ) );
@@ -1180,6 +1220,14 @@ void pk_rsa_alt(  )
     TEST_ASSERT( sig_len == RSA_KEY_LEN );
     TEST_ASSERT( mbedtls_pk_verify( &rsa, MBEDTLS_MD_NONE,
                             hash, sizeof hash, sig, sig_len ) == 0 );
+
+    /* Test write data */
+    unsigned char keybuf[4096], altbuf[4096];
+    int keylen = mbedtls_pk_write_pubkey_der( &rsa, keybuf, sizeof(keybuf) );
+    TEST_ASSERT(keylen > 0);
+    int altlen = mbedtls_pk_write_pubkey_der( &alt, altbuf, sizeof(altbuf) );
+    TEST_ASSERT(altlen == keylen);
+    TEST_ASSERT( memcmp(keybuf, altbuf, keylen) == 0);
 
     /* Test decrypt */
     TEST_ASSERT( mbedtls_pk_encrypt( &rsa, msg, sizeof msg,


### PR DESCRIPTION
`mbedtls_pk_write_pubkey_der` fails if called with an RSA-alt key, because (obviously) it doesn't have access to the actual bits of the key. Unfortunately this makes it impossible to generate a certificate or CSR using an external RSA-alt key key, because the operation will fail when it tries to write the public key to the cert/CSR data. (See ARMmbed/mbedtls#2768 for details.)

This commit fixes that by adding `mbedtls_pk_rsa_alt_write_pubkey_func`, a new callback for RSA-alt keys that writes the RSAPublicKey sequence just like the internal `pk_write_rsa_pubkey` function. The app developer will have to add that callback, but then cert creation will work. (See my patch to test_suite_pk.function for an example.)

I was unsure what to do with the `mbedtls_pk_setup_rsa_alt` function — I needed to add a parameter for the new callback, but that would break compatibility. (Too bad C doesn't have default argument values!) So I added a new function `mbedtls_pk_setup_rsa_alt2` that adds the extra parameter. If there's a different convention for how to do this kind of API evolution in mbed, I can change it.