### PR TITLE
Buffer Alloc: allow allocating zero length buffers

### DIFF
--- a/library/memory_buffer_alloc.c
+++ b/library/memory_buffer_alloc.c
@@ -241,9 +241,15 @@ static void *buffer_alloc_calloc( size_t n, size_t size )
     if( heap.buf == NULL || heap.first == NULL )
         return( NULL );
 
+    if( n == 0 || size == 0 )
+    {
+        n = 1;
+        size = 1;
+    }
+
     original_len = len = n * size;
 
-    if( n == 0 || size == 0 || len / n != size )
+    if( len / n != size )
         return( NULL );
     else if( len > (size_t)-MBEDTLS_MEMORY_ALIGN_MULTIPLE )
         return( NULL );

--- a/tests/suites/test_suite_memory_buffer_alloc.function
+++ b/tests/suites/test_suite_memory_buffer_alloc.function
@@ -30,6 +30,46 @@ void mbedtls_memory_buffer_alloc_self_test(  )
 /* END_CASE */
 
 /* BEGIN_CASE */
+void memory_buffer_alloc_free_zero( )
+{
+    unsigned char buf[1024];
+    unsigned char *ptr_a = NULL, *ptr_b = NULL, *ptr_c = NULL;
+
+    mbedtls_memory_buffer_alloc_init( buf, sizeof( buf ) );
+
+    mbedtls_memory_buffer_set_verify( MBEDTLS_MEMORY_VERIFY_ALWAYS );
+
+    ptr_a = mbedtls_calloc( 0, sizeof(int) );
+    TEST_ASSERT( check_pointer( ptr_a ) == 0 );
+
+    ptr_b = mbedtls_calloc( 100, 0 );
+    TEST_ASSERT( check_pointer( ptr_b ) == 0 );
+
+    ptr_c = mbedtls_calloc( 0, 0 );
+    TEST_ASSERT( check_pointer( ptr_c ) == 0 );
+
+    mbedtls_free( ptr_a );
+    ptr_a = NULL;
+    TEST_ASSERT( mbedtls_memory_buffer_alloc_verify() == 0 );
+
+    mbedtls_free( ptr_b );
+    ptr_b = NULL;
+    TEST_ASSERT( mbedtls_memory_buffer_alloc_verify() == 0 );
+
+    mbedtls_free( ptr_c );
+    ptr_c = NULL;
+    TEST_ASSERT( mbedtls_memory_buffer_alloc_verify() == 0 );
+
+    ptr_a = mbedtls_calloc( 0, sizeof(char) );
+    TEST_ASSERT( check_pointer( ptr_a ) == 0 );
+
+    mbedtls_free( ptr_a );
+    ptr_a = NULL;
+    TEST_ASSERT( mbedtls_memory_buffer_alloc_verify() == 0 );
+}
+/* END_CASE */
+
+/* BEGIN_CASE */
 void memory_buffer_alloc_free_alloc( int a_bytes, int b_bytes, int c_bytes,
                                      int d_bytes, int free_a, int free_b,
                                      int free_c, int free_d, int e_bytes,


### PR DESCRIPTION
The allocator returned NULL pointer when trying to allocate zero length
buffers. Most memory allocators allow it and applications might expect a
valid pointer even when allocating zero bytes.