### PR TITLE
Stop transactions from being reentrant

### DIFF
--- a/library/psa_crypto_storage.c
+++ b/library/psa_crypto_storage.c
@@ -419,7 +419,7 @@ psa_status_t psa_crypto_save_transaction( void )
 {
     struct psa_storage_info_t p_info;
     psa_status_t status;
-    status = psa_its_get_info( PSA_CRYPTO_ITS_RANDOM_SEED_UID, &p_info );
+    status = psa_its_get_info( PSA_CRYPTO_ITS_TRANSACTION_UID, &p_info );
     if( status == PSA_SUCCESS )
     {
         /* This shouldn't happen: we're trying to start a transaction while


### PR DESCRIPTION
We want to explicitly disallow creating new transactions when a
transaction is already in progress. However, we were incorrectly
checking for the existence of the injected entropy file before
continuing with creating a transaction. This meant we could have a
transaction already in progress and would be able to still create a new
transaction. It also meant we couldn't start a new transaction if any
entropy had been injected. Check the transaction file instead of the
injected entropy file in order to prevent multiple concurrent
transactions.