### PR TITLE
test_psa_constant_names: support key agreement, better code structure

### DIFF
--- a/tests/scripts/test_psa_constant_names.py
+++ b/tests/scripts/test_psa_constant_names.py
@@ -61,6 +61,7 @@ class read_file_lines:
 
 class Inputs:
     """Accumulate information about macros to test.
+
     This includes macro names as well as information about their arguments
     when applicable.
     """
@@ -101,6 +102,7 @@ class Inputs:
 
     def gather_arguments(self):
         """Populate the list of values for macro arguments.
+
         Call this after parsing all the inputs.
         """
         self.arguments_for['hash_alg'] = sorted(self.hash_algorithms)
@@ -118,6 +120,7 @@ class Inputs:
 
     def distribute_arguments(self, name):
         """Generate macro calls with each tested argument set.
+
         If name is a macro without arguments, just yield "name".
         If name is a macro with arguments, yield a series of
         "name(arg1,...,argN)" where each argument takes each possible
@@ -305,15 +308,21 @@ int main(void)
 NORMALIZE_STRIP_RE = re.compile(r'\s+')
 def normalize(expr):
     """Normalize the C expression so as not to care about trivial differences.
+
     Currently "trivial differences" means whitespace.
     """
     return re.sub(NORMALIZE_STRIP_RE, '', expr)
 
 def do_test(options, inputs, type_word, names):
     """Test psa_constant_names for the specified type.
+
     Run program on names.
     Use inputs to figure out what arguments to pass to macros that
     take arguments.
+
+    Return ``(count, errors)`` where ``count`` is the number of expressions
+    that have been tested and ``errors`` is the list of errors that were
+    encountered.
     """
     expressions = sorted(inputs.generate_expressions(names))
     values = run_c(options, type_word, expressions)
@@ -332,6 +341,7 @@ def report_errors(errors):
 
 def run_tests(options, inputs):
     """Run psa_constant_names on all the gathered inputs.
+
     Return a tuple (count, errors) where count is the total number of inputs
     that were tested and errors is the list of cases where the output was
     not as expected.

--- a/tests/scripts/test_psa_constant_names.py
+++ b/tests/scripts/test_psa_constant_names.py
@@ -251,9 +251,9 @@ class Inputs:
                 if m:
                     self.add_test_case_line(m.group(1), m.group(2))
 
-def gather_inputs(headers, test_suites):
+def gather_inputs(headers, test_suites, inputs_class=Inputs):
     """Read the list of inputs to test psa_constant_names with."""
-    inputs = Inputs()
+    inputs = inputs_class()
     for header in headers:
         inputs.parse_header(header)
     for test_cases in test_suites:

--- a/tests/scripts/test_psa_constant_names.py
+++ b/tests/scripts/test_psa_constant_names.py
@@ -61,6 +61,7 @@ class read_file_lines:
                 from exc_value
 
 class Inputs:
+    # pylint: disable=too-many-instance-attributes
     """Accumulate information about macros to test.
 
     This includes macro names as well as information about their arguments
@@ -92,6 +93,16 @@ class Inputs:
             'GROUP': self.dh_groups,
             'KEY_TYPE': self.key_types,
             'KEY_USAGE': self.key_usage_flags,
+        }
+        # Test functions
+        self.table_by_test_function = {
+            'key_type': self.key_types,
+            'ecc_key_types': self.ecc_curves,
+            'dh_key_types': self.dh_groups,
+            'hash_algorithm': self.hash_algorithms,
+            'mac_algorithm': self.mac_algorithms,
+            'hmac_algorithm': self.mac_algorithms,
+            'aead_algorithm': self.aead_algorithms,
         }
         # macro name -> list of argument names
         self.argspecs = {}
@@ -220,24 +231,17 @@ class Inputs:
 
     def add_test_case_line(self, function, argument):
         """Parse a test case data line, looking for algorithm metadata tests."""
+        sets = []
         if function.endswith('_algorithm'):
             # As above, ECDH and FFDH algorithms are excluded for now.
             # Support for them will be added in the future.
             if 'ECDH' in argument or 'FFDH' in argument:
                 return
-            self.algorithms.add(argument)
-            if function == 'hash_algorithm':
-                self.hash_algorithms.add(argument)
-            elif function in ['mac_algorithm', 'hmac_algorithm']:
-                self.mac_algorithms.add(argument)
-            elif function == 'aead_algorithm':
-                self.aead_algorithms.add(argument)
-        elif function == 'key_type':
-            self.key_types.add(argument)
-        elif function == 'ecc_key_types':
-            self.ecc_curves.add(argument)
-        elif function == 'dh_key_types':
-            self.dh_groups.add(argument)
+            sets.append(self.algorithms)
+        if function in self.table_by_test_function:
+            sets.append(self.table_by_test_function[function])
+        for s in sets:
+            s.add(argument)
 
     # Regex matching a *.data line containing a test function call and
     # its arguments. The actual definition is partly positional, but this

--- a/tests/scripts/test_psa_constant_names.py
+++ b/tests/scripts/test_psa_constant_names.py
@@ -89,8 +89,8 @@ class Inputs:
         self.table_by_prefix = {
             'ERROR': self.statuses,
             'ALG': self.algorithms,
-            'CURVE': self.ecc_curves,
-            'GROUP': self.dh_groups,
+            'ECC_CURVE': self.ecc_curves,
+            'DH_GROUP': self.dh_groups,
             'KEY_TYPE': self.key_types,
             'KEY_USAGE': self.key_usage_flags,
         }
@@ -183,7 +183,7 @@ class Inputs:
     # Groups: 1=macro name, 2=type, 3=argument list (optional).
     _header_line_re = \
         re.compile(r'#define +' +
-                   r'(PSA_((?:KEY_)?[A-Z]+)_\w+)' +
+                   r'(PSA_((?:(?:DH|ECC|KEY)_)?[A-Z]+)_\w+)' +
                    r'(?:\(([^\n()]*)\))?')
     # Regex of macro names to exclude.
     _excluded_name_re = re.compile(r'_(?:GET|IS|OF)_|_(?:BASE|FLAG|MASK)\Z')

--- a/tests/scripts/test_psa_constant_names.py
+++ b/tests/scripts/test_psa_constant_names.py
@@ -104,6 +104,8 @@ class Inputs:
             'mac_algorithm': self.mac_algorithms,
             'hmac_algorithm': self.mac_algorithms,
             'aead_algorithm': self.aead_algorithms,
+            'key_derivation_algorithm': self.kdf_algorithms,
+            'key_agreement_algorithm': self.ka_algorithms,
         }
         # macro name -> list of argument names
         self.argspecs = {}
@@ -197,10 +199,6 @@ class Inputs:
         # Auxiliary macro whose name doesn't fit the usual patterns for
         # auxiliary macros.
         'PSA_ALG_AEAD_WITH_DEFAULT_TAG_LENGTH_CASE',
-        # PSA_ALG_ECDH and PSA_ALG_FFDH are excluded for now as the script
-        # currently doesn't support them.
-        'PSA_ALG_ECDH',
-        'PSA_ALG_FFDH',
         # Deprecated aliases.
         'PSA_ERROR_UNKNOWN_ERROR',
         'PSA_ERROR_OCCUPIED_SLOT',
@@ -248,11 +246,13 @@ class Inputs:
         """Parse a test case data line, looking for algorithm metadata tests."""
         sets = []
         if function.endswith('_algorithm'):
-            # As above, ECDH and FFDH algorithms are excluded for now.
-            # Support for them will be added in the future.
-            if 'ECDH' in argument or 'FFDH' in argument:
-                return
             sets.append(self.algorithms)
+            if function == 'key_agreement_algorithm' and \
+               argument.startswith('PSA_ALG_KEY_AGREEMENT('):
+                # We only want *raw* key agreement algorithms as such, so
+                # exclude ones that are already chained with a KDF.
+                # Keep the expression as one to test as an algorithm.
+                function = 'other_algorithm'
         if function in self.table_by_test_function:
             sets.append(self.table_by_test_function[function])
         if self.accept_test_case_line(function, argument):

--- a/tests/scripts/test_psa_constant_names.py
+++ b/tests/scripts/test_psa_constant_names.py
@@ -354,15 +354,15 @@ def main():
     parser.add_argument('--include', '-I',
                         action='append', default=['include'],
                         help='Directory for header files')
-    parser.add_argument('--program',
-                        default='programs/psa/psa_constant_names',
-                        help='Program to test')
     parser.add_argument('--keep-c',
                         action='store_true', dest='keep_c', default=False,
                         help='Keep the intermediate C file')
     parser.add_argument('--no-keep-c',
                         action='store_false', dest='keep_c',
                         help='Don\'t keep the intermediate C file (default)')
+    parser.add_argument('--program',
+                        default='programs/psa/psa_constant_names',
+                        help='Program to test')
     options = parser.parse_args()
     headers = [os.path.join(options.include[0], 'psa', h)
                for h in ['crypto.h', 'crypto_extra.h', 'crypto_values.h']]

--- a/tests/scripts/test_psa_constant_names.py
+++ b/tests/scripts/test_psa_constant_names.py
@@ -324,6 +324,17 @@ def normalize(expr):
     """
     return re.sub(NORMALIZE_STRIP_RE, '', expr)
 
+def collect_values(options, inputs, type_word):
+    """Generate expressions using known macro names and calculate their values.
+
+    Return a list of pairs of (expr, value) where expr is an expression and
+    value is a string representation of its integer value.
+    """
+    names = inputs.get_names(type_word)
+    expressions = sorted(inputs.generate_expressions(names))
+    values = run_c(options, type_word, expressions)
+    return expressions, values
+
 def do_test(options, inputs, type_word):
     """Test psa_constant_names for the specified type.
 
@@ -335,9 +346,7 @@ def do_test(options, inputs, type_word):
     that have been tested and ``errors`` is the list of errors that were
     encountered.
     """
-    names = inputs.get_names(type_word)
-    expressions = sorted(inputs.generate_expressions(names))
-    values = run_c(options, type_word, expressions)
+    expressions, values = collect_values(options, inputs, type_word)
     output = subprocess.check_output([options.program, type_word] + values)
     outputs = output.decode('ascii').strip().split('\n')
     errors = [(type_word, expr, value, output)

--- a/tests/scripts/test_psa_constant_names.py
+++ b/tests/scripts/test_psa_constant_names.py
@@ -97,15 +97,22 @@ class Inputs:
         }
         # Test functions
         self.table_by_test_function = {
-            'key_type': self.key_types,
-            'ecc_key_types': self.ecc_curves,
-            'dh_key_types': self.dh_groups,
-            'hash_algorithm': self.hash_algorithms,
-            'mac_algorithm': self.mac_algorithms,
-            'hmac_algorithm': self.mac_algorithms,
-            'aead_algorithm': self.aead_algorithms,
-            'key_derivation_algorithm': self.kdf_algorithms,
-            'key_agreement_algorithm': self.ka_algorithms,
+            # Any function ending in _algorithm also gets added to
+            # self.algorithms.
+            'key_type': [self.key_types],
+            'ecc_key_types': [self.ecc_curves],
+            'dh_key_types': [self.dh_groups],
+            'hash_algorithm': [self.hash_algorithms],
+            'mac_algorithm': [self.mac_algorithms],
+            'cipher_algorithm': [],
+            'hmac_algorithm': [self.mac_algorithms],
+            'aead_algorithm': [self.aead_algorithms],
+            'key_derivation_algorithm': [self.kdf_algorithms],
+            'key_agreement_algorithm': [self.ka_algorithms],
+            'asymmetric_signature_algorithm': [],
+            'asymmetric_signature_wildcard': [self.algorithms],
+            'asymmetric_encryption_algorithm': [],
+            'other_algorithm': [],
         }
         # macro name -> list of argument names
         self.argspecs = {}
@@ -253,8 +260,7 @@ class Inputs:
                 # exclude ones that are already chained with a KDF.
                 # Keep the expression as one to test as an algorithm.
                 function = 'other_algorithm'
-        if function in self.table_by_test_function:
-            sets.append(self.table_by_test_function[function])
+        sets += self.table_by_test_function[function]
         if self.accept_test_case_line(function, argument):
             for s in sets:
                 s.add(argument)

--- a/tests/scripts/test_psa_constant_names.py
+++ b/tests/scripts/test_psa_constant_names.py
@@ -349,6 +349,9 @@ def run_tests(options, inputs):
         errors += e
     return count, errors
 
+HEADERS = ['psa/crypto.h', 'psa/crypto_extra.h', 'psa/crypto_values.h']
+TEST_SUITES = ['tests/suites/test_suite_psa_crypto_metadata.data']
+
 def main():
     parser = argparse.ArgumentParser(description=globals()['__doc__'])
     parser.add_argument('--include', '-I',
@@ -364,10 +367,8 @@ def main():
                         default='programs/psa/psa_constant_names',
                         help='Program to test')
     options = parser.parse_args()
-    headers = [os.path.join(options.include[0], 'psa', h)
-               for h in ['crypto.h', 'crypto_extra.h', 'crypto_values.h']]
-    test_suites = ['tests/suites/test_suite_psa_crypto_metadata.data']
-    inputs = gather_inputs(headers, test_suites)
+    headers = [os.path.join(options.include[0], h) for h in HEADERS]
+    inputs = gather_inputs(headers, TEST_SUITES)
     count, errors = run_tests(options, inputs)
     report_errors(errors)
     if errors == []:

--- a/tests/scripts/test_psa_constant_names.py
+++ b/tests/scripts/test_psa_constant_names.py
@@ -307,8 +307,7 @@ def normalize(expr):
     """Normalize the C expression so as not to care about trivial differences.
     Currently "trivial differences" means whitespace.
     """
-    expr = re.sub(NORMALIZE_STRIP_RE, '', expr, len(expr))
-    return expr.strip().split('\n')
+    return re.sub(NORMALIZE_STRIP_RE, '', expr)
 
 def do_test(options, inputs, type_word, names):
     """Test psa_constant_names for the specified type.

--- a/tests/scripts/test_psa_constant_names.py
+++ b/tests/scripts/test_psa_constant_names.py
@@ -100,6 +100,17 @@ class Inputs:
             'tag_length': ['1', '63'],
         }
 
+    def get_names(self, type_word):
+        """Return the set of known names of values of the given type."""
+        return {
+            'status': self.statuses,
+            'algorithm': self.algorithms,
+            'ecc_curve': self.ecc_curves,
+            'dh_group': self.dh_groups,
+            'key_type': self.key_types,
+            'key_usage': self.key_usage_flags,
+        }[type_word]
+
     def gather_arguments(self):
         """Populate the list of values for macro arguments.
 
@@ -313,7 +324,7 @@ def normalize(expr):
     """
     return re.sub(NORMALIZE_STRIP_RE, '', expr)
 
-def do_test(options, inputs, type_word, names):
+def do_test(options, inputs, type_word):
     """Test psa_constant_names for the specified type.
 
     Run program on names.
@@ -324,6 +335,7 @@ def do_test(options, inputs, type_word, names):
     that have been tested and ``errors`` is the list of errors that were
     encountered.
     """
+    names = inputs.get_names(type_word)
     expressions = sorted(inputs.generate_expressions(names))
     values = run_c(options, type_word, expressions)
     output = subprocess.check_output([options.program, type_word] + values)
@@ -348,13 +360,9 @@ def run_tests(options, inputs):
     """
     count = 0
     errors = []
-    for type_word, names in [('status', inputs.statuses),
-                             ('algorithm', inputs.algorithms),
-                             ('ecc_curve', inputs.ecc_curves),
-                             ('dh_group', inputs.dh_groups),
-                             ('key_type', inputs.key_types),
-                             ('key_usage', inputs.key_usage_flags)]:
-        c, e = do_test(options, inputs, type_word, names)
+    for type_word in ['status', 'algorithm', 'ecc_curve', 'dh_group',
+                      'key_type', 'key_usage']:
+        c, e = do_test(options, inputs, type_word)
         count += c
         errors += e
     return count, errors

--- a/tests/suites/test_suite_psa_crypto_metadata.data
+++ b/tests/suites/test_suite_psa_crypto_metadata.data
@@ -262,6 +262,26 @@ Key derivation: HKDF using SHA-256
 depends_on:MBEDTLS_SHA256_C
 key_derivation_algorithm:PSA_ALG_HKDF( PSA_ALG_SHA_256 ):ALG_IS_HKDF
 
+Key derivation: HKDF using SHA-384
+depends_on:MBEDTLS_SHA512_C
+key_derivation_algorithm:PSA_ALG_HKDF( PSA_ALG_SHA_384 ):ALG_IS_HKDF
+
+Key derivation: TLS 1.2 PRF using SHA-256
+depends_on:MBEDTLS_SHA256_C
+key_derivation_algorithm:PSA_ALG_TLS12_PRF( PSA_ALG_SHA_256 ):ALG_IS_TLS12_PRF
+
+Key derivation: TLS 1.2 PRF using SHA-384
+depends_on:MBEDTLS_SHA512_C
+key_derivation_algorithm:PSA_ALG_TLS12_PRF( PSA_ALG_SHA_384 ):ALG_IS_TLS12_PRF
+
+Key derivation: TLS 1.2 PSK-to-MS using SHA-256
+depends_on:MBEDTLS_SHA256_C
+key_derivation_algorithm:PSA_ALG_TLS12_PSK_TO_MS( PSA_ALG_SHA_256 ):ALG_IS_TLS12_PSK_TO_MS
+
+Key derivation: TLS 1.2 PSK-to-MS using SHA-384
+depends_on:MBEDTLS_SHA512_C
+key_derivation_algorithm:PSA_ALG_TLS12_PSK_TO_MS( PSA_ALG_SHA_384 ):ALG_IS_TLS12_PSK_TO_MS
+
 Key agreement: FFDH, raw output
 depends_on:MBEDTLS_DHM_C
 key_agreement_algorithm:PSA_ALG_FFDH:ALG_IS_FFDH | ALG_IS_RAW_KEY_AGREEMENT:PSA_ALG_FFDH:PSA_ALG_CATEGORY_KEY_DERIVATION
@@ -270,6 +290,10 @@ Key agreement: FFDH, HKDF using SHA-256
 depends_on:MBEDTLS_DHM_C
 key_agreement_algorithm:PSA_ALG_KEY_AGREEMENT( PSA_ALG_FFDH, PSA_ALG_HKDF( PSA_ALG_SHA_256 ) ):ALG_IS_FFDH:PSA_ALG_FFDH:PSA_ALG_HKDF( PSA_ALG_SHA_256 )
 
+Key agreement: FFDH, HKDF using SHA-384
+depends_on:MBEDTLS_DHM_C
+key_agreement_algorithm:PSA_ALG_KEY_AGREEMENT( PSA_ALG_FFDH, PSA_ALG_HKDF( PSA_ALG_SHA_384 ) ):ALG_IS_FFDH:PSA_ALG_FFDH:PSA_ALG_HKDF( PSA_ALG_SHA_384 )
+
 Key agreement: ECDH, raw output
 depends_on:MBEDTLS_ECDH_C
 key_agreement_algorithm:PSA_ALG_ECDH:ALG_IS_ECDH | ALG_IS_RAW_KEY_AGREEMENT:PSA_ALG_ECDH:PSA_ALG_CATEGORY_KEY_DERIVATION
@@ -277,6 +301,10 @@ key_agreement_algorithm:PSA_ALG_ECDH:ALG_IS_ECDH | ALG_IS_RAW_KEY_AGREEMENT:PSA_
 Key agreement: ECDH, HKDF using SHA-256
 depends_on:MBEDTLS_ECDH_C
 key_agreement_algorithm:PSA_ALG_KEY_AGREEMENT( PSA_ALG_ECDH, PSA_ALG_HKDF( PSA_ALG_SHA_256 ) ):ALG_IS_ECDH:PSA_ALG_ECDH:PSA_ALG_HKDF( PSA_ALG_SHA_256 )
+
+Key agreement: ECDH, HKDF using SHA-384
+depends_on:MBEDTLS_ECDH_C
+key_agreement_algorithm:PSA_ALG_KEY_AGREEMENT( PSA_ALG_ECDH, PSA_ALG_HKDF( PSA_ALG_SHA_384 ) ):ALG_IS_ECDH:PSA_ALG_ECDH:PSA_ALG_HKDF( PSA_ALG_SHA_384 )
 
 Key type: raw data
 key_type:PSA_KEY_TYPE_RAW_DATA:KEY_TYPE_IS_UNSTRUCTURED

--- a/tests/suites/test_suite_psa_crypto_metadata.function
+++ b/tests/suites/test_suite_psa_crypto_metadata.function
@@ -37,6 +37,8 @@
 #define ALG_IS_WILDCARD                 ( 1u << 19 )
 #define ALG_IS_RAW_KEY_AGREEMENT        ( 1u << 20 )
 #define ALG_IS_AEAD_ON_BLOCK_CIPHER     ( 1u << 21 )
+#define ALG_IS_TLS12_PRF                ( 1u << 22 )
+#define ALG_IS_TLS12_PSK_TO_MS          ( 1u << 23 )
 
 /* Flags for key type classification macros. There is a flag for every
  * key type classification macro PSA_KEY_TYPE_IS_xxx except for some that


### PR DESCRIPTION
This pull request consists mostly of changes to `test_psa_constant_names.py`:

* Many small refactorings of `test_psa_constant_names.py`. I initially did them in preparation for reusing major parts of the code in another script. This other script is not stable yet and I'm not sure if I need it after all. Since the refactorings are at worst harmless and at best useful to make the code easier to maintain, I'm submitting them.
* Fix the collection of curves, which I discovered to be broken.
* Error out if a test case uses a macro name which isn't defined in a header covered by this script.
* Add support for key agreement, which was long overdue.
* In `test_suite_psa_crypto_metadata`, add a few more test cases for KDF.
