### PR TITLE
Finish side-porting commits from mbedtls-restricted that missed the split

### DIFF
--- a/include/mbedtls/check_config.h
+++ b/include/mbedtls/check_config.h
@@ -134,7 +134,7 @@
 #error "MBEDTLS_ECDSA_DETERMINISTIC defined, but not all prerequisites"
 #endif
 
-#if defined(MBEDTLS_ECP_C) && ( !defined(MBEDTLS_BIGNUM_C) || (   \
+#if defined(MBEDTLS_ECP_C) && ( !defined(MBEDTLS_BIGNUM_C) || (    \
     !defined(MBEDTLS_ECP_DP_SECP192R1_ENABLED) &&                  \
     !defined(MBEDTLS_ECP_DP_SECP224R1_ENABLED) &&                  \
     !defined(MBEDTLS_ECP_DP_SECP256R1_ENABLED) &&                  \
@@ -145,7 +145,9 @@
     !defined(MBEDTLS_ECP_DP_BP512R1_ENABLED)   &&                  \
     !defined(MBEDTLS_ECP_DP_SECP192K1_ENABLED) &&                  \
     !defined(MBEDTLS_ECP_DP_SECP224K1_ENABLED) &&                  \
-    !defined(MBEDTLS_ECP_DP_SECP256K1_ENABLED) ) )
+    !defined(MBEDTLS_ECP_DP_SECP256K1_ENABLED) &&                  \
+    !defined(MBEDTLS_ECP_DP_CURVE25519_ENABLED) &&                 \
+    !defined(MBEDTLS_ECP_DP_CURVE448_ENABLED) ) )
 #error "MBEDTLS_ECP_C defined, but not all prerequisites"
 #endif
 

--- a/include/mbedtls/rsa.h
+++ b/include/mbedtls/rsa.h
@@ -907,7 +907,8 @@ int mbedtls_rsa_rsaes_oaep_decrypt( mbedtls_rsa_context *ctx,
  *                 the size of the hash corresponding to \p md_alg.
  * \param sig      The buffer to hold the signature. This must be a writable
  *                 buffer of length \c ctx->len Bytes. For example, \c 256 Bytes
- *                 for an 2048-bit RSA modulus.
+ *                 for an 2048-bit RSA modulus. A buffer length of
+ *                 #MBEDTLS_MPI_MAX_SIZE is always safe.
  *
  * \return         \c 0 if the signing operation was successful.
  * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
@@ -954,7 +955,8 @@ int mbedtls_rsa_pkcs1_sign( mbedtls_rsa_context *ctx,
  *                 the size of the hash corresponding to \p md_alg.
  * \param sig      The buffer to hold the signature. This must be a writable
  *                 buffer of length \c ctx->len Bytes. For example, \c 256 Bytes
- *                 for an 2048-bit RSA modulus.
+ *                 for an 2048-bit RSA modulus. A buffer length of
+ *                 #MBEDTLS_MPI_MAX_SIZE is always safe.
  *
  * \return         \c 0 if the signing operation was successful.
  * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
@@ -1015,7 +1017,8 @@ int mbedtls_rsa_rsassa_pkcs1_v15_sign( mbedtls_rsa_context *ctx,
  *                 the size of the hash corresponding to \p md_alg.
  * \param sig      The buffer to hold the signature. This must be a writable
  *                 buffer of length \c ctx->len Bytes. For example, \c 256 Bytes
- *                 for an 2048-bit RSA modulus.
+ *                 for an 2048-bit RSA modulus. A buffer length of
+ *                 #MBEDTLS_MPI_MAX_SIZE is always safe.
  *
  * \return         \c 0 if the signing operation was successful.
  * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.


### PR DESCRIPTION
When we split Mbed Crypto from Mbed TLS, we missed the last few commits in the restricted branch of Mbed TLS which were quarantined security fixes. These commits are present in the git history of Mbed TLS, but their effect was cancelled by the removal of crypto files, and the commits never appeared in Mbed Crypto.

We're fixing this through 3 pull requests:

* https://github.com/ARMmbed/mbed-crypto/pull/314, a straightforward port of [#r503](https://github.com/ARMmbed/mbedtls-restricted/pull/503).
* https://github.com/ARMmbed/mbed-crypto/pull/315, which fixes the same issue as [#r573](https://github.com/ARMmbed/mbedtls-restricted/pull/573) in a more robust way.
* The present PR has the bits of [#r573](https://github.com/ARMmbed/mbedtls-restricted/pull/573) that are not covered by #315. Commit by commit:
    * [c4638cc6401a88124f9f54d60439eda6d2368641](https://github.com/ARMmbed/mbedtls/commit/c4638cc6401a88124f9f54d60439eda6d2368641): entirely superseded by #315.
    * [5dbe7caf2eeea340ad3a38b0280c772562d4edd4](https://github.com/ARMmbed/mbedtls/commit/5dbe7caf2eeea340ad3a38b0280c772562d4edd4): cherry-picked here.
    * [49bd3e897e4ff7dfc1c09351213b3e22470abc7e](https://github.com/ARMmbed/mbedtls/commit/49bd3e897e4ff7dfc1c09351213b3e22470abc7e): superseded by #315 for `pk.h`, cherry-picked here for `rsa.h`.
    * [c1955559ad7bab3be5666d4687269e7d2ddc1edd](https://github.com/ARMmbed/mbedtls/commit/c1955559ad7bab3be5666d4687269e7d2ddc1edd) and [69969ef088359b225eb955a40a8b842679fcc6e9](https://github.com/ARMmbed/mbedtls/commit/69969ef088359b225eb955a40a8b842679fcc6e9): not useful because #315 adds unit tests which, when run with `config-suite-b.h` (through `test-ref-configs.pl`), provide the desired coverage, namely having some test fail if the maximum signature size is not calculated correctly, especially in a configuration where RSA is disabled and the smallest MPI is just large enough for ECC.

(`#rNNN` are private links.)

This pull request deliberately omits the addition of a run of `programs/pkey/pk_sign` to `all.sh`. While this would be desirable, it wasn't in scope of #r573, and was only added there as a non-regression test which is now performed through unit tests. A better approach to smoke-test sample programs would be through demo scripts as in https://github.com/ARMmbed/mbedtls/pull/2698.

**Goal of this PR: all the commits that had gone missing are now present in Mbed Crypto.**

Internal ref: IOTCRYPT-969
