### PR TITLE
Add support for building MSVC shared libraries

### DIFF
--- a/3rdparty/everest/include/everest/everest.h
+++ b/3rdparty/everest/include/everest/everest.h
@@ -22,6 +22,8 @@
 #ifndef MBEDTLS_EVEREST_H
 #define MBEDTLS_EVEREST_H
 
+#include "mbedtls/export.h"
+
 #include "everest/x25519.h"
 
 #ifdef __cplusplus
@@ -58,14 +60,14 @@ typedef struct {
  *
  * \return          \c 0 on success.
  */
-int mbedtls_everest_setup( mbedtls_ecdh_context_everest *ctx, int grp_id );
+MBEDCRYPTO_EXPORT int mbedtls_everest_setup( mbedtls_ecdh_context_everest *ctx, int grp_id );
 
 /**
  * \brief           This function frees a context.
  *
  * \param ctx       The context to free.
  */
-void mbedtls_everest_free( mbedtls_ecdh_context_everest *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_everest_free( mbedtls_ecdh_context_everest *ctx );
 
 /**
  * \brief           This function generates a public key and a TLS
@@ -90,7 +92,7 @@ void mbedtls_everest_free( mbedtls_ecdh_context_everest *ctx );
  * \return          \c 0 on success.
  * \return          An \c MBEDTLS_ERR_ECP_XXX error code on failure.
  */
-int mbedtls_everest_make_params( mbedtls_ecdh_context_everest *ctx, size_t *olen,
+MBEDCRYPTO_EXPORT int mbedtls_everest_make_params( mbedtls_ecdh_context_everest *ctx, size_t *olen,
                                  unsigned char *buf, size_t blen,
                                  int( *f_rng )( void *, unsigned char *, size_t ),
                                  void *p_rng );
@@ -112,7 +114,7 @@ int mbedtls_everest_make_params( mbedtls_ecdh_context_everest *ctx, size_t *olen
  * \return          An \c MBEDTLS_ERR_ECP_XXX error code on failure.
  *
  */
-int mbedtls_everest_read_params( mbedtls_ecdh_context_everest *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_everest_read_params( mbedtls_ecdh_context_everest *ctx,
                                  const unsigned char **buf, const unsigned char *end );
 
 /**
@@ -132,7 +134,7 @@ int mbedtls_everest_read_params( mbedtls_ecdh_context_everest *ctx,
  * \return          An \c MBEDTLS_ERR_ECP_XXX error code on failure.
  *
  */
-int mbedtls_everest_read_params( mbedtls_ecdh_context_everest *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_everest_read_params( mbedtls_ecdh_context_everest *ctx,
                                  const unsigned char **buf, const unsigned char *end );
 
 /**
@@ -153,7 +155,7 @@ int mbedtls_everest_read_params( mbedtls_ecdh_context_everest *ctx,
  * \return          An \c MBEDTLS_ERR_ECP_XXX error code on failure.
  *
  */
-int mbedtls_everest_get_params( mbedtls_ecdh_context_everest *ctx, const mbedtls_ecp_keypair *key,
+MBEDCRYPTO_EXPORT int mbedtls_everest_get_params( mbedtls_ecdh_context_everest *ctx, const mbedtls_ecp_keypair *key,
                                 mbedtls_everest_ecdh_side side );
 
 /**
@@ -175,7 +177,7 @@ int mbedtls_everest_get_params( mbedtls_ecdh_context_everest *ctx, const mbedtls
  * \return          \c 0 on success.
  * \return          An \c MBEDTLS_ERR_ECP_XXX error code on failure.
  */
-int mbedtls_everest_make_public( mbedtls_ecdh_context_everest *ctx, size_t *olen,
+MBEDCRYPTO_EXPORT int mbedtls_everest_make_public( mbedtls_ecdh_context_everest *ctx, size_t *olen,
                                  unsigned char *buf, size_t blen,
                                  int( *f_rng )( void *, unsigned char *, size_t ),
                                  void *p_rng );
@@ -197,7 +199,7 @@ int mbedtls_everest_make_public( mbedtls_ecdh_context_everest *ctx, size_t *olen
  * \return      \c 0 on success.
  * \return      An \c MBEDTLS_ERR_ECP_XXX error code on failure.
  */
-int mbedtls_everest_read_public( mbedtls_ecdh_context_everest *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_everest_read_public( mbedtls_ecdh_context_everest *ctx,
                                  const unsigned char *buf, size_t blen );
 
 /**
@@ -222,7 +224,7 @@ int mbedtls_everest_read_public( mbedtls_ecdh_context_everest *ctx,
  * \return          \c 0 on success.
  * \return          An \c MBEDTLS_ERR_ECP_XXX error code on failure.
  */
-int mbedtls_everest_calc_secret( mbedtls_ecdh_context_everest *ctx, size_t *olen,
+MBEDCRYPTO_EXPORT int mbedtls_everest_calc_secret( mbedtls_ecdh_context_everest *ctx, size_t *olen,
                                  unsigned char *buf, size_t blen,
                                  int( *f_rng )( void *, unsigned char *, size_t ),
                                  void *p_rng );

--- a/3rdparty/everest/include/everest/x25519.h
+++ b/3rdparty/everest/include/everest/x25519.h
@@ -22,6 +22,8 @@
 #ifndef MBEDTLS_X25519_H
 #define MBEDTLS_X25519_H
 
+#include "mbedtls/export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -52,14 +54,14 @@ typedef struct
  *
  * \param ctx       The x25519 context to initialize.
  */
-void mbedtls_x25519_init( mbedtls_x25519_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_x25519_init( mbedtls_x25519_context *ctx );
 
 /**
  * \brief           This function frees a context.
  *
  * \param ctx       The context to free.
  */
-void mbedtls_x25519_free( mbedtls_x25519_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_x25519_free( mbedtls_x25519_context *ctx );
 
 /**
  * \brief           This function generates a public key and a TLS
@@ -78,7 +80,7 @@ void mbedtls_x25519_free( mbedtls_x25519_context *ctx );
  * \return          \c 0 on success.
  * \return          An \c MBEDTLS_ERR_ECP_XXX error code on failure.
  */
-int mbedtls_x25519_make_params( mbedtls_x25519_context *ctx, size_t *olen,
+MBEDCRYPTO_EXPORT int mbedtls_x25519_make_params( mbedtls_x25519_context *ctx, size_t *olen,
                         unsigned char *buf, size_t blen,
                         int( *f_rng )(void *, unsigned char *, size_t),
                         void *p_rng );
@@ -96,7 +98,7 @@ int mbedtls_x25519_make_params( mbedtls_x25519_context *ctx, size_t *olen,
  * \return          An \c MBEDTLS_ERR_ECP_XXX error code on failure.
  *
  */
-int mbedtls_x25519_read_params( mbedtls_x25519_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_x25519_read_params( mbedtls_x25519_context *ctx,
                         const unsigned char **buf, const unsigned char *end );
 
 /**
@@ -117,7 +119,7 @@ int mbedtls_x25519_read_params( mbedtls_x25519_context *ctx,
  * \return          An \c MBEDTLS_ERR_ECP_XXX error code on failure.
  *
  */
-int mbedtls_x25519_get_params( mbedtls_x25519_context *ctx, const mbedtls_ecp_keypair *key,
+MBEDCRYPTO_EXPORT int mbedtls_x25519_get_params( mbedtls_x25519_context *ctx, const mbedtls_ecp_keypair *key,
                                mbedtls_x25519_ecdh_side side );
 
 /**
@@ -137,7 +139,7 @@ int mbedtls_x25519_get_params( mbedtls_x25519_context *ctx, const mbedtls_ecp_ke
  * \return          \c 0 on success.
  * \return          An \c MBEDTLS_ERR_ECP_XXX error code on failure.
  */
-int mbedtls_x25519_calc_secret( mbedtls_x25519_context *ctx, size_t *olen,
+MBEDCRYPTO_EXPORT int mbedtls_x25519_calc_secret( mbedtls_x25519_context *ctx, size_t *olen,
                         unsigned char *buf, size_t blen,
                         int( *f_rng )(void *, unsigned char *, size_t),
                         void *p_rng );
@@ -160,7 +162,7 @@ int mbedtls_x25519_calc_secret( mbedtls_x25519_context *ctx, size_t *olen,
  * \return          \c 0 on success.
  * \return          An \c MBEDTLS_ERR_ECP_XXX error code on failure.
  */
-int mbedtls_x25519_make_public( mbedtls_x25519_context *ctx, size_t *olen,
+MBEDCRYPTO_EXPORT int mbedtls_x25519_make_public( mbedtls_x25519_context *ctx, size_t *olen,
                         unsigned char *buf, size_t blen,
                         int( *f_rng )(void *, unsigned char *, size_t),
                         void *p_rng );
@@ -180,7 +182,7 @@ int mbedtls_x25519_make_public( mbedtls_x25519_context *ctx, size_t *olen,
  * \return      \c 0 on success.
  * \return      An \c MBEDTLS_ERR_ECP_XXX error code on failure.
  */
-int mbedtls_x25519_read_public( mbedtls_x25519_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_x25519_read_public( mbedtls_x25519_context *ctx,
                         const unsigned char *buf, size_t blen );
 
 #ifdef __cplusplus

--- a/include/mbedtls/aes.h
+++ b/include/mbedtls/aes.h
@@ -47,6 +47,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -123,7 +125,7 @@ typedef struct mbedtls_aes_xts_context
  *
  * \param ctx      The AES context to initialize. This must not be \c NULL.
  */
-void mbedtls_aes_init( mbedtls_aes_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_aes_init( mbedtls_aes_context *ctx );
 
 /**
  * \brief          This function releases and clears the specified AES context.
@@ -132,7 +134,7 @@ void mbedtls_aes_init( mbedtls_aes_context *ctx );
  *                 If this is \c NULL, this function does nothing.
  *                 Otherwise, the context must have been at least initialized.
  */
-void mbedtls_aes_free( mbedtls_aes_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_aes_free( mbedtls_aes_context *ctx );
 
 #if defined(MBEDTLS_CIPHER_MODE_XTS)
 /**
@@ -143,7 +145,7 @@ void mbedtls_aes_free( mbedtls_aes_context *ctx );
  *
  * \param ctx      The AES XTS context to initialize. This must not be \c NULL.
  */
-void mbedtls_aes_xts_init( mbedtls_aes_xts_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_aes_xts_init( mbedtls_aes_xts_context *ctx );
 
 /**
  * \brief          This function releases and clears the specified AES XTS context.
@@ -152,7 +154,7 @@ void mbedtls_aes_xts_init( mbedtls_aes_xts_context *ctx );
  *                 If this is \c NULL, this function does nothing.
  *                 Otherwise, the context must have been at least initialized.
  */
-void mbedtls_aes_xts_free( mbedtls_aes_xts_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_aes_xts_free( mbedtls_aes_xts_context *ctx );
 #endif /* MBEDTLS_CIPHER_MODE_XTS */
 
 /**
@@ -170,7 +172,7 @@ void mbedtls_aes_xts_free( mbedtls_aes_xts_context *ctx );
  * \return         \c 0 on success.
  * \return         #MBEDTLS_ERR_AES_INVALID_KEY_LENGTH on failure.
  */
-int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
+MBEDCRYPTO_EXPORT int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
                     unsigned int keybits );
 
 /**
@@ -188,7 +190,7 @@ int mbedtls_aes_setkey_enc( mbedtls_aes_context *ctx, const unsigned char *key,
  * \return         \c 0 on success.
  * \return         #MBEDTLS_ERR_AES_INVALID_KEY_LENGTH on failure.
  */
-int mbedtls_aes_setkey_dec( mbedtls_aes_context *ctx, const unsigned char *key,
+MBEDCRYPTO_EXPORT int mbedtls_aes_setkey_dec( mbedtls_aes_context *ctx, const unsigned char *key,
                     unsigned int keybits );
 
 #if defined(MBEDTLS_CIPHER_MODE_XTS)
@@ -208,7 +210,7 @@ int mbedtls_aes_setkey_dec( mbedtls_aes_context *ctx, const unsigned char *key,
  * \return         \c 0 on success.
  * \return         #MBEDTLS_ERR_AES_INVALID_KEY_LENGTH on failure.
  */
-int mbedtls_aes_xts_setkey_enc( mbedtls_aes_xts_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_aes_xts_setkey_enc( mbedtls_aes_xts_context *ctx,
                                 const unsigned char *key,
                                 unsigned int keybits );
 
@@ -228,7 +230,7 @@ int mbedtls_aes_xts_setkey_enc( mbedtls_aes_xts_context *ctx,
  * \return         \c 0 on success.
  * \return         #MBEDTLS_ERR_AES_INVALID_KEY_LENGTH on failure.
  */
-int mbedtls_aes_xts_setkey_dec( mbedtls_aes_xts_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_aes_xts_setkey_dec( mbedtls_aes_xts_context *ctx,
                                 const unsigned char *key,
                                 unsigned int keybits );
 #endif /* MBEDTLS_CIPHER_MODE_XTS */
@@ -256,7 +258,7 @@ int mbedtls_aes_xts_setkey_dec( mbedtls_aes_xts_context *ctx,
 
  * \return         \c 0 on success.
  */
-int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
                     int mode,
                     const unsigned char input[16],
                     unsigned char output[16] );
@@ -303,7 +305,7 @@ int mbedtls_aes_crypt_ecb( mbedtls_aes_context *ctx,
  * \return         #MBEDTLS_ERR_AES_INVALID_INPUT_LENGTH
  *                 on failure.
  */
-int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
                     int mode,
                     size_t length,
                     unsigned char iv[16],
@@ -347,7 +349,7 @@ int mbedtls_aes_crypt_cbc( mbedtls_aes_context *ctx,
  *                     smaller than an AES block in size (16 Bytes) or if \p
  *                     length is larger than 2^20 blocks (16 MiB).
  */
-int mbedtls_aes_crypt_xts( mbedtls_aes_xts_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_aes_crypt_xts( mbedtls_aes_xts_context *ctx,
                            int mode,
                            size_t length,
                            const unsigned char data_unit[16],
@@ -395,7 +397,7 @@ int mbedtls_aes_crypt_xts( mbedtls_aes_xts_context *ctx,
  *
  * \return         \c 0 on success.
  */
-int mbedtls_aes_crypt_cfb128( mbedtls_aes_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_aes_crypt_cfb128( mbedtls_aes_context *ctx,
                        int mode,
                        size_t length,
                        size_t *iv_off,
@@ -439,7 +441,7 @@ int mbedtls_aes_crypt_cfb128( mbedtls_aes_context *ctx,
  *
  * \return         \c 0 on success.
  */
-int mbedtls_aes_crypt_cfb8( mbedtls_aes_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_aes_crypt_cfb8( mbedtls_aes_context *ctx,
                     int mode,
                     size_t length,
                     unsigned char iv[16],
@@ -493,7 +495,7 @@ int mbedtls_aes_crypt_cfb8( mbedtls_aes_context *ctx,
  *
  * \return         \c 0 on success.
  */
-int mbedtls_aes_crypt_ofb( mbedtls_aes_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_aes_crypt_ofb( mbedtls_aes_context *ctx,
                        size_t length,
                        size_t *iv_off,
                        unsigned char iv[16],
@@ -579,7 +581,7 @@ int mbedtls_aes_crypt_ofb( mbedtls_aes_context *ctx,
  *
  * \return                 \c 0 on success.
  */
-int mbedtls_aes_crypt_ctr( mbedtls_aes_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_aes_crypt_ctr( mbedtls_aes_context *ctx,
                        size_t length,
                        size_t *nc_off,
                        unsigned char nonce_counter[16],
@@ -599,7 +601,7 @@ int mbedtls_aes_crypt_ctr( mbedtls_aes_context *ctx,
  *
  * \return          \c 0 on success.
  */
-int mbedtls_internal_aes_encrypt( mbedtls_aes_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_internal_aes_encrypt( mbedtls_aes_context *ctx,
                                   const unsigned char input[16],
                                   unsigned char output[16] );
 
@@ -614,7 +616,7 @@ int mbedtls_internal_aes_encrypt( mbedtls_aes_context *ctx,
  *
  * \return          \c 0 on success.
  */
-int mbedtls_internal_aes_decrypt( mbedtls_aes_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_internal_aes_decrypt( mbedtls_aes_context *ctx,
                                   const unsigned char input[16],
                                   unsigned char output[16] );
 
@@ -663,7 +665,7 @@ MBEDTLS_DEPRECATED void mbedtls_aes_decrypt( mbedtls_aes_context *ctx,
  * \return         \c 0 on success.
  * \return         \c 1 on failure.
  */
-int mbedtls_aes_self_test( int verbose );
+MBEDCRYPTO_EXPORT int mbedtls_aes_self_test( int verbose );
 
 #endif /* MBEDTLS_SELF_TEST */
 

--- a/include/mbedtls/aesni.h
+++ b/include/mbedtls/aesni.h
@@ -33,6 +33,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include "mbedtls/aes.h"
 
 #define MBEDTLS_AESNI_AES      0x02000000u
@@ -61,7 +63,7 @@ extern "C" {
  *
  * \return         1 if CPU has support for the feature, 0 otherwise
  */
-int mbedtls_aesni_has_support( unsigned int what );
+MBEDCRYPTO_EXPORT int mbedtls_aesni_has_support( unsigned int what );
 
 /**
  * \brief          Internal AES-NI AES-ECB block encryption and decryption
@@ -76,7 +78,7 @@ int mbedtls_aesni_has_support( unsigned int what );
  *
  * \return         0 on success (cannot fail)
  */
-int mbedtls_aesni_crypt_ecb( mbedtls_aes_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_aesni_crypt_ecb( mbedtls_aes_context *ctx,
                              int mode,
                              const unsigned char input[16],
                              unsigned char output[16] );
@@ -94,7 +96,7 @@ int mbedtls_aesni_crypt_ecb( mbedtls_aes_context *ctx,
  * \note           Both operands and result are bit strings interpreted as
  *                 elements of GF(2^128) as per the GCM spec.
  */
-void mbedtls_aesni_gcm_mult( unsigned char c[16],
+MBEDCRYPTO_EXPORT void mbedtls_aesni_gcm_mult( unsigned char c[16],
                              const unsigned char a[16],
                              const unsigned char b[16] );
 
@@ -109,7 +111,7 @@ void mbedtls_aesni_gcm_mult( unsigned char c[16],
  * \param fwdkey    Original round keys (for encryption)
  * \param nr        Number of rounds (that is, number of round keys minus one)
  */
-void mbedtls_aesni_inverse_key( unsigned char *invkey,
+MBEDCRYPTO_EXPORT void mbedtls_aesni_inverse_key( unsigned char *invkey,
                                 const unsigned char *fwdkey,
                                 int nr );
 
@@ -125,7 +127,7 @@ void mbedtls_aesni_inverse_key( unsigned char *invkey,
  *
  * \return          0 if successful, or MBEDTLS_ERR_AES_INVALID_KEY_LENGTH
  */
-int mbedtls_aesni_setkey_enc( unsigned char *rk,
+MBEDCRYPTO_EXPORT int mbedtls_aesni_setkey_enc( unsigned char *rk,
                               const unsigned char *key,
                               size_t bits );
 

--- a/include/mbedtls/arc4.h
+++ b/include/mbedtls/arc4.h
@@ -34,6 +34,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include <stddef.h>
 
 /* MBEDTLS_ERR_ARC4_HW_ACCEL_FAILED is deprecated and should not be used. */
@@ -76,7 +78,7 @@ mbedtls_arc4_context;
  *                 instead.
  *
  */
-void mbedtls_arc4_init( mbedtls_arc4_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_arc4_init( mbedtls_arc4_context *ctx );
 
 /**
  * \brief          Clear ARC4 context
@@ -88,7 +90,7 @@ void mbedtls_arc4_init( mbedtls_arc4_context *ctx );
  *                 instead.
  *
  */
-void mbedtls_arc4_free( mbedtls_arc4_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_arc4_free( mbedtls_arc4_context *ctx );
 
 /**
  * \brief          ARC4 key schedule
@@ -102,7 +104,7 @@ void mbedtls_arc4_free( mbedtls_arc4_context *ctx );
  *                 instead.
  *
  */
-void mbedtls_arc4_setup( mbedtls_arc4_context *ctx, const unsigned char *key,
+MBEDCRYPTO_EXPORT void mbedtls_arc4_setup( mbedtls_arc4_context *ctx, const unsigned char *key,
                  unsigned int keylen );
 
 /**
@@ -120,7 +122,7 @@ void mbedtls_arc4_setup( mbedtls_arc4_context *ctx, const unsigned char *key,
  *                 instead.
  *
  */
-int mbedtls_arc4_crypt( mbedtls_arc4_context *ctx, size_t length, const unsigned char *input,
+MBEDCRYPTO_EXPORT int mbedtls_arc4_crypt( mbedtls_arc4_context *ctx, size_t length, const unsigned char *input,
                 unsigned char *output );
 
 #if defined(MBEDTLS_SELF_TEST)
@@ -135,7 +137,7 @@ int mbedtls_arc4_crypt( mbedtls_arc4_context *ctx, size_t length, const unsigned
  *                 instead.
  *
  */
-int mbedtls_arc4_self_test( int verbose );
+MBEDCRYPTO_EXPORT int mbedtls_arc4_self_test( int verbose );
 
 #endif /* MBEDTLS_SELF_TEST */
 

--- a/include/mbedtls/aria.h
+++ b/include/mbedtls/aria.h
@@ -36,6 +36,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -93,7 +95,7 @@ mbedtls_aria_context;
  *
  * \param ctx      The ARIA context to initialize. This must not be \c NULL.
  */
-void mbedtls_aria_init( mbedtls_aria_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_aria_init( mbedtls_aria_context *ctx );
 
 /**
  * \brief          This function releases and clears the specified ARIA context.
@@ -102,7 +104,7 @@ void mbedtls_aria_init( mbedtls_aria_context *ctx );
  *                 case this function returns immediately. If it is not \c NULL,
  *                 it must point to an initialized ARIA context.
  */
-void mbedtls_aria_free( mbedtls_aria_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_aria_free( mbedtls_aria_context *ctx );
 
 /**
  * \brief          This function sets the encryption key.
@@ -119,7 +121,7 @@ void mbedtls_aria_free( mbedtls_aria_context *ctx );
  * \return         \c 0 on success.
  * \return         A negative error code on failure.
  */
-int mbedtls_aria_setkey_enc( mbedtls_aria_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_aria_setkey_enc( mbedtls_aria_context *ctx,
                              const unsigned char *key,
                              unsigned int keybits );
 
@@ -138,7 +140,7 @@ int mbedtls_aria_setkey_enc( mbedtls_aria_context *ctx,
  * \return         \c 0 on success.
  * \return         A negative error code on failure.
  */
-int mbedtls_aria_setkey_dec( mbedtls_aria_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_aria_setkey_dec( mbedtls_aria_context *ctx,
                              const unsigned char *key,
                              unsigned int keybits );
 
@@ -162,7 +164,7 @@ int mbedtls_aria_setkey_dec( mbedtls_aria_context *ctx,
  * \return         \c 0 on success.
  * \return         A negative error code on failure.
  */
-int mbedtls_aria_crypt_ecb( mbedtls_aria_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_aria_crypt_ecb( mbedtls_aria_context *ctx,
                             const unsigned char input[MBEDTLS_ARIA_BLOCKSIZE],
                             unsigned char output[MBEDTLS_ARIA_BLOCKSIZE] );
 
@@ -208,7 +210,7 @@ int mbedtls_aria_crypt_ecb( mbedtls_aria_context *ctx,
  * \return         \c 0 on success.
  * \return         A negative error code on failure.
  */
-int mbedtls_aria_crypt_cbc( mbedtls_aria_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_aria_crypt_cbc( mbedtls_aria_context *ctx,
                             int mode,
                             size_t length,
                             unsigned char iv[MBEDTLS_ARIA_BLOCKSIZE],
@@ -258,7 +260,7 @@ int mbedtls_aria_crypt_cbc( mbedtls_aria_context *ctx,
  * \return         \c 0 on success.
  * \return         A negative error code on failure.
  */
-int mbedtls_aria_crypt_cfb128( mbedtls_aria_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_aria_crypt_cfb128( mbedtls_aria_context *ctx,
                                int mode,
                                size_t length,
                                size_t *iv_off,
@@ -345,7 +347,7 @@ int mbedtls_aria_crypt_cfb128( mbedtls_aria_context *ctx,
  * \return                 \c 0 on success.
  * \return                 A negative error code on failure.
  */
-int mbedtls_aria_crypt_ctr( mbedtls_aria_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_aria_crypt_ctr( mbedtls_aria_context *ctx,
                             size_t length,
                             size_t *nc_off,
                             unsigned char nonce_counter[MBEDTLS_ARIA_BLOCKSIZE],
@@ -360,7 +362,7 @@ int mbedtls_aria_crypt_ctr( mbedtls_aria_context *ctx,
  *
  * \return         \c 0 on success, or \c 1 on failure.
  */
-int mbedtls_aria_self_test( int verbose );
+MBEDCRYPTO_EXPORT int mbedtls_aria_self_test( int verbose );
 #endif /* MBEDTLS_SELF_TEST */
 
 #ifdef __cplusplus

--- a/include/mbedtls/asn1.h
+++ b/include/mbedtls/asn1.h
@@ -30,6 +30,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include <stddef.h>
 
 #if defined(MBEDTLS_BIGNUM_C)
@@ -191,7 +193,7 @@ mbedtls_asn1_named_data;
  *              would end beyond \p end.
  * \return      #MBEDTLS_ERR_ASN1_INVALID_LENGTH if the length is unparseable.
  */
-int mbedtls_asn1_get_len( unsigned char **p,
+MBEDCRYPTO_EXPORT int mbedtls_asn1_get_len( unsigned char **p,
                           const unsigned char *end,
                           size_t *len );
 
@@ -216,7 +218,7 @@ int mbedtls_asn1_get_len( unsigned char **p,
  *              would end beyond \p end.
  * \return      #MBEDTLS_ERR_ASN1_INVALID_LENGTH if the length is unparseable.
  */
-int mbedtls_asn1_get_tag( unsigned char **p,
+MBEDCRYPTO_EXPORT int mbedtls_asn1_get_tag( unsigned char **p,
                           const unsigned char *end,
                           size_t *len, int tag );
 
@@ -235,7 +237,7 @@ int mbedtls_asn1_get_tag( unsigned char **p,
  * \return      An ASN.1 error code if the input does not start with
  *              a valid ASN.1 BOOLEAN.
  */
-int mbedtls_asn1_get_bool( unsigned char **p,
+MBEDCRYPTO_EXPORT int mbedtls_asn1_get_bool( unsigned char **p,
                            const unsigned char *end,
                            int *val );
 
@@ -256,7 +258,7 @@ int mbedtls_asn1_get_bool( unsigned char **p,
  * \return      #MBEDTLS_ERR_ASN1_INVALID_LENGTH if the parsed value does
  *              not fit in an \c int.
  */
-int mbedtls_asn1_get_int( unsigned char **p,
+MBEDCRYPTO_EXPORT int mbedtls_asn1_get_int( unsigned char **p,
                           const unsigned char *end,
                           int *val );
 
@@ -277,7 +279,7 @@ int mbedtls_asn1_get_int( unsigned char **p,
  * \return      #MBEDTLS_ERR_ASN1_INVALID_LENGTH if the parsed value does
  *              not fit in an \c int.
  */
-int mbedtls_asn1_get_enum( unsigned char **p,
+MBEDCRYPTO_EXPORT int mbedtls_asn1_get_enum( unsigned char **p,
                            const unsigned char *end,
                            int *val );
 
@@ -298,7 +300,7 @@ int mbedtls_asn1_get_enum( unsigned char **p,
  * \return      An ASN.1 error code if the input does not start with
  *              a valid ASN.1 BIT STRING.
  */
-int mbedtls_asn1_get_bitstring( unsigned char **p, const unsigned char *end,
+MBEDCRYPTO_EXPORT int mbedtls_asn1_get_bitstring( unsigned char **p, const unsigned char *end,
                                 mbedtls_asn1_bitstring *bs );
 
 /**
@@ -319,7 +321,7 @@ int mbedtls_asn1_get_bitstring( unsigned char **p, const unsigned char *end,
  * \return      An ASN.1 error code if the input does not start with
  *              a valid ASN.1 BIT STRING.
  */
-int mbedtls_asn1_get_bitstring_null( unsigned char **p,
+MBEDCRYPTO_EXPORT int mbedtls_asn1_get_bitstring_null( unsigned char **p,
                                      const unsigned char *end,
                                      size_t *len );
 
@@ -364,7 +366,7 @@ int mbedtls_asn1_get_bitstring_null( unsigned char **p,
  * \return      An ASN.1 error code if the input does not start with
  *              a valid ASN.1 BIT STRING.
  */
-int mbedtls_asn1_get_sequence_of( unsigned char **p,
+MBEDCRYPTO_EXPORT int mbedtls_asn1_get_sequence_of( unsigned char **p,
                                   const unsigned char *end,
                                   mbedtls_asn1_sequence *cur,
                                   int tag );
@@ -388,7 +390,7 @@ int mbedtls_asn1_get_sequence_of( unsigned char **p,
  *              not fit in an \c int.
  * \return      An MPI error code if the parsed value is too large.
  */
-int mbedtls_asn1_get_mpi( unsigned char **p,
+MBEDCRYPTO_EXPORT int mbedtls_asn1_get_mpi( unsigned char **p,
                           const unsigned char *end,
                           mbedtls_mpi *X );
 #endif /* MBEDTLS_BIGNUM_C */
@@ -409,7 +411,7 @@ int mbedtls_asn1_get_mpi( unsigned char **p,
  *
  * \return      0 if successful or a specific ASN.1 or MPI error code.
  */
-int mbedtls_asn1_get_alg( unsigned char **p,
+MBEDCRYPTO_EXPORT int mbedtls_asn1_get_alg( unsigned char **p,
                   const unsigned char *end,
                   mbedtls_asn1_buf *alg, mbedtls_asn1_buf *params );
 
@@ -428,7 +430,7 @@ int mbedtls_asn1_get_alg( unsigned char **p,
  *
  * \return      0 if successful or a specific ASN.1 or MPI error code.
  */
-int mbedtls_asn1_get_alg_null( unsigned char **p,
+MBEDCRYPTO_EXPORT int mbedtls_asn1_get_alg_null( unsigned char **p,
                        const unsigned char *end,
                        mbedtls_asn1_buf *alg );
 
@@ -452,7 +454,7 @@ mbedtls_asn1_named_data *mbedtls_asn1_find_named_data( mbedtls_asn1_named_data *
  *              This function calls mbedtls_free() on
  *              `entry->oid.p` and `entry->val.p`.
  */
-void mbedtls_asn1_free_named_data( mbedtls_asn1_named_data *entry );
+MBEDCRYPTO_EXPORT void mbedtls_asn1_free_named_data( mbedtls_asn1_named_data *entry );
 
 /**
  * \brief       Free all entries in a mbedtls_asn1_named_data list.
@@ -462,7 +464,7 @@ void mbedtls_asn1_free_named_data( mbedtls_asn1_named_data *entry );
  *              mbedtls_free() on each list element and
  *              sets \c *head to \c NULL.
  */
-void mbedtls_asn1_free_named_data_list( mbedtls_asn1_named_data **head );
+MBEDCRYPTO_EXPORT void mbedtls_asn1_free_named_data_list( mbedtls_asn1_named_data **head );
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/asn1write.h
+++ b/include/mbedtls/asn1write.h
@@ -30,6 +30,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include "mbedtls/asn1.h"
 
 #define MBEDTLS_ASN1_CHK_ADD(g, f)                      \
@@ -57,7 +59,7 @@ extern "C" {
  * \return          The number of bytes written to \p p on success.
  * \return          A negative \c MBEDTLS_ERR_ASN1_XXX error code on failure.
  */
-int mbedtls_asn1_write_len( unsigned char **p, unsigned char *start,
+MBEDCRYPTO_EXPORT int mbedtls_asn1_write_len( unsigned char **p, unsigned char *start,
                             size_t len );
 /**
  * \brief           Write an ASN.1 tag in ASN.1 format.
@@ -71,7 +73,7 @@ int mbedtls_asn1_write_len( unsigned char **p, unsigned char *start,
  * \return          The number of bytes written to \p p on success.
  * \return          A negative \c MBEDTLS_ERR_ASN1_XXX error code on failure.
  */
-int mbedtls_asn1_write_tag( unsigned char **p, unsigned char *start,
+MBEDCRYPTO_EXPORT int mbedtls_asn1_write_tag( unsigned char **p, unsigned char *start,
                             unsigned char tag );
 
 /**
@@ -87,7 +89,7 @@ int mbedtls_asn1_write_tag( unsigned char **p, unsigned char *start,
  * \return          The number of bytes written to \p p on success.
  * \return          A negative \c MBEDTLS_ERR_ASN1_XXX error code on failure.
  */
-int mbedtls_asn1_write_raw_buffer( unsigned char **p, unsigned char *start,
+MBEDCRYPTO_EXPORT int mbedtls_asn1_write_raw_buffer( unsigned char **p, unsigned char *start,
                                    const unsigned char *buf, size_t size );
 
 #if defined(MBEDTLS_BIGNUM_C)
@@ -105,7 +107,7 @@ int mbedtls_asn1_write_raw_buffer( unsigned char **p, unsigned char *start,
  * \return          The number of bytes written to \p p on success.
  * \return          A negative \c MBEDTLS_ERR_ASN1_XXX error code on failure.
  */
-int mbedtls_asn1_write_mpi( unsigned char **p, unsigned char *start,
+MBEDCRYPTO_EXPORT int mbedtls_asn1_write_mpi( unsigned char **p, unsigned char *start,
                             const mbedtls_mpi *X );
 #endif /* MBEDTLS_BIGNUM_C */
 
@@ -121,7 +123,7 @@ int mbedtls_asn1_write_mpi( unsigned char **p, unsigned char *start,
  * \return          The number of bytes written to \p p on success.
  * \return          A negative \c MBEDTLS_ERR_ASN1_XXX error code on failure.
  */
-int mbedtls_asn1_write_null( unsigned char **p, unsigned char *start );
+MBEDCRYPTO_EXPORT int mbedtls_asn1_write_null( unsigned char **p, unsigned char *start );
 
 /**
  * \brief           Write an OID tag (#MBEDTLS_ASN1_OID) and data
@@ -137,7 +139,7 @@ int mbedtls_asn1_write_null( unsigned char **p, unsigned char *start );
  * \return          The number of bytes written to \p p on success.
  * \return          A negative \c MBEDTLS_ERR_ASN1_XXX error code on failure.
  */
-int mbedtls_asn1_write_oid( unsigned char **p, unsigned char *start,
+MBEDCRYPTO_EXPORT int mbedtls_asn1_write_oid( unsigned char **p, unsigned char *start,
                             const char *oid, size_t oid_len );
 
 /**
@@ -155,7 +157,7 @@ int mbedtls_asn1_write_oid( unsigned char **p, unsigned char *start,
  * \return          The number of bytes written to \p p on success.
  * \return          A negative \c MBEDTLS_ERR_ASN1_XXX error code on failure.
  */
-int mbedtls_asn1_write_algorithm_identifier( unsigned char **p,
+MBEDCRYPTO_EXPORT int mbedtls_asn1_write_algorithm_identifier( unsigned char **p,
                                              unsigned char *start,
                                              const char *oid, size_t oid_len,
                                              size_t par_len );
@@ -173,7 +175,7 @@ int mbedtls_asn1_write_algorithm_identifier( unsigned char **p,
  * \return          The number of bytes written to \p p on success.
  * \return          A negative \c MBEDTLS_ERR_ASN1_XXX error code on failure.
  */
-int mbedtls_asn1_write_bool( unsigned char **p, unsigned char *start,
+MBEDCRYPTO_EXPORT int mbedtls_asn1_write_bool( unsigned char **p, unsigned char *start,
                              int boolean );
 
 /**
@@ -190,7 +192,7 @@ int mbedtls_asn1_write_bool( unsigned char **p, unsigned char *start,
  * \return          The number of bytes written to \p p on success.
  * \return          A negative \c MBEDTLS_ERR_ASN1_XXX error code on failure.
  */
-int mbedtls_asn1_write_int( unsigned char **p, unsigned char *start, int val );
+MBEDCRYPTO_EXPORT int mbedtls_asn1_write_int( unsigned char **p, unsigned char *start, int val );
 
 /**
  * \brief           Write an enum tag (#MBEDTLS_ASN1_ENUMERATED) and value
@@ -205,7 +207,7 @@ int mbedtls_asn1_write_int( unsigned char **p, unsigned char *start, int val );
  * \return          The number of bytes written to \p p on success.
  * \return          A negative \c MBEDTLS_ERR_ASN1_XXX error code on failure.
  */
-int mbedtls_asn1_write_enum( unsigned char **p, unsigned char *start, int val );
+MBEDCRYPTO_EXPORT int mbedtls_asn1_write_enum( unsigned char **p, unsigned char *start, int val );
 
 /**
  * \brief           Write a string in ASN.1 format using a specific
@@ -224,7 +226,7 @@ int mbedtls_asn1_write_enum( unsigned char **p, unsigned char *start, int val );
  * \return          The number of bytes written to \p p on success.
  * \return          A negative error code on failure.
  */
-int mbedtls_asn1_write_tagged_string( unsigned char **p, unsigned char *start,
+MBEDCRYPTO_EXPORT int mbedtls_asn1_write_tagged_string( unsigned char **p, unsigned char *start,
                                       int tag, const char *text,
                                       size_t text_len );
 
@@ -243,7 +245,7 @@ int mbedtls_asn1_write_tagged_string( unsigned char **p, unsigned char *start,
  * \return          The number of bytes written to \p p on success.
  * \return          A negative error code on failure.
  */
-int mbedtls_asn1_write_printable_string( unsigned char **p,
+MBEDCRYPTO_EXPORT int mbedtls_asn1_write_printable_string( unsigned char **p,
                                          unsigned char *start,
                                          const char *text, size_t text_len );
 
@@ -262,7 +264,7 @@ int mbedtls_asn1_write_printable_string( unsigned char **p,
  * \return          The number of bytes written to \p p on success.
  * \return          A negative error code on failure.
  */
-int mbedtls_asn1_write_utf8_string( unsigned char **p, unsigned char *start,
+MBEDCRYPTO_EXPORT int mbedtls_asn1_write_utf8_string( unsigned char **p, unsigned char *start,
                                     const char *text, size_t text_len );
 
 /**
@@ -280,7 +282,7 @@ int mbedtls_asn1_write_utf8_string( unsigned char **p, unsigned char *start,
  * \return          The number of bytes written to \p p on success.
  * \return          A negative error code on failure.
  */
-int mbedtls_asn1_write_ia5_string( unsigned char **p, unsigned char *start,
+MBEDCRYPTO_EXPORT int mbedtls_asn1_write_ia5_string( unsigned char **p, unsigned char *start,
                                    const char *text, size_t text_len );
 
 /**
@@ -297,7 +299,7 @@ int mbedtls_asn1_write_ia5_string( unsigned char **p, unsigned char *start,
  * \return          The number of bytes written to \p p on success.
  * \return          A negative error code on failure.
  */
-int mbedtls_asn1_write_bitstring( unsigned char **p, unsigned char *start,
+MBEDCRYPTO_EXPORT int mbedtls_asn1_write_bitstring( unsigned char **p, unsigned char *start,
                                   const unsigned char *buf, size_t bits );
 
 /**
@@ -317,7 +319,7 @@ int mbedtls_asn1_write_bitstring( unsigned char **p, unsigned char *start,
  * \return          The number of bytes written to \p p on success.
  * \return          A negative error code on failure.
  */
-int mbedtls_asn1_write_named_bitstring( unsigned char **p,
+MBEDCRYPTO_EXPORT int mbedtls_asn1_write_named_bitstring( unsigned char **p,
                                         unsigned char *start,
                                         const unsigned char *buf,
                                         size_t bits );
@@ -336,7 +338,7 @@ int mbedtls_asn1_write_named_bitstring( unsigned char **p,
  * \return          The number of bytes written to \p p on success.
  * \return          A negative error code on failure.
  */
-int mbedtls_asn1_write_octet_string( unsigned char **p, unsigned char *start,
+MBEDCRYPTO_EXPORT int mbedtls_asn1_write_octet_string( unsigned char **p, unsigned char *start,
                                      const unsigned char *buf, size_t size );
 
 /**
@@ -360,7 +362,7 @@ int mbedtls_asn1_write_octet_string( unsigned char **p, unsigned char *start,
  * \return          A pointer to the new / existing entry on success.
  * \return          \c NULL if if there was a memory allocation error.
  */
-mbedtls_asn1_named_data *mbedtls_asn1_store_named_data( mbedtls_asn1_named_data **list,
+MBEDCRYPTO_EXPORT mbedtls_asn1_named_data *mbedtls_asn1_store_named_data( mbedtls_asn1_named_data **list,
                                         const char *oid, size_t oid_len,
                                         const unsigned char *val,
                                         size_t val_len );

--- a/include/mbedtls/base64.h
+++ b/include/mbedtls/base64.h
@@ -30,6 +30,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include <stddef.h>
 
 #define MBEDTLS_ERR_BASE64_BUFFER_TOO_SMALL               -0x002A  /**< Output buffer too small. */
@@ -58,7 +60,7 @@ extern "C" {
  * \note           Call this function with dlen = 0 to obtain the
  *                 required buffer size in *olen
  */
-int mbedtls_base64_encode( unsigned char *dst, size_t dlen, size_t *olen,
+MBEDCRYPTO_EXPORT int mbedtls_base64_encode( unsigned char *dst, size_t dlen, size_t *olen,
                    const unsigned char *src, size_t slen );
 
 /**
@@ -78,7 +80,7 @@ int mbedtls_base64_encode( unsigned char *dst, size_t dlen, size_t *olen,
  * \note           Call this function with *dst = NULL or dlen = 0 to obtain
  *                 the required buffer size in *olen
  */
-int mbedtls_base64_decode( unsigned char *dst, size_t dlen, size_t *olen,
+MBEDCRYPTO_EXPORT int mbedtls_base64_decode( unsigned char *dst, size_t dlen, size_t *olen,
                    const unsigned char *src, size_t slen );
 
 #if defined(MBEDTLS_SELF_TEST)
@@ -87,7 +89,7 @@ int mbedtls_base64_decode( unsigned char *dst, size_t dlen, size_t *olen,
  *
  * \return         0 if successful, or 1 if the test failed
  */
-int mbedtls_base64_self_test( int verbose );
+MBEDCRYPTO_EXPORT int mbedtls_base64_self_test( int verbose );
 
 #endif /* MBEDTLS_SELF_TEST */
 

--- a/include/mbedtls/bignum.h
+++ b/include/mbedtls/bignum.h
@@ -30,6 +30,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -199,7 +201,7 @@ mbedtls_mpi;
  *
  * \param X         The MPI context to initialize. This must not be \c NULL.
  */
-void mbedtls_mpi_init( mbedtls_mpi *X );
+MBEDCRYPTO_EXPORT void mbedtls_mpi_init( mbedtls_mpi *X );
 
 /**
  * \brief          This function frees the components of an MPI context.
@@ -208,7 +210,7 @@ void mbedtls_mpi_init( mbedtls_mpi *X );
  *                 in which case this function is a no-op. If it is
  *                 not \c NULL, it must point to an initialized MPI.
  */
-void mbedtls_mpi_free( mbedtls_mpi *X );
+MBEDCRYPTO_EXPORT void mbedtls_mpi_free( mbedtls_mpi *X );
 
 /**
  * \brief          Enlarge an MPI to the specified number of limbs.
@@ -223,7 +225,7 @@ void mbedtls_mpi_free( mbedtls_mpi *X );
  * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if memory allocation failed.
  * \return         Another negative error code on other kinds of failure.
  */
-int mbedtls_mpi_grow( mbedtls_mpi *X, size_t nblimbs );
+MBEDCRYPTO_EXPORT int mbedtls_mpi_grow( mbedtls_mpi *X, size_t nblimbs );
 
 /**
  * \brief          This function resizes an MPI downwards, keeping at least the
@@ -240,7 +242,7 @@ int mbedtls_mpi_grow( mbedtls_mpi *X, size_t nblimbs );
  *                 (this can only happen when resizing up).
  * \return         Another negative error code on other kinds of failure.
  */
-int mbedtls_mpi_shrink( mbedtls_mpi *X, size_t nblimbs );
+MBEDCRYPTO_EXPORT int mbedtls_mpi_shrink( mbedtls_mpi *X, size_t nblimbs );
 
 /**
  * \brief          Make a copy of an MPI.
@@ -255,7 +257,7 @@ int mbedtls_mpi_shrink( mbedtls_mpi *X, size_t nblimbs );
  * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if memory allocation failed.
  * \return         Another negative error code on other kinds of failure.
  */
-int mbedtls_mpi_copy( mbedtls_mpi *X, const mbedtls_mpi *Y );
+MBEDCRYPTO_EXPORT int mbedtls_mpi_copy( mbedtls_mpi *X, const mbedtls_mpi *Y );
 
 /**
  * \brief          Swap the contents of two MPIs.
@@ -263,7 +265,7 @@ int mbedtls_mpi_copy( mbedtls_mpi *X, const mbedtls_mpi *Y );
  * \param X        The first MPI. It must be initialized.
  * \param Y        The second MPI. It must be initialized.
  */
-void mbedtls_mpi_swap( mbedtls_mpi *X, mbedtls_mpi *Y );
+MBEDCRYPTO_EXPORT void mbedtls_mpi_swap( mbedtls_mpi *X, mbedtls_mpi *Y );
 
 /**
  * \brief          Perform a safe conditional copy of MPI which doesn't
@@ -289,7 +291,7 @@ void mbedtls_mpi_swap( mbedtls_mpi *X, mbedtls_mpi *Y );
  * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if memory allocation failed.
  * \return         Another negative error code on other kinds of failure.
  */
-int mbedtls_mpi_safe_cond_assign( mbedtls_mpi *X, const mbedtls_mpi *Y, unsigned char assign );
+MBEDCRYPTO_EXPORT int mbedtls_mpi_safe_cond_assign( mbedtls_mpi *X, const mbedtls_mpi *Y, unsigned char assign );
 
 /**
  * \brief          Perform a safe conditional swap which doesn't
@@ -314,7 +316,7 @@ int mbedtls_mpi_safe_cond_assign( mbedtls_mpi *X, const mbedtls_mpi *Y, unsigned
  * \return         Another negative error code on other kinds of failure.
  *
  */
-int mbedtls_mpi_safe_cond_swap( mbedtls_mpi *X, mbedtls_mpi *Y, unsigned char assign );
+MBEDCRYPTO_EXPORT int mbedtls_mpi_safe_cond_swap( mbedtls_mpi *X, mbedtls_mpi *Y, unsigned char assign );
 
 /**
  * \brief          Store integer value in MPI.
@@ -326,7 +328,7 @@ int mbedtls_mpi_safe_cond_swap( mbedtls_mpi *X, mbedtls_mpi *Y, unsigned char as
  * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if memory allocation failed.
  * \return         Another negative error code on other kinds of failure.
  */
-int mbedtls_mpi_lset( mbedtls_mpi *X, mbedtls_mpi_sint z );
+MBEDCRYPTO_EXPORT int mbedtls_mpi_lset( mbedtls_mpi *X, mbedtls_mpi_sint z );
 
 /**
  * \brief          Get a specific bit from an MPI.
@@ -338,7 +340,7 @@ int mbedtls_mpi_lset( mbedtls_mpi *X, mbedtls_mpi_sint z );
  *                 of \c X is unset or set.
  * \return         A negative error code on failure.
  */
-int mbedtls_mpi_get_bit( const mbedtls_mpi *X, size_t pos );
+MBEDCRYPTO_EXPORT int mbedtls_mpi_get_bit( const mbedtls_mpi *X, size_t pos );
 
 /**
  * \brief          Modify a specific bit in an MPI.
@@ -355,7 +357,7 @@ int mbedtls_mpi_get_bit( const mbedtls_mpi *X, size_t pos );
  * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if memory allocation failed.
  * \return         Another negative error code on other kinds of failure.
  */
-int mbedtls_mpi_set_bit( mbedtls_mpi *X, size_t pos, unsigned char val );
+MBEDCRYPTO_EXPORT int mbedtls_mpi_set_bit( mbedtls_mpi *X, size_t pos, unsigned char val );
 
 /**
  * \brief          Return the number of bits of value \c 0 before the
@@ -369,7 +371,7 @@ int mbedtls_mpi_set_bit( mbedtls_mpi *X, size_t pos, unsigned char val );
  * \return         The number of bits of value \c 0 before the least significant
  *                 bit of value \c 1 in \p X.
  */
-size_t mbedtls_mpi_lsb( const mbedtls_mpi *X );
+MBEDCRYPTO_EXPORT size_t mbedtls_mpi_lsb( const mbedtls_mpi *X );
 
 /**
  * \brief          Return the number of bits up to and including the most
@@ -383,7 +385,7 @@ size_t mbedtls_mpi_lsb( const mbedtls_mpi *X );
  * \return         The number of bits up to and including the most
  *                 significant bit of value \c 1.
  */
-size_t mbedtls_mpi_bitlen( const mbedtls_mpi *X );
+MBEDCRYPTO_EXPORT size_t mbedtls_mpi_bitlen( const mbedtls_mpi *X );
 
 /**
  * \brief          Return the total size of an MPI value in bytes.
@@ -398,7 +400,7 @@ size_t mbedtls_mpi_bitlen( const mbedtls_mpi *X );
  * \return         The least number of bytes capable of storing
  *                 the absolute value of \p X.
  */
-size_t mbedtls_mpi_size( const mbedtls_mpi *X );
+MBEDCRYPTO_EXPORT size_t mbedtls_mpi_size( const mbedtls_mpi *X );
 
 /**
  * \brief          Import an MPI from an ASCII string.
@@ -410,7 +412,7 @@ size_t mbedtls_mpi_size( const mbedtls_mpi *X );
  * \return         \c 0 if successful.
  * \return         A negative error code on failure.
  */
-int mbedtls_mpi_read_string( mbedtls_mpi *X, int radix, const char *s );
+MBEDCRYPTO_EXPORT int mbedtls_mpi_read_string( mbedtls_mpi *X, int radix, const char *s );
 
 /**
  * \brief          Export an MPI to an ASCII string.
@@ -434,7 +436,7 @@ int mbedtls_mpi_read_string( mbedtls_mpi *X, int radix, const char *s );
  *                 size of \p buf required for a successful call.
  * \return         Another negative error code on different kinds of failure.
  */
-int mbedtls_mpi_write_string( const mbedtls_mpi *X, int radix,
+MBEDCRYPTO_EXPORT int mbedtls_mpi_write_string( const mbedtls_mpi *X, int radix,
                               char *buf, size_t buflen, size_t *olen );
 
 #if defined(MBEDTLS_FS_IO)
@@ -459,7 +461,7 @@ int mbedtls_mpi_write_string( const mbedtls_mpi *X, int radix,
  *                 is too small.
  * \return         Another negative error code on failure.
  */
-int mbedtls_mpi_read_file( mbedtls_mpi *X, int radix, FILE *fin );
+MBEDCRYPTO_EXPORT int mbedtls_mpi_read_file( mbedtls_mpi *X, int radix, FILE *fin );
 
 /**
  * \brief          Export an MPI into an opened file.
@@ -476,7 +478,7 @@ int mbedtls_mpi_read_file( mbedtls_mpi *X, int radix, FILE *fin );
  * \return         \c 0 if successful.
  * \return         A negative error code on failure.
  */
-int mbedtls_mpi_write_file( const char *p, const mbedtls_mpi *X,
+MBEDCRYPTO_EXPORT int mbedtls_mpi_write_file( const char *p, const mbedtls_mpi *X,
                             int radix, FILE *fout );
 #endif /* MBEDTLS_FS_IO */
 
@@ -492,7 +494,7 @@ int mbedtls_mpi_write_file( const char *p, const mbedtls_mpi *X,
  * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if memory allocation failed.
  * \return         Another negative error code on different kinds of failure.
  */
-int mbedtls_mpi_read_binary( mbedtls_mpi *X, const unsigned char *buf,
+MBEDCRYPTO_EXPORT int mbedtls_mpi_read_binary( mbedtls_mpi *X, const unsigned char *buf,
                              size_t buflen );
 
 /**
@@ -507,7 +509,7 @@ int mbedtls_mpi_read_binary( mbedtls_mpi *X, const unsigned char *buf,
  * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if memory allocation failed.
  * \return         Another negative error code on different kinds of failure.
  */
-int mbedtls_mpi_read_binary_le( mbedtls_mpi *X,
+MBEDCRYPTO_EXPORT int mbedtls_mpi_read_binary_le( mbedtls_mpi *X,
                                 const unsigned char *buf, size_t buflen );
 
 /**
@@ -525,7 +527,7 @@ int mbedtls_mpi_read_binary_le( mbedtls_mpi *X,
  *                 large enough to hold the value of \p X.
  * \return         Another negative error code on different kinds of failure.
  */
-int mbedtls_mpi_write_binary( const mbedtls_mpi *X, unsigned char *buf,
+MBEDCRYPTO_EXPORT int mbedtls_mpi_write_binary( const mbedtls_mpi *X, unsigned char *buf,
                               size_t buflen );
 
 /**
@@ -543,7 +545,7 @@ int mbedtls_mpi_write_binary( const mbedtls_mpi *X, unsigned char *buf,
  *                 large enough to hold the value of \p X.
  * \return         Another negative error code on different kinds of failure.
  */
-int mbedtls_mpi_write_binary_le( const mbedtls_mpi *X,
+MBEDCRYPTO_EXPORT int mbedtls_mpi_write_binary_le( const mbedtls_mpi *X,
                                  unsigned char *buf, size_t buflen );
 
 /**
@@ -556,7 +558,7 @@ int mbedtls_mpi_write_binary_le( const mbedtls_mpi *X,
  * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if a memory allocation failed.
  * \return         Another negative error code on different kinds of failure.
  */
-int mbedtls_mpi_shift_l( mbedtls_mpi *X, size_t count );
+MBEDCRYPTO_EXPORT int mbedtls_mpi_shift_l( mbedtls_mpi *X, size_t count );
 
 /**
  * \brief          Perform a right-shift on an MPI: X >>= count
@@ -568,7 +570,7 @@ int mbedtls_mpi_shift_l( mbedtls_mpi *X, size_t count );
  * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if a memory allocation failed.
  * \return         Another negative error code on different kinds of failure.
  */
-int mbedtls_mpi_shift_r( mbedtls_mpi *X, size_t count );
+MBEDCRYPTO_EXPORT int mbedtls_mpi_shift_r( mbedtls_mpi *X, size_t count );
 
 /**
  * \brief          Compare the absolute values of two MPIs.
@@ -580,7 +582,7 @@ int mbedtls_mpi_shift_r( mbedtls_mpi *X, size_t count );
  * \return         \c -1 if `|X|` is lesser than `|Y|`.
  * \return         \c 0 if `|X|` is equal to `|Y|`.
  */
-int mbedtls_mpi_cmp_abs( const mbedtls_mpi *X, const mbedtls_mpi *Y );
+MBEDCRYPTO_EXPORT int mbedtls_mpi_cmp_abs( const mbedtls_mpi *X, const mbedtls_mpi *Y );
 
 /**
  * \brief          Compare two MPIs.
@@ -592,7 +594,7 @@ int mbedtls_mpi_cmp_abs( const mbedtls_mpi *X, const mbedtls_mpi *Y );
  * \return         \c -1 if \p X is lesser than \p Y.
  * \return         \c 0 if \p X is equal to \p Y.
  */
-int mbedtls_mpi_cmp_mpi( const mbedtls_mpi *X, const mbedtls_mpi *Y );
+MBEDCRYPTO_EXPORT int mbedtls_mpi_cmp_mpi( const mbedtls_mpi *X, const mbedtls_mpi *Y );
 
 /**
  * \brief          Compare an MPI with an integer.
@@ -604,7 +606,7 @@ int mbedtls_mpi_cmp_mpi( const mbedtls_mpi *X, const mbedtls_mpi *Y );
  * \return         \c -1 if \p X is lesser than \p z.
  * \return         \c 0 if \p X is equal to \p z.
  */
-int mbedtls_mpi_cmp_int( const mbedtls_mpi *X, mbedtls_mpi_sint z );
+MBEDCRYPTO_EXPORT int mbedtls_mpi_cmp_int( const mbedtls_mpi *X, mbedtls_mpi_sint z );
 
 /**
  * \brief          Perform an unsigned addition of MPIs: X = |A| + |B|
@@ -617,7 +619,7 @@ int mbedtls_mpi_cmp_int( const mbedtls_mpi *X, mbedtls_mpi_sint z );
  * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if a memory allocation failed.
  * \return         Another negative error code on different kinds of failure.
  */
-int mbedtls_mpi_add_abs( mbedtls_mpi *X, const mbedtls_mpi *A,
+MBEDCRYPTO_EXPORT int mbedtls_mpi_add_abs( mbedtls_mpi *X, const mbedtls_mpi *A,
                          const mbedtls_mpi *B );
 
 /**
@@ -632,7 +634,7 @@ int mbedtls_mpi_add_abs( mbedtls_mpi *X, const mbedtls_mpi *A,
  * \return         Another negative error code on different kinds of failure.
  *
  */
-int mbedtls_mpi_sub_abs( mbedtls_mpi *X, const mbedtls_mpi *A,
+MBEDCRYPTO_EXPORT int mbedtls_mpi_sub_abs( mbedtls_mpi *X, const mbedtls_mpi *A,
                          const mbedtls_mpi *B );
 
 /**
@@ -646,7 +648,7 @@ int mbedtls_mpi_sub_abs( mbedtls_mpi *X, const mbedtls_mpi *A,
  * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if a memory allocation failed.
  * \return         Another negative error code on different kinds of failure.
  */
-int mbedtls_mpi_add_mpi( mbedtls_mpi *X, const mbedtls_mpi *A,
+MBEDCRYPTO_EXPORT int mbedtls_mpi_add_mpi( mbedtls_mpi *X, const mbedtls_mpi *A,
                          const mbedtls_mpi *B );
 
 /**
@@ -660,7 +662,7 @@ int mbedtls_mpi_add_mpi( mbedtls_mpi *X, const mbedtls_mpi *A,
  * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if a memory allocation failed.
  * \return         Another negative error code on different kinds of failure.
  */
-int mbedtls_mpi_sub_mpi( mbedtls_mpi *X, const mbedtls_mpi *A,
+MBEDCRYPTO_EXPORT int mbedtls_mpi_sub_mpi( mbedtls_mpi *X, const mbedtls_mpi *A,
                          const mbedtls_mpi *B );
 
 /**
@@ -674,7 +676,7 @@ int mbedtls_mpi_sub_mpi( mbedtls_mpi *X, const mbedtls_mpi *A,
  * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if a memory allocation failed.
  * \return         Another negative error code on different kinds of failure.
  */
-int mbedtls_mpi_add_int( mbedtls_mpi *X, const mbedtls_mpi *A,
+MBEDCRYPTO_EXPORT int mbedtls_mpi_add_int( mbedtls_mpi *X, const mbedtls_mpi *A,
                          mbedtls_mpi_sint b );
 
 /**
@@ -689,7 +691,7 @@ int mbedtls_mpi_add_int( mbedtls_mpi *X, const mbedtls_mpi *A,
  * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if a memory allocation failed.
  * \return         Another negative error code on different kinds of failure.
  */
-int mbedtls_mpi_sub_int( mbedtls_mpi *X, const mbedtls_mpi *A,
+MBEDCRYPTO_EXPORT int mbedtls_mpi_sub_int( mbedtls_mpi *X, const mbedtls_mpi *A,
                          mbedtls_mpi_sint b );
 
 /**
@@ -704,7 +706,7 @@ int mbedtls_mpi_sub_int( mbedtls_mpi *X, const mbedtls_mpi *A,
  * \return         Another negative error code on different kinds of failure.
  *
  */
-int mbedtls_mpi_mul_mpi( mbedtls_mpi *X, const mbedtls_mpi *A,
+MBEDCRYPTO_EXPORT int mbedtls_mpi_mul_mpi( mbedtls_mpi *X, const mbedtls_mpi *A,
                          const mbedtls_mpi *B );
 
 /**
@@ -720,7 +722,7 @@ int mbedtls_mpi_mul_mpi( mbedtls_mpi *X, const mbedtls_mpi *A,
  * \return         Another negative error code on different kinds of failure.
  *
  */
-int mbedtls_mpi_mul_int( mbedtls_mpi *X, const mbedtls_mpi *A,
+MBEDCRYPTO_EXPORT int mbedtls_mpi_mul_int( mbedtls_mpi *X, const mbedtls_mpi *A,
                          mbedtls_mpi_uint b );
 
 /**
@@ -741,7 +743,7 @@ int mbedtls_mpi_mul_int( mbedtls_mpi *X, const mbedtls_mpi *A,
  * \return         #MBEDTLS_ERR_MPI_DIVISION_BY_ZERO if \p B equals zero.
  * \return         Another negative error code on different kinds of failure.
  */
-int mbedtls_mpi_div_mpi( mbedtls_mpi *Q, mbedtls_mpi *R, const mbedtls_mpi *A,
+MBEDCRYPTO_EXPORT int mbedtls_mpi_div_mpi( mbedtls_mpi *Q, mbedtls_mpi *R, const mbedtls_mpi *A,
                          const mbedtls_mpi *B );
 
 /**
@@ -762,7 +764,7 @@ int mbedtls_mpi_div_mpi( mbedtls_mpi *Q, mbedtls_mpi *R, const mbedtls_mpi *A,
  * \return         #MBEDTLS_ERR_MPI_DIVISION_BY_ZERO if \p b equals zero.
  * \return         Another negative error code on different kinds of failure.
  */
-int mbedtls_mpi_div_int( mbedtls_mpi *Q, mbedtls_mpi *R, const mbedtls_mpi *A,
+MBEDCRYPTO_EXPORT int mbedtls_mpi_div_int( mbedtls_mpi *Q, mbedtls_mpi *R, const mbedtls_mpi *A,
                          mbedtls_mpi_sint b );
 
 /**
@@ -782,7 +784,7 @@ int mbedtls_mpi_div_int( mbedtls_mpi *Q, mbedtls_mpi *R, const mbedtls_mpi *A,
  * \return         Another negative error code on different kinds of failure.
  *
  */
-int mbedtls_mpi_mod_mpi( mbedtls_mpi *R, const mbedtls_mpi *A,
+MBEDCRYPTO_EXPORT int mbedtls_mpi_mod_mpi( mbedtls_mpi *R, const mbedtls_mpi *A,
                          const mbedtls_mpi *B );
 
 /**
@@ -801,7 +803,7 @@ int mbedtls_mpi_mod_mpi( mbedtls_mpi *R, const mbedtls_mpi *A,
  * \return         #MBEDTLS_ERR_MPI_NEGATIVE_VALUE if \p b is negative.
  * \return         Another negative error code on different kinds of failure.
  */
-int mbedtls_mpi_mod_int( mbedtls_mpi_uint *r, const mbedtls_mpi *A,
+MBEDCRYPTO_EXPORT int mbedtls_mpi_mod_int( mbedtls_mpi_uint *r, const mbedtls_mpi *A,
                          mbedtls_mpi_sint b );
 
 /**
@@ -830,7 +832,7 @@ int mbedtls_mpi_mod_int( mbedtls_mpi_uint *r, const mbedtls_mpi *A,
  * \return         Another negative error code on different kinds of failures.
  *
  */
-int mbedtls_mpi_exp_mod( mbedtls_mpi *X, const mbedtls_mpi *A,
+MBEDCRYPTO_EXPORT int mbedtls_mpi_exp_mod( mbedtls_mpi *X, const mbedtls_mpi *A,
                          const mbedtls_mpi *E, const mbedtls_mpi *N,
                          mbedtls_mpi *_RR );
 
@@ -851,7 +853,7 @@ int mbedtls_mpi_exp_mod( mbedtls_mpi *X, const mbedtls_mpi *A,
  *                 as a big-endian representation of an MPI; this can
  *                 be relevant in applications like deterministic ECDSA.
  */
-int mbedtls_mpi_fill_random( mbedtls_mpi *X, size_t size,
+MBEDCRYPTO_EXPORT int mbedtls_mpi_fill_random( mbedtls_mpi *X, size_t size,
                      int (*f_rng)(void *, unsigned char *, size_t),
                      void *p_rng );
 
@@ -866,7 +868,7 @@ int mbedtls_mpi_fill_random( mbedtls_mpi *X, size_t size,
  * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED if a memory allocation failed.
  * \return         Another negative error code on different kinds of failure.
  */
-int mbedtls_mpi_gcd( mbedtls_mpi *G, const mbedtls_mpi *A,
+MBEDCRYPTO_EXPORT int mbedtls_mpi_gcd( mbedtls_mpi *G, const mbedtls_mpi *A,
                      const mbedtls_mpi *B );
 
 /**
@@ -885,7 +887,7 @@ int mbedtls_mpi_gcd( mbedtls_mpi *G, const mbedtls_mpi *A,
  * \return         #MBEDTLS_ERR_MPI_NOT_ACCEPTABLE if \p has no modular inverse
  *                 with respect to \p N.
  */
-int mbedtls_mpi_inv_mod( mbedtls_mpi *X, const mbedtls_mpi *A,
+MBEDCRYPTO_EXPORT int mbedtls_mpi_inv_mod( mbedtls_mpi *X, const mbedtls_mpi *A,
                          const mbedtls_mpi *N );
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
@@ -946,7 +948,7 @@ MBEDTLS_DEPRECATED int mbedtls_mpi_is_prime( const mbedtls_mpi *X,
  * \return         #MBEDTLS_ERR_MPI_NOT_ACCEPTABLE if \p X is not prime.
  * \return         Another negative error code on other kinds of failure.
  */
-int mbedtls_mpi_is_prime_ext( const mbedtls_mpi *X, int rounds,
+MBEDCRYPTO_EXPORT int mbedtls_mpi_is_prime_ext( const mbedtls_mpi *X, int rounds,
                               int (*f_rng)(void *, unsigned char *, size_t),
                               void *p_rng );
 /**
@@ -979,7 +981,7 @@ typedef enum {
  * \return         #MBEDTLS_ERR_MPI_BAD_INPUT_DATA if `nbits` is not between
  *                 \c 3 and #MBEDTLS_MPI_MAX_BITS.
  */
-int mbedtls_mpi_gen_prime( mbedtls_mpi *X, size_t nbits, int flags,
+MBEDCRYPTO_EXPORT int mbedtls_mpi_gen_prime( mbedtls_mpi *X, size_t nbits, int flags,
                    int (*f_rng)(void *, unsigned char *, size_t),
                    void *p_rng );
 
@@ -990,7 +992,7 @@ int mbedtls_mpi_gen_prime( mbedtls_mpi *X, size_t nbits, int flags,
  *
  * \return         0 if successful, or 1 if the test failed
  */
-int mbedtls_mpi_self_test( int verbose );
+MBEDCRYPTO_EXPORT int mbedtls_mpi_self_test( int verbose );
 
 #endif /* MBEDTLS_SELF_TEST */
 

--- a/include/mbedtls/blowfish.h
+++ b/include/mbedtls/blowfish.h
@@ -30,6 +30,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -81,7 +83,7 @@ mbedtls_blowfish_context;
  * \param ctx      The Blowfish context to be initialized.
  *                 This must not be \c NULL.
  */
-void mbedtls_blowfish_init( mbedtls_blowfish_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_blowfish_init( mbedtls_blowfish_context *ctx );
 
 /**
  * \brief          Clear a Blowfish context.
@@ -91,7 +93,7 @@ void mbedtls_blowfish_init( mbedtls_blowfish_context *ctx );
  *                 returns immediately. If it is not \c NULL, it must
  *                 point to an initialized Blowfish context.
  */
-void mbedtls_blowfish_free( mbedtls_blowfish_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_blowfish_free( mbedtls_blowfish_context *ctx );
 
 /**
  * \brief          Perform a Blowfish key schedule operation.
@@ -105,7 +107,7 @@ void mbedtls_blowfish_free( mbedtls_blowfish_context *ctx );
  * \return         \c 0 if successful.
  * \return         A negative error code on failure.
  */
-int mbedtls_blowfish_setkey( mbedtls_blowfish_context *ctx, const unsigned char *key,
+MBEDCRYPTO_EXPORT int mbedtls_blowfish_setkey( mbedtls_blowfish_context *ctx, const unsigned char *key,
                      unsigned int keybits );
 
 /**
@@ -124,7 +126,7 @@ int mbedtls_blowfish_setkey( mbedtls_blowfish_context *ctx, const unsigned char 
  * \return         \c 0 if successful.
  * \return         A negative error code on failure.
  */
-int mbedtls_blowfish_crypt_ecb( mbedtls_blowfish_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_blowfish_crypt_ecb( mbedtls_blowfish_context *ctx,
                         int mode,
                         const unsigned char input[MBEDTLS_BLOWFISH_BLOCKSIZE],
                         unsigned char output[MBEDTLS_BLOWFISH_BLOCKSIZE] );
@@ -158,7 +160,7 @@ int mbedtls_blowfish_crypt_ecb( mbedtls_blowfish_context *ctx,
  * \return         \c 0 if successful.
  * \return         A negative error code on failure.
  */
-int mbedtls_blowfish_crypt_cbc( mbedtls_blowfish_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_blowfish_crypt_cbc( mbedtls_blowfish_context *ctx,
                         int mode,
                         size_t length,
                         unsigned char iv[MBEDTLS_BLOWFISH_BLOCKSIZE],
@@ -198,7 +200,7 @@ int mbedtls_blowfish_crypt_cbc( mbedtls_blowfish_context *ctx,
  * \return         \c 0 if successful.
  * \return         A negative error code on failure.
  */
-int mbedtls_blowfish_crypt_cfb64( mbedtls_blowfish_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_blowfish_crypt_cfb64( mbedtls_blowfish_context *ctx,
                           int mode,
                           size_t length,
                           size_t *iv_off,
@@ -271,7 +273,7 @@ int mbedtls_blowfish_crypt_cfb64( mbedtls_blowfish_context *ctx,
  * \return              \c 0 if successful.
  * \return              A negative error code on failure.
  */
-int mbedtls_blowfish_crypt_ctr( mbedtls_blowfish_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_blowfish_crypt_ctr( mbedtls_blowfish_context *ctx,
                         size_t length,
                         size_t *nc_off,
                         unsigned char nonce_counter[MBEDTLS_BLOWFISH_BLOCKSIZE],

--- a/include/mbedtls/camellia.h
+++ b/include/mbedtls/camellia.h
@@ -30,6 +30,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -77,7 +79,7 @@ mbedtls_camellia_context;
  * \param ctx      The CAMELLIA context to be initialized.
  *                 This must not be \c NULL.
  */
-void mbedtls_camellia_init( mbedtls_camellia_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_camellia_init( mbedtls_camellia_context *ctx );
 
 /**
  * \brief          Clear a CAMELLIA context.
@@ -86,7 +88,7 @@ void mbedtls_camellia_init( mbedtls_camellia_context *ctx );
  *                 in which case this function returns immediately. If it is not
  *                 \c NULL, it must be initialized.
  */
-void mbedtls_camellia_free( mbedtls_camellia_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_camellia_free( mbedtls_camellia_context *ctx );
 
 /**
  * \brief          Perform a CAMELLIA key schedule operation for encryption.
@@ -100,7 +102,7 @@ void mbedtls_camellia_free( mbedtls_camellia_context *ctx );
  * \return         \c 0 if successful.
  * \return         A negative error code on failure.
  */
-int mbedtls_camellia_setkey_enc( mbedtls_camellia_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_camellia_setkey_enc( mbedtls_camellia_context *ctx,
                                  const unsigned char *key,
                                  unsigned int keybits );
 
@@ -116,7 +118,7 @@ int mbedtls_camellia_setkey_enc( mbedtls_camellia_context *ctx,
  * \return         \c 0 if successful.
  * \return         A negative error code on failure.
  */
-int mbedtls_camellia_setkey_dec( mbedtls_camellia_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_camellia_setkey_dec( mbedtls_camellia_context *ctx,
                                  const unsigned char *key,
                                  unsigned int keybits );
 
@@ -135,7 +137,7 @@ int mbedtls_camellia_setkey_dec( mbedtls_camellia_context *ctx,
  * \return         \c 0 if successful.
  * \return         A negative error code on failure.
  */
-int mbedtls_camellia_crypt_ecb( mbedtls_camellia_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_camellia_crypt_ecb( mbedtls_camellia_context *ctx,
                     int mode,
                     const unsigned char input[16],
                     unsigned char output[16] );
@@ -169,7 +171,7 @@ int mbedtls_camellia_crypt_ecb( mbedtls_camellia_context *ctx,
  * \return         \c 0 if successful.
  * \return         A negative error code on failure.
  */
-int mbedtls_camellia_crypt_cbc( mbedtls_camellia_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_camellia_crypt_cbc( mbedtls_camellia_context *ctx,
                     int mode,
                     size_t length,
                     unsigned char iv[16],
@@ -215,7 +217,7 @@ int mbedtls_camellia_crypt_cbc( mbedtls_camellia_context *ctx,
  * \return         \c 0 if successful.
  * \return         A negative error code on failure.
  */
-int mbedtls_camellia_crypt_cfb128( mbedtls_camellia_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_camellia_crypt_cfb128( mbedtls_camellia_context *ctx,
                        int mode,
                        size_t length,
                        size_t *iv_off,
@@ -299,7 +301,7 @@ int mbedtls_camellia_crypt_cfb128( mbedtls_camellia_context *ctx,
  * \return              \c 0 if successful.
  * \return              A negative error code on failure.
  */
-int mbedtls_camellia_crypt_ctr( mbedtls_camellia_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_camellia_crypt_ctr( mbedtls_camellia_context *ctx,
                        size_t length,
                        size_t *nc_off,
                        unsigned char nonce_counter[16],
@@ -315,7 +317,7 @@ int mbedtls_camellia_crypt_ctr( mbedtls_camellia_context *ctx,
  *
  * \return         0 if successful, or 1 if the test failed
  */
-int mbedtls_camellia_self_test( int verbose );
+MBEDCRYPTO_EXPORT int mbedtls_camellia_self_test( int verbose );
 
 #endif /* MBEDTLS_SELF_TEST */
 

--- a/include/mbedtls/ccm.h
+++ b/include/mbedtls/ccm.h
@@ -55,6 +55,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include "mbedtls/cipher.h"
 
 #define MBEDTLS_ERR_CCM_BAD_INPUT       -0x000D /**< Bad input parameters to the function. */
@@ -92,7 +94,7 @@ mbedtls_ccm_context;
  *
  * \param ctx       The CCM context to initialize. This must not be \c NULL.
  */
-void mbedtls_ccm_init( mbedtls_ccm_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_ccm_init( mbedtls_ccm_context *ctx );
 
 /**
  * \brief           This function initializes the CCM context set in the
@@ -107,7 +109,7 @@ void mbedtls_ccm_init( mbedtls_ccm_context *ctx );
  * \return          \c 0 on success.
  * \return          A CCM or cipher-specific error code on failure.
  */
-int mbedtls_ccm_setkey( mbedtls_ccm_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_ccm_setkey( mbedtls_ccm_context *ctx,
                         mbedtls_cipher_id_t cipher,
                         const unsigned char *key,
                         unsigned int keybits );
@@ -119,7 +121,7 @@ int mbedtls_ccm_setkey( mbedtls_ccm_context *ctx,
  * \param ctx       The CCM context to clear. If this is \c NULL, the function
  *                  has no effect. Otherwise, this must be initialized.
  */
-void mbedtls_ccm_free( mbedtls_ccm_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_ccm_free( mbedtls_ccm_context *ctx );
 
 /**
  * \brief           This function encrypts a buffer using CCM.
@@ -157,7 +159,7 @@ void mbedtls_ccm_free( mbedtls_ccm_context *ctx );
  * \return          \c 0 on success.
  * \return          A CCM or cipher-specific error code on failure.
  */
-int mbedtls_ccm_encrypt_and_tag( mbedtls_ccm_context *ctx, size_t length,
+MBEDCRYPTO_EXPORT int mbedtls_ccm_encrypt_and_tag( mbedtls_ccm_context *ctx, size_t length,
                          const unsigned char *iv, size_t iv_len,
                          const unsigned char *add, size_t add_len,
                          const unsigned char *input, unsigned char *output,
@@ -205,7 +207,7 @@ int mbedtls_ccm_encrypt_and_tag( mbedtls_ccm_context *ctx, size_t length,
  * \return          \c 0 on success.
  * \return          A CCM or cipher-specific error code on failure.
  */
-int mbedtls_ccm_star_encrypt_and_tag( mbedtls_ccm_context *ctx, size_t length,
+MBEDCRYPTO_EXPORT int mbedtls_ccm_star_encrypt_and_tag( mbedtls_ccm_context *ctx, size_t length,
                          const unsigned char *iv, size_t iv_len,
                          const unsigned char *add, size_t add_len,
                          const unsigned char *input, unsigned char *output,
@@ -242,7 +244,7 @@ int mbedtls_ccm_star_encrypt_and_tag( mbedtls_ccm_context *ctx, size_t length,
  * \return          #MBEDTLS_ERR_CCM_AUTH_FAILED if the tag does not match.
  * \return          A cipher-specific error code on calculation failure.
  */
-int mbedtls_ccm_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
+MBEDCRYPTO_EXPORT int mbedtls_ccm_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
                       const unsigned char *iv, size_t iv_len,
                       const unsigned char *add, size_t add_len,
                       const unsigned char *input, unsigned char *output,
@@ -287,7 +289,7 @@ int mbedtls_ccm_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
  * \return          #MBEDTLS_ERR_CCM_AUTH_FAILED if the tag does not match.
  * \return          A cipher-specific error code on calculation failure.
  */
-int mbedtls_ccm_star_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
+MBEDCRYPTO_EXPORT int mbedtls_ccm_star_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
                       const unsigned char *iv, size_t iv_len,
                       const unsigned char *add, size_t add_len,
                       const unsigned char *input, unsigned char *output,
@@ -300,7 +302,7 @@ int mbedtls_ccm_star_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
  * \return         \c 0 on success.
  * \return         \c 1 on failure.
  */
-int mbedtls_ccm_self_test( int verbose );
+MBEDCRYPTO_EXPORT int mbedtls_ccm_self_test( int verbose );
 #endif /* MBEDTLS_SELF_TEST && MBEDTLS_AES_C */
 
 #ifdef __cplusplus

--- a/include/mbedtls/chacha20.h
+++ b/include/mbedtls/chacha20.h
@@ -39,6 +39,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include <stdint.h>
 #include <stddef.h>
 
@@ -85,7 +87,7 @@ mbedtls_chacha20_context;
  * \param ctx       The ChaCha20 context to initialize.
  *                  This must not be \c NULL.
  */
-void mbedtls_chacha20_init( mbedtls_chacha20_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_chacha20_init( mbedtls_chacha20_context *ctx );
 
 /**
  * \brief           This function releases and clears the specified
@@ -96,7 +98,7 @@ void mbedtls_chacha20_init( mbedtls_chacha20_context *ctx );
  *                  \c NULL, it must point to an initialized context.
  *
  */
-void mbedtls_chacha20_free( mbedtls_chacha20_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_chacha20_free( mbedtls_chacha20_context *ctx );
 
 /**
  * \brief           This function sets the encryption/decryption key.
@@ -114,7 +116,7 @@ void mbedtls_chacha20_free( mbedtls_chacha20_context *ctx );
  * \return          \c 0 on success.
  * \return          #MBEDTLS_ERR_CHACHA20_BAD_INPUT_DATA if ctx or key is NULL.
  */
-int mbedtls_chacha20_setkey( mbedtls_chacha20_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_chacha20_setkey( mbedtls_chacha20_context *ctx,
                              const unsigned char key[32] );
 
 /**
@@ -136,7 +138,7 @@ int mbedtls_chacha20_setkey( mbedtls_chacha20_context *ctx,
  * \return          #MBEDTLS_ERR_CHACHA20_BAD_INPUT_DATA if ctx or nonce is
  *                  NULL.
  */
-int mbedtls_chacha20_starts( mbedtls_chacha20_context* ctx,
+MBEDCRYPTO_EXPORT int mbedtls_chacha20_starts( mbedtls_chacha20_context* ctx,
                              const unsigned char nonce[12],
                              uint32_t counter );
 
@@ -169,7 +171,7 @@ int mbedtls_chacha20_starts( mbedtls_chacha20_context* ctx,
  * \return          \c 0 on success.
  * \return          A negative error code on failure.
  */
-int mbedtls_chacha20_update( mbedtls_chacha20_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_chacha20_update( mbedtls_chacha20_context *ctx,
                              size_t size,
                              const unsigned char *input,
                              unsigned char *output );
@@ -202,7 +204,7 @@ int mbedtls_chacha20_update( mbedtls_chacha20_context *ctx,
  * \return          \c 0 on success.
  * \return          A negative error code on failure.
  */
-int mbedtls_chacha20_crypt( const unsigned char key[32],
+MBEDCRYPTO_EXPORT int mbedtls_chacha20_crypt( const unsigned char key[32],
                             const unsigned char nonce[12],
                             uint32_t counter,
                             size_t size,
@@ -216,7 +218,7 @@ int mbedtls_chacha20_crypt( const unsigned char key[32],
  * \return          \c 0 on success.
  * \return          \c 1 on failure.
  */
-int mbedtls_chacha20_self_test( int verbose );
+MBEDCRYPTO_EXPORT int mbedtls_chacha20_self_test( int verbose );
 #endif /* MBEDTLS_SELF_TEST */
 
 #ifdef __cplusplus

--- a/include/mbedtls/chachapoly.h
+++ b/include/mbedtls/chachapoly.h
@@ -39,6 +39,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 /* for shared error codes */
 #include "mbedtls/poly1305.h"
 
@@ -117,7 +119,7 @@ mbedtls_chachapoly_context;
  *
  * \param ctx       The ChachaPoly context to initialize. Must not be \c NULL.
  */
-void mbedtls_chachapoly_init( mbedtls_chachapoly_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_chachapoly_init( mbedtls_chachapoly_context *ctx );
 
 /**
  * \brief           This function releases and clears the specified
@@ -126,7 +128,7 @@ void mbedtls_chachapoly_init( mbedtls_chachapoly_context *ctx );
  * \param ctx       The ChachaPoly context to clear. This may be \c NULL, in which
  *                  case this function is a no-op.
  */
-void mbedtls_chachapoly_free( mbedtls_chachapoly_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_chachapoly_free( mbedtls_chachapoly_context *ctx );
 
 /**
  * \brief           This function sets the ChaCha20-Poly1305
@@ -139,7 +141,7 @@ void mbedtls_chachapoly_free( mbedtls_chachapoly_context *ctx );
  * \return          \c 0 on success.
  * \return          A negative error code on failure.
  */
-int mbedtls_chachapoly_setkey( mbedtls_chachapoly_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_chachapoly_setkey( mbedtls_chachapoly_context *ctx,
                                const unsigned char key[32] );
 
 /**
@@ -167,7 +169,7 @@ int mbedtls_chachapoly_setkey( mbedtls_chachapoly_context *ctx,
  * \return          \c 0 on success.
  * \return          A negative error code on failure.
  */
-int mbedtls_chachapoly_starts( mbedtls_chachapoly_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_chachapoly_starts( mbedtls_chachapoly_context *ctx,
                                const unsigned char nonce[12],
                                mbedtls_chachapoly_mode_t mode );
 
@@ -210,7 +212,7 @@ int mbedtls_chachapoly_starts( mbedtls_chachapoly_context *ctx,
  *                  if the operations has not been started or has been
  *                  finished, or if the AAD has been finished.
  */
-int mbedtls_chachapoly_update_aad( mbedtls_chachapoly_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_chachapoly_update_aad( mbedtls_chachapoly_context *ctx,
                                    const unsigned char *aad,
                                    size_t aad_len );
 
@@ -245,7 +247,7 @@ int mbedtls_chachapoly_update_aad( mbedtls_chachapoly_context *ctx,
  *                  finished.
  * \return          Another negative error code on other kinds of failure.
  */
-int mbedtls_chachapoly_update( mbedtls_chachapoly_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_chachapoly_update( mbedtls_chachapoly_context *ctx,
                                size_t len,
                                const unsigned char *input,
                                unsigned char *output );
@@ -266,7 +268,7 @@ int mbedtls_chachapoly_update( mbedtls_chachapoly_context *ctx,
  *                  finished.
  * \return          Another negative error code on other kinds of failure.
  */
-int mbedtls_chachapoly_finish( mbedtls_chachapoly_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_chachapoly_finish( mbedtls_chachapoly_context *ctx,
                                unsigned char mac[16] );
 
 /**
@@ -298,7 +300,7 @@ int mbedtls_chachapoly_finish( mbedtls_chachapoly_context *ctx,
  * \return          \c 0 on success.
  * \return          A negative error code on failure.
  */
-int mbedtls_chachapoly_encrypt_and_tag( mbedtls_chachapoly_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_chachapoly_encrypt_and_tag( mbedtls_chachapoly_context *ctx,
                                         size_t length,
                                         const unsigned char nonce[12],
                                         const unsigned char *aad,
@@ -332,7 +334,7 @@ int mbedtls_chachapoly_encrypt_and_tag( mbedtls_chachapoly_context *ctx,
  *                  if the data was not authentic.
  * \return          Another negative error code on other kinds of failure.
  */
-int mbedtls_chachapoly_auth_decrypt( mbedtls_chachapoly_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_chachapoly_auth_decrypt( mbedtls_chachapoly_context *ctx,
                                      size_t length,
                                      const unsigned char nonce[12],
                                      const unsigned char *aad,
@@ -348,7 +350,7 @@ int mbedtls_chachapoly_auth_decrypt( mbedtls_chachapoly_context *ctx,
  * \return          \c 0 on success.
  * \return          \c 1 on failure.
  */
-int mbedtls_chachapoly_self_test( int verbose );
+MBEDCRYPTO_EXPORT int mbedtls_chachapoly_self_test( int verbose );
 #endif /* MBEDTLS_SELF_TEST */
 
 #ifdef __cplusplus

--- a/include/mbedtls/cipher.h
+++ b/include/mbedtls/cipher.h
@@ -35,6 +35,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include <stddef.h>
 #include "mbedtls/platform_util.h"
 
@@ -357,7 +359,7 @@ typedef struct mbedtls_cipher_context_t
  * \return      A statically-allocated array of cipher identifiers
  *              of type cipher_type_t. The last entry is zero.
  */
-const int *mbedtls_cipher_list( void );
+MBEDCRYPTO_EXPORT const int *mbedtls_cipher_list( void );
 
 /**
  * \brief               This function retrieves the cipher-information
@@ -370,7 +372,7 @@ const int *mbedtls_cipher_list( void );
  *                      given \p cipher_name.
  * \return              \c NULL if the associated cipher information is not found.
  */
-const mbedtls_cipher_info_t *mbedtls_cipher_info_from_string( const char *cipher_name );
+MBEDCRYPTO_EXPORT const mbedtls_cipher_info_t *mbedtls_cipher_info_from_string( const char *cipher_name );
 
 /**
  * \brief               This function retrieves the cipher-information
@@ -382,7 +384,7 @@ const mbedtls_cipher_info_t *mbedtls_cipher_info_from_string( const char *cipher
  *                      given \p cipher_type.
  * \return              \c NULL if the associated cipher information is not found.
  */
-const mbedtls_cipher_info_t *mbedtls_cipher_info_from_type( const mbedtls_cipher_type_t cipher_type );
+MBEDCRYPTO_EXPORT const mbedtls_cipher_info_t *mbedtls_cipher_info_from_type( const mbedtls_cipher_type_t cipher_type );
 
 /**
  * \brief               This function retrieves the cipher-information
@@ -398,7 +400,7 @@ const mbedtls_cipher_info_t *mbedtls_cipher_info_from_type( const mbedtls_cipher
  *                      given \p cipher_id.
  * \return              \c NULL if the associated cipher information is not found.
  */
-const mbedtls_cipher_info_t *mbedtls_cipher_info_from_values( const mbedtls_cipher_id_t cipher_id,
+MBEDCRYPTO_EXPORT const mbedtls_cipher_info_t *mbedtls_cipher_info_from_values( const mbedtls_cipher_id_t cipher_id,
                                               int key_bitlen,
                                               const mbedtls_cipher_mode_t mode );
 
@@ -407,7 +409,7 @@ const mbedtls_cipher_info_t *mbedtls_cipher_info_from_values( const mbedtls_ciph
  *
  * \param ctx           The context to be initialized. This must not be \c NULL.
  */
-void mbedtls_cipher_init( mbedtls_cipher_context_t *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_cipher_init( mbedtls_cipher_context_t *ctx );
 
 /**
  * \brief               This function frees and clears the cipher-specific
@@ -418,7 +420,7 @@ void mbedtls_cipher_init( mbedtls_cipher_context_t *ctx );
  *                      function has no effect, otherwise this must point to an
  *                      initialized context.
  */
-void mbedtls_cipher_free( mbedtls_cipher_context_t *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_cipher_free( mbedtls_cipher_context_t *ctx );
 
 
 /**
@@ -438,7 +440,7 @@ void mbedtls_cipher_free( mbedtls_cipher_context_t *ctx );
  * In future versions, the caller will be required to call
  * mbedtls_cipher_init() on the structure first.
  */
-int mbedtls_cipher_setup( mbedtls_cipher_context_t *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_cipher_setup( mbedtls_cipher_context_t *ctx,
                           const mbedtls_cipher_info_t *cipher_info );
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
@@ -463,7 +465,7 @@ int mbedtls_cipher_setup( mbedtls_cipher_context_t *ctx,
  * \return              #MBEDTLS_ERR_CIPHER_ALLOC_FAILED if allocation of the
  *                      cipher-specific context fails.
  */
-int mbedtls_cipher_setup_psa( mbedtls_cipher_context_t *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_cipher_setup_psa( mbedtls_cipher_context_t *ctx,
                               const mbedtls_cipher_info_t *cipher_info,
                               size_t taglen );
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
@@ -621,7 +623,7 @@ static inline mbedtls_operation_t mbedtls_cipher_get_operation(
  *                      parameter-verification failure.
  * \return              A cipher-specific error code on failure.
  */
-int mbedtls_cipher_setkey( mbedtls_cipher_context_t *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_cipher_setkey( mbedtls_cipher_context_t *ctx,
                            const unsigned char *key,
                            int key_bitlen,
                            const mbedtls_operation_t operation );
@@ -643,7 +645,7 @@ int mbedtls_cipher_setkey( mbedtls_cipher_context_t *ctx,
  * \return              #MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA if the cipher mode
  *                      does not support padding.
  */
-int mbedtls_cipher_set_padding_mode( mbedtls_cipher_context_t *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_cipher_set_padding_mode( mbedtls_cipher_context_t *ctx,
                                      mbedtls_cipher_padding_t mode );
 #endif /* MBEDTLS_CIPHER_MODE_WITH_PADDING */
 
@@ -665,7 +667,7 @@ int mbedtls_cipher_set_padding_mode( mbedtls_cipher_context_t *ctx,
  * \return          #MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA on
  *                  parameter-verification failure.
  */
-int mbedtls_cipher_set_iv( mbedtls_cipher_context_t *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_cipher_set_iv( mbedtls_cipher_context_t *ctx,
                            const unsigned char *iv,
                            size_t iv_len );
 
@@ -678,7 +680,7 @@ int mbedtls_cipher_set_iv( mbedtls_cipher_context_t *ctx,
  * \return        #MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA on
  *                parameter-verification failure.
  */
-int mbedtls_cipher_reset( mbedtls_cipher_context_t *ctx );
+MBEDCRYPTO_EXPORT int mbedtls_cipher_reset( mbedtls_cipher_context_t *ctx );
 
 #if defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CHACHAPOLY_C)
 /**
@@ -695,7 +697,7 @@ int mbedtls_cipher_reset( mbedtls_cipher_context_t *ctx );
  * \return              \c 0 on success.
  * \return              A specific error code on failure.
  */
-int mbedtls_cipher_update_ad( mbedtls_cipher_context_t *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_cipher_update_ad( mbedtls_cipher_context_t *ctx,
                       const unsigned char *ad, size_t ad_len );
 #endif /* MBEDTLS_GCM_C || MBEDTLS_CHACHAPOLY_C */
 
@@ -733,7 +735,7 @@ int mbedtls_cipher_update_ad( mbedtls_cipher_context_t *ctx,
  *                      unsupported mode for a cipher.
  * \return              A cipher-specific error code on failure.
  */
-int mbedtls_cipher_update( mbedtls_cipher_context_t *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_cipher_update( mbedtls_cipher_context_t *ctx,
                            const unsigned char *input,
                            size_t ilen, unsigned char *output,
                            size_t *olen );
@@ -760,7 +762,7 @@ int mbedtls_cipher_update( mbedtls_cipher_context_t *ctx,
  *                      while decrypting.
  * \return              A cipher-specific error code on failure.
  */
-int mbedtls_cipher_finish( mbedtls_cipher_context_t *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_cipher_finish( mbedtls_cipher_context_t *ctx,
                    unsigned char *output, size_t *olen );
 
 #if defined(MBEDTLS_GCM_C) || defined(MBEDTLS_CHACHAPOLY_C)
@@ -780,7 +782,7 @@ int mbedtls_cipher_finish( mbedtls_cipher_context_t *ctx,
  * \return              \c 0 on success.
  * \return              A specific error code on failure.
  */
-int mbedtls_cipher_write_tag( mbedtls_cipher_context_t *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_cipher_write_tag( mbedtls_cipher_context_t *ctx,
                       unsigned char *tag, size_t tag_len );
 
 /**
@@ -796,7 +798,7 @@ int mbedtls_cipher_write_tag( mbedtls_cipher_context_t *ctx,
  * \return              \c 0 on success.
  * \return              A specific error code on failure.
  */
-int mbedtls_cipher_check_tag( mbedtls_cipher_context_t *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_cipher_check_tag( mbedtls_cipher_context_t *ctx,
                       const unsigned char *tag, size_t tag_len );
 #endif /* MBEDTLS_GCM_C || MBEDTLS_CHACHAPOLY_C */
 
@@ -833,7 +835,7 @@ int mbedtls_cipher_check_tag( mbedtls_cipher_context_t *ctx,
  *                      while decrypting.
  * \return              A cipher-specific error code on failure.
  */
-int mbedtls_cipher_crypt( mbedtls_cipher_context_t *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_cipher_crypt( mbedtls_cipher_context_t *ctx,
                   const unsigned char *iv, size_t iv_len,
                   const unsigned char *input, size_t ilen,
                   unsigned char *output, size_t *olen );
@@ -869,7 +871,7 @@ int mbedtls_cipher_crypt( mbedtls_cipher_context_t *ctx,
  *                      parameter-verification failure.
  * \return              A cipher-specific error code on failure.
  */
-int mbedtls_cipher_auth_encrypt( mbedtls_cipher_context_t *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_cipher_auth_encrypt( mbedtls_cipher_context_t *ctx,
                          const unsigned char *iv, size_t iv_len,
                          const unsigned char *ad, size_t ad_len,
                          const unsigned char *input, size_t ilen,
@@ -911,7 +913,7 @@ int mbedtls_cipher_auth_encrypt( mbedtls_cipher_context_t *ctx,
  * \return              #MBEDTLS_ERR_CIPHER_AUTH_FAILED if data is not authentic.
  * \return              A cipher-specific error code on failure.
  */
-int mbedtls_cipher_auth_decrypt( mbedtls_cipher_context_t *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_cipher_auth_decrypt( mbedtls_cipher_context_t *ctx,
                          const unsigned char *iv, size_t iv_len,
                          const unsigned char *ad, size_t ad_len,
                          const unsigned char *input, size_t ilen,

--- a/include/mbedtls/cmac.h
+++ b/include/mbedtls/cmac.h
@@ -34,6 +34,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include "mbedtls/cipher.h"
 
 #ifdef __cplusplus
@@ -90,7 +92,7 @@ struct mbedtls_cmac_context_t
  * \return              \c 0 on success.
  * \return              A cipher-specific error code on failure.
  */
-int mbedtls_cipher_cmac_starts( mbedtls_cipher_context_t *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_cipher_cmac_starts( mbedtls_cipher_context_t *ctx,
                                 const unsigned char *key, size_t keybits );
 
 /**
@@ -109,7 +111,7 @@ int mbedtls_cipher_cmac_starts( mbedtls_cipher_context_t *ctx,
  * \return             #MBEDTLS_ERR_MD_BAD_INPUT_DATA
  *                     if parameter verification fails.
  */
-int mbedtls_cipher_cmac_update( mbedtls_cipher_context_t *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_cipher_cmac_update( mbedtls_cipher_context_t *ctx,
                                 const unsigned char *input, size_t ilen );
 
 /**
@@ -127,7 +129,7 @@ int mbedtls_cipher_cmac_update( mbedtls_cipher_context_t *ctx,
  * \return              #MBEDTLS_ERR_MD_BAD_INPUT_DATA
  *                      if parameter verification fails.
  */
-int mbedtls_cipher_cmac_finish( mbedtls_cipher_context_t *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_cipher_cmac_finish( mbedtls_cipher_context_t *ctx,
                                 unsigned char *output );
 
 /**
@@ -144,7 +146,7 @@ int mbedtls_cipher_cmac_finish( mbedtls_cipher_context_t *ctx,
  * \return              #MBEDTLS_ERR_MD_BAD_INPUT_DATA
  *                      if parameter verification fails.
  */
-int mbedtls_cipher_cmac_reset( mbedtls_cipher_context_t *ctx );
+MBEDCRYPTO_EXPORT int mbedtls_cipher_cmac_reset( mbedtls_cipher_context_t *ctx );
 
 /**
  * \brief               This function calculates the full generic CMAC
@@ -168,7 +170,7 @@ int mbedtls_cipher_cmac_reset( mbedtls_cipher_context_t *ctx );
  * \return              #MBEDTLS_ERR_MD_BAD_INPUT_DATA
  *                      if parameter verification fails.
  */
-int mbedtls_cipher_cmac( const mbedtls_cipher_info_t *cipher_info,
+MBEDCRYPTO_EXPORT int mbedtls_cipher_cmac( const mbedtls_cipher_info_t *cipher_info,
                          const unsigned char *key, size_t keylen,
                          const unsigned char *input, size_t ilen,
                          unsigned char *output );
@@ -191,7 +193,7 @@ int mbedtls_cipher_cmac( const mbedtls_cipher_info_t *cipher_info,
  *
  * \return          \c 0 on success.
  */
-int mbedtls_aes_cmac_prf_128( const unsigned char *key, size_t key_len,
+MBEDCRYPTO_EXPORT int mbedtls_aes_cmac_prf_128( const unsigned char *key, size_t key_len,
                               const unsigned char *input, size_t in_len,
                               unsigned char output[16] );
 #endif /* MBEDTLS_AES_C */
@@ -203,7 +205,7 @@ int mbedtls_aes_cmac_prf_128( const unsigned char *key, size_t key_len,
  * \return         \c 0 on success.
  * \return         \c 1 on failure.
  */
-int mbedtls_cmac_self_test( int verbose );
+MBEDCRYPTO_EXPORT int mbedtls_cmac_self_test( int verbose );
 #endif /* MBEDTLS_SELF_TEST && ( MBEDTLS_AES_C || MBEDTLS_DES_C ) */
 
 #ifdef __cplusplus

--- a/include/mbedtls/ctr_drbg.h
+++ b/include/mbedtls/ctr_drbg.h
@@ -49,6 +49,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include "mbedtls/aes.h"
 
 #if defined(MBEDTLS_THREADING_C)
@@ -212,7 +214,7 @@ mbedtls_ctr_drbg_context;
  *
  * \param ctx           The CTR_DRBG context to initialize.
  */
-void mbedtls_ctr_drbg_init( mbedtls_ctr_drbg_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_ctr_drbg_init( mbedtls_ctr_drbg_context *ctx );
 
 /**
  * \brief               This function seeds and sets up the CTR_DRBG
@@ -302,7 +304,7 @@ void mbedtls_ctr_drbg_init( mbedtls_ctr_drbg_context *ctx );
  * \return              \c 0 on success.
  * \return              #MBEDTLS_ERR_CTR_DRBG_ENTROPY_SOURCE_FAILED on failure.
  */
-int mbedtls_ctr_drbg_seed( mbedtls_ctr_drbg_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_ctr_drbg_seed( mbedtls_ctr_drbg_context *ctx,
                    int (*f_entropy)(void *, unsigned char *, size_t),
                    void *p_entropy,
                    const unsigned char *custom,
@@ -313,7 +315,7 @@ int mbedtls_ctr_drbg_seed( mbedtls_ctr_drbg_context *ctx,
  *
  * \param ctx           The CTR_DRBG context to clear.
  */
-void mbedtls_ctr_drbg_free( mbedtls_ctr_drbg_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_ctr_drbg_free( mbedtls_ctr_drbg_context *ctx );
 
 /**
  * \brief               This function turns prediction resistance on or off.
@@ -328,7 +330,7 @@ void mbedtls_ctr_drbg_free( mbedtls_ctr_drbg_context *ctx );
  * \param ctx           The CTR_DRBG context.
  * \param resistance    #MBEDTLS_CTR_DRBG_PR_ON or #MBEDTLS_CTR_DRBG_PR_OFF.
  */
-void mbedtls_ctr_drbg_set_prediction_resistance( mbedtls_ctr_drbg_context *ctx,
+MBEDCRYPTO_EXPORT void mbedtls_ctr_drbg_set_prediction_resistance( mbedtls_ctr_drbg_context *ctx,
                                          int resistance );
 
 /**
@@ -355,7 +357,7 @@ void mbedtls_ctr_drbg_set_prediction_resistance( mbedtls_ctr_drbg_context *ctx,
  *                      and at most the maximum length accepted by the
  *                      entropy function that is set in the context.
  */
-void mbedtls_ctr_drbg_set_entropy_len( mbedtls_ctr_drbg_context *ctx,
+MBEDCRYPTO_EXPORT void mbedtls_ctr_drbg_set_entropy_len( mbedtls_ctr_drbg_context *ctx,
                                size_t len );
 
 /**
@@ -377,7 +379,7 @@ void mbedtls_ctr_drbg_set_entropy_len( mbedtls_ctr_drbg_context *ctx,
  * \return              #MBEDTLS_ERR_CTR_DRBG_ENTROPY_SOURCE_FAILED
  *                      if the initial seeding has already taken place.
  */
-int mbedtls_ctr_drbg_set_nonce_len( mbedtls_ctr_drbg_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_ctr_drbg_set_nonce_len( mbedtls_ctr_drbg_context *ctx,
                                     size_t len );
 
 /**
@@ -392,7 +394,7 @@ int mbedtls_ctr_drbg_set_nonce_len( mbedtls_ctr_drbg_context *ctx,
  * \param ctx           The CTR_DRBG context.
  * \param interval      The reseed interval.
  */
-void mbedtls_ctr_drbg_set_reseed_interval( mbedtls_ctr_drbg_context *ctx,
+MBEDCRYPTO_EXPORT void mbedtls_ctr_drbg_set_reseed_interval( mbedtls_ctr_drbg_context *ctx,
                                    int interval );
 
 /**
@@ -410,7 +412,7 @@ void mbedtls_ctr_drbg_set_reseed_interval( mbedtls_ctr_drbg_context *ctx,
  * \return              \c 0 on success.
  * \return              #MBEDTLS_ERR_CTR_DRBG_ENTROPY_SOURCE_FAILED on failure.
  */
-int mbedtls_ctr_drbg_reseed( mbedtls_ctr_drbg_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_ctr_drbg_reseed( mbedtls_ctr_drbg_context *ctx,
                      const unsigned char *additional, size_t len );
 
 /**
@@ -428,7 +430,7 @@ int mbedtls_ctr_drbg_reseed( mbedtls_ctr_drbg_context *ctx,
  *                     #MBEDTLS_CTR_DRBG_MAX_SEED_INPUT.
  * \return             An error from the underlying AES cipher on failure.
  */
-int mbedtls_ctr_drbg_update_ret( mbedtls_ctr_drbg_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_ctr_drbg_update_ret( mbedtls_ctr_drbg_context *ctx,
                                  const unsigned char *additional,
                                  size_t add_len );
 
@@ -458,7 +460,7 @@ int mbedtls_ctr_drbg_update_ret( mbedtls_ctr_drbg_context *ctx,
  * \return    #MBEDTLS_ERR_CTR_DRBG_ENTROPY_SOURCE_FAILED or
  *            #MBEDTLS_ERR_CTR_DRBG_REQUEST_TOO_BIG on failure.
  */
-int mbedtls_ctr_drbg_random_with_add( void *p_rng,
+MBEDCRYPTO_EXPORT int mbedtls_ctr_drbg_random_with_add( void *p_rng,
                               unsigned char *output, size_t output_len,
                               const unsigned char *additional, size_t add_len );
 
@@ -478,7 +480,7 @@ int mbedtls_ctr_drbg_random_with_add( void *p_rng,
  * \return              #MBEDTLS_ERR_CTR_DRBG_ENTROPY_SOURCE_FAILED or
  *                      #MBEDTLS_ERR_CTR_DRBG_REQUEST_TOO_BIG on failure.
  */
-int mbedtls_ctr_drbg_random( void *p_rng,
+MBEDCRYPTO_EXPORT int mbedtls_ctr_drbg_random( void *p_rng,
                      unsigned char *output, size_t output_len );
 
 
@@ -522,7 +524,7 @@ MBEDTLS_DEPRECATED void mbedtls_ctr_drbg_update(
  * \return              #MBEDTLS_ERR_CTR_DRBG_ENTROPY_SOURCE_FAILED on reseed
  *                      failure.
  */
-int mbedtls_ctr_drbg_write_seed_file( mbedtls_ctr_drbg_context *ctx, const char *path );
+MBEDCRYPTO_EXPORT int mbedtls_ctr_drbg_write_seed_file( mbedtls_ctr_drbg_context *ctx, const char *path );
 
 /**
  * \brief               This function reads and updates a seed file. The seed
@@ -538,7 +540,7 @@ int mbedtls_ctr_drbg_write_seed_file( mbedtls_ctr_drbg_context *ctx, const char 
  * \return              #MBEDTLS_ERR_CTR_DRBG_INPUT_TOO_BIG if the existing
  *                      seed file is too large.
  */
-int mbedtls_ctr_drbg_update_seed_file( mbedtls_ctr_drbg_context *ctx, const char *path );
+MBEDCRYPTO_EXPORT int mbedtls_ctr_drbg_update_seed_file( mbedtls_ctr_drbg_context *ctx, const char *path );
 #endif /* MBEDTLS_FS_IO */
 
 #if defined(MBEDTLS_SELF_TEST)
@@ -549,7 +551,7 @@ int mbedtls_ctr_drbg_update_seed_file( mbedtls_ctr_drbg_context *ctx, const char
  * \return              \c 0 on success.
  * \return              \c 1 on failure.
  */
-int mbedtls_ctr_drbg_self_test( int verbose );
+MBEDCRYPTO_EXPORT int mbedtls_ctr_drbg_self_test( int verbose );
 
 #endif /* MBEDTLS_SELF_TEST */
 

--- a/include/mbedtls/des.h
+++ b/include/mbedtls/des.h
@@ -35,6 +35,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -91,7 +93,7 @@ mbedtls_des3_context;
  *                 security risk. We recommend considering stronger ciphers
  *                 instead.
  */
-void mbedtls_des_init( mbedtls_des_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_des_init( mbedtls_des_context *ctx );
 
 /**
  * \brief          Clear DES context
@@ -102,21 +104,21 @@ void mbedtls_des_init( mbedtls_des_context *ctx );
  *                 security risk. We recommend considering stronger ciphers
  *                 instead.
  */
-void mbedtls_des_free( mbedtls_des_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_des_free( mbedtls_des_context *ctx );
 
 /**
  * \brief          Initialize Triple-DES context
  *
  * \param ctx      DES3 context to be initialized
  */
-void mbedtls_des3_init( mbedtls_des3_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_des3_init( mbedtls_des3_context *ctx );
 
 /**
  * \brief          Clear Triple-DES context
  *
  * \param ctx      DES3 context to be cleared
  */
-void mbedtls_des3_free( mbedtls_des3_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_des3_free( mbedtls_des3_context *ctx );
 
 /**
  * \brief          Set key parity on the given key to odd.
@@ -130,7 +132,7 @@ void mbedtls_des3_free( mbedtls_des3_context *ctx );
  *                 security risk. We recommend considering stronger ciphers
  *                 instead.
  */
-void mbedtls_des_key_set_parity( unsigned char key[MBEDTLS_DES_KEY_SIZE] );
+MBEDCRYPTO_EXPORT void mbedtls_des_key_set_parity( unsigned char key[MBEDTLS_DES_KEY_SIZE] );
 
 /**
  * \brief          Check that key parity on the given key is odd.
@@ -146,7 +148,7 @@ void mbedtls_des_key_set_parity( unsigned char key[MBEDTLS_DES_KEY_SIZE] );
  *                 security risk. We recommend considering stronger ciphers
  *                 instead.
  */
-int mbedtls_des_key_check_key_parity( const unsigned char key[MBEDTLS_DES_KEY_SIZE] );
+MBEDCRYPTO_EXPORT int mbedtls_des_key_check_key_parity( const unsigned char key[MBEDTLS_DES_KEY_SIZE] );
 
 /**
  * \brief          Check that key is not a weak or semi-weak DES key
@@ -159,7 +161,7 @@ int mbedtls_des_key_check_key_parity( const unsigned char key[MBEDTLS_DES_KEY_SI
  *                 security risk. We recommend considering stronger ciphers
  *                 instead.
  */
-int mbedtls_des_key_check_weak( const unsigned char key[MBEDTLS_DES_KEY_SIZE] );
+MBEDCRYPTO_EXPORT int mbedtls_des_key_check_weak( const unsigned char key[MBEDTLS_DES_KEY_SIZE] );
 
 /**
  * \brief          DES key schedule (56-bit, encryption)
@@ -173,7 +175,7 @@ int mbedtls_des_key_check_weak( const unsigned char key[MBEDTLS_DES_KEY_SIZE] );
  *                 security risk. We recommend considering stronger ciphers
  *                 instead.
  */
-int mbedtls_des_setkey_enc( mbedtls_des_context *ctx, const unsigned char key[MBEDTLS_DES_KEY_SIZE] );
+MBEDCRYPTO_EXPORT int mbedtls_des_setkey_enc( mbedtls_des_context *ctx, const unsigned char key[MBEDTLS_DES_KEY_SIZE] );
 
 /**
  * \brief          DES key schedule (56-bit, decryption)
@@ -187,7 +189,7 @@ int mbedtls_des_setkey_enc( mbedtls_des_context *ctx, const unsigned char key[MB
  *                 security risk. We recommend considering stronger ciphers
  *                 instead.
  */
-int mbedtls_des_setkey_dec( mbedtls_des_context *ctx, const unsigned char key[MBEDTLS_DES_KEY_SIZE] );
+MBEDCRYPTO_EXPORT int mbedtls_des_setkey_dec( mbedtls_des_context *ctx, const unsigned char key[MBEDTLS_DES_KEY_SIZE] );
 
 /**
  * \brief          Triple-DES key schedule (112-bit, encryption)
@@ -197,7 +199,7 @@ int mbedtls_des_setkey_dec( mbedtls_des_context *ctx, const unsigned char key[MB
  *
  * \return         0
  */
-int mbedtls_des3_set2key_enc( mbedtls_des3_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_des3_set2key_enc( mbedtls_des3_context *ctx,
                       const unsigned char key[MBEDTLS_DES_KEY_SIZE * 2] );
 
 /**
@@ -208,7 +210,7 @@ int mbedtls_des3_set2key_enc( mbedtls_des3_context *ctx,
  *
  * \return         0
  */
-int mbedtls_des3_set2key_dec( mbedtls_des3_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_des3_set2key_dec( mbedtls_des3_context *ctx,
                       const unsigned char key[MBEDTLS_DES_KEY_SIZE * 2] );
 
 /**
@@ -219,7 +221,7 @@ int mbedtls_des3_set2key_dec( mbedtls_des3_context *ctx,
  *
  * \return         0
  */
-int mbedtls_des3_set3key_enc( mbedtls_des3_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_des3_set3key_enc( mbedtls_des3_context *ctx,
                       const unsigned char key[MBEDTLS_DES_KEY_SIZE * 3] );
 
 /**
@@ -230,7 +232,7 @@ int mbedtls_des3_set3key_enc( mbedtls_des3_context *ctx,
  *
  * \return         0
  */
-int mbedtls_des3_set3key_dec( mbedtls_des3_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_des3_set3key_dec( mbedtls_des3_context *ctx,
                       const unsigned char key[MBEDTLS_DES_KEY_SIZE * 3] );
 
 /**
@@ -246,7 +248,7 @@ int mbedtls_des3_set3key_dec( mbedtls_des3_context *ctx,
  *                 security risk. We recommend considering stronger ciphers
  *                 instead.
  */
-int mbedtls_des_crypt_ecb( mbedtls_des_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_des_crypt_ecb( mbedtls_des_context *ctx,
                     const unsigned char input[8],
                     unsigned char output[8] );
 
@@ -273,7 +275,7 @@ int mbedtls_des_crypt_ecb( mbedtls_des_context *ctx,
  *                 security risk. We recommend considering stronger ciphers
  *                 instead.
  */
-int mbedtls_des_crypt_cbc( mbedtls_des_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_des_crypt_cbc( mbedtls_des_context *ctx,
                     int mode,
                     size_t length,
                     unsigned char iv[8],
@@ -290,7 +292,7 @@ int mbedtls_des_crypt_cbc( mbedtls_des_context *ctx,
  *
  * \return         0 if successful
  */
-int mbedtls_des3_crypt_ecb( mbedtls_des3_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_des3_crypt_ecb( mbedtls_des3_context *ctx,
                      const unsigned char input[8],
                      unsigned char output[8] );
 
@@ -315,7 +317,7 @@ int mbedtls_des3_crypt_ecb( mbedtls_des3_context *ctx,
  *
  * \return         0 if successful, or MBEDTLS_ERR_DES_INVALID_INPUT_LENGTH
  */
-int mbedtls_des3_crypt_cbc( mbedtls_des3_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_des3_crypt_cbc( mbedtls_des3_context *ctx,
                      int mode,
                      size_t length,
                      unsigned char iv[8],
@@ -335,7 +337,7 @@ int mbedtls_des3_crypt_cbc( mbedtls_des3_context *ctx,
  *                 security risk. We recommend considering stronger ciphers
  *                 instead.
  */
-void mbedtls_des_setkey( uint32_t SK[32],
+MBEDCRYPTO_EXPORT void mbedtls_des_setkey( uint32_t SK[32],
                          const unsigned char key[MBEDTLS_DES_KEY_SIZE] );
 
 #if defined(MBEDTLS_SELF_TEST)
@@ -345,7 +347,7 @@ void mbedtls_des_setkey( uint32_t SK[32],
  *
  * \return         0 if successful, or 1 if the test failed
  */
-int mbedtls_des_self_test( int verbose );
+MBEDCRYPTO_EXPORT int mbedtls_des_self_test( int verbose );
 
 #endif /* MBEDTLS_SELF_TEST */
 

--- a/include/mbedtls/dhm.h
+++ b/include/mbedtls/dhm.h
@@ -70,6 +70,9 @@
 #else
 #include MBEDTLS_CONFIG_FILE
 #endif
+
+#include "mbedtls/export.h"
+
 #include "mbedtls/bignum.h"
 
 /*
@@ -124,7 +127,7 @@ mbedtls_dhm_context;
  *
  * \param ctx      The DHM context to initialize.
  */
-void mbedtls_dhm_init( mbedtls_dhm_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_dhm_init( mbedtls_dhm_context *ctx );
 
 /**
  * \brief          This function parses the DHM parameters in a
@@ -148,7 +151,7 @@ void mbedtls_dhm_init( mbedtls_dhm_context *ctx );
  * \return         \c 0 on success.
  * \return         An \c MBEDTLS_ERR_DHM_XXX error code on failure.
  */
-int mbedtls_dhm_read_params( mbedtls_dhm_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_dhm_read_params( mbedtls_dhm_context *ctx,
                              unsigned char **p,
                              const unsigned char *end );
 
@@ -184,7 +187,7 @@ int mbedtls_dhm_read_params( mbedtls_dhm_context *ctx,
  * \return         \c 0 on success.
  * \return         An \c MBEDTLS_ERR_DHM_XXX error code on failure.
  */
-int mbedtls_dhm_make_params( mbedtls_dhm_context *ctx, int x_size,
+MBEDCRYPTO_EXPORT int mbedtls_dhm_make_params( mbedtls_dhm_context *ctx, int x_size,
                      unsigned char *output, size_t *olen,
                      int (*f_rng)(void *, unsigned char *, size_t),
                      void *p_rng );
@@ -204,7 +207,7 @@ int mbedtls_dhm_make_params( mbedtls_dhm_context *ctx, int x_size,
  * \return         \c 0 if successful.
  * \return         An \c MBEDTLS_ERR_DHM_XXX error code on failure.
  */
-int mbedtls_dhm_set_group( mbedtls_dhm_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_dhm_set_group( mbedtls_dhm_context *ctx,
                            const mbedtls_mpi *P,
                            const mbedtls_mpi *G );
 
@@ -224,7 +227,7 @@ int mbedtls_dhm_set_group( mbedtls_dhm_context *ctx,
  * \return         \c 0 on success.
  * \return         An \c MBEDTLS_ERR_DHM_XXX error code on failure.
  */
-int mbedtls_dhm_read_public( mbedtls_dhm_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_dhm_read_public( mbedtls_dhm_context *ctx,
                      const unsigned char *input, size_t ilen );
 
 /**
@@ -251,7 +254,7 @@ int mbedtls_dhm_read_public( mbedtls_dhm_context *ctx,
  * \return         \c 0 on success.
  * \return         An \c MBEDTLS_ERR_DHM_XXX error code on failure.
  */
-int mbedtls_dhm_make_public( mbedtls_dhm_context *ctx, int x_size,
+MBEDCRYPTO_EXPORT int mbedtls_dhm_make_public( mbedtls_dhm_context *ctx, int x_size,
                      unsigned char *output, size_t olen,
                      int (*f_rng)(void *, unsigned char *, size_t),
                      void *p_rng );
@@ -282,7 +285,7 @@ int mbedtls_dhm_make_public( mbedtls_dhm_context *ctx, int x_size,
  * \return              \c 0 on success.
  * \return              An \c MBEDTLS_ERR_DHM_XXX error code on failure.
  */
-int mbedtls_dhm_calc_secret( mbedtls_dhm_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_dhm_calc_secret( mbedtls_dhm_context *ctx,
                      unsigned char *output, size_t output_size, size_t *olen,
                      int (*f_rng)(void *, unsigned char *, size_t),
                      void *p_rng );
@@ -295,7 +298,7 @@ int mbedtls_dhm_calc_secret( mbedtls_dhm_context *ctx,
  *                 in which case this function is a no-op. If it is not \c NULL,
  *                 it must point to an initialized DHM context.
  */
-void mbedtls_dhm_free( mbedtls_dhm_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_dhm_free( mbedtls_dhm_context *ctx );
 
 #if defined(MBEDTLS_ASN1_PARSE_C)
 /**
@@ -312,7 +315,7 @@ void mbedtls_dhm_free( mbedtls_dhm_context *ctx );
  * \return            An \c MBEDTLS_ERR_DHM_XXX or \c MBEDTLS_ERR_PEM_XXX error
  *                    code on failure.
  */
-int mbedtls_dhm_parse_dhm( mbedtls_dhm_context *dhm, const unsigned char *dhmin,
+MBEDCRYPTO_EXPORT int mbedtls_dhm_parse_dhm( mbedtls_dhm_context *dhm, const unsigned char *dhmin,
                            size_t dhminlen );
 
 #if defined(MBEDTLS_FS_IO)
@@ -328,7 +331,7 @@ int mbedtls_dhm_parse_dhm( mbedtls_dhm_context *dhm, const unsigned char *dhmin,
  * \return         An \c MBEDTLS_ERR_DHM_XXX or \c MBEDTLS_ERR_PEM_XXX
  *                 error code on failure.
  */
-int mbedtls_dhm_parse_dhmfile( mbedtls_dhm_context *dhm, const char *path );
+MBEDCRYPTO_EXPORT int mbedtls_dhm_parse_dhmfile( mbedtls_dhm_context *dhm, const char *path );
 #endif /* MBEDTLS_FS_IO */
 #endif /* MBEDTLS_ASN1_PARSE_C */
 
@@ -340,7 +343,7 @@ int mbedtls_dhm_parse_dhmfile( mbedtls_dhm_context *dhm, const char *path );
  * \return         \c 0 on success.
  * \return         \c 1 on failure.
  */
-int mbedtls_dhm_self_test( int verbose );
+MBEDCRYPTO_EXPORT int mbedtls_dhm_self_test( int verbose );
 
 #endif /* MBEDTLS_SELF_TEST */
 #ifdef __cplusplus

--- a/include/mbedtls/ecdh.h
+++ b/include/mbedtls/ecdh.h
@@ -40,6 +40,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include "mbedtls/ecp.h"
 
 #if defined(MBEDTLS_ECDH_VARIANT_EVEREST_ENABLED)
@@ -151,7 +153,7 @@ mbedtls_ecdh_context;
  *
  * \return         \c 1 if the group can be used, \c 0 otherwise
  */
-int mbedtls_ecdh_can_do( mbedtls_ecp_group_id gid );
+MBEDCRYPTO_EXPORT int mbedtls_ecdh_can_do( mbedtls_ecp_group_id gid );
 
 /**
  * \brief           This function generates an ECDH keypair on an elliptic
@@ -178,7 +180,7 @@ int mbedtls_ecdh_can_do( mbedtls_ecp_group_id gid );
  * \return          Another \c MBEDTLS_ERR_ECP_XXX or
  *                  \c MBEDTLS_MPI_XXX error code on failure.
  */
-int mbedtls_ecdh_gen_public( mbedtls_ecp_group *grp, mbedtls_mpi *d, mbedtls_ecp_point *Q,
+MBEDCRYPTO_EXPORT int mbedtls_ecdh_gen_public( mbedtls_ecp_group *grp, mbedtls_mpi *d, mbedtls_ecp_point *Q,
                      int (*f_rng)(void *, unsigned char *, size_t),
                      void *p_rng );
 
@@ -216,7 +218,7 @@ int mbedtls_ecdh_gen_public( mbedtls_ecp_group *grp, mbedtls_mpi *d, mbedtls_ecp
  * \return          Another \c MBEDTLS_ERR_ECP_XXX or
  *                  \c MBEDTLS_MPI_XXX error code on failure.
  */
-int mbedtls_ecdh_compute_shared( mbedtls_ecp_group *grp, mbedtls_mpi *z,
+MBEDCRYPTO_EXPORT int mbedtls_ecdh_compute_shared( mbedtls_ecp_group *grp, mbedtls_mpi *z,
                          const mbedtls_ecp_point *Q, const mbedtls_mpi *d,
                          int (*f_rng)(void *, unsigned char *, size_t),
                          void *p_rng );
@@ -226,7 +228,7 @@ int mbedtls_ecdh_compute_shared( mbedtls_ecp_group *grp, mbedtls_mpi *z,
  *
  * \param ctx       The ECDH context to initialize. This must not be \c NULL.
  */
-void mbedtls_ecdh_init( mbedtls_ecdh_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_ecdh_init( mbedtls_ecdh_context *ctx );
 
 /**
  * \brief           This function sets up the ECDH context with the information
@@ -244,7 +246,7 @@ void mbedtls_ecdh_init( mbedtls_ecdh_context *ctx );
  *
  * \return          \c 0 on success.
  */
-int mbedtls_ecdh_setup( mbedtls_ecdh_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_ecdh_setup( mbedtls_ecdh_context *ctx,
                         mbedtls_ecp_group_id grp_id );
 
 /**
@@ -254,7 +256,7 @@ int mbedtls_ecdh_setup( mbedtls_ecdh_context *ctx,
  *                  case this function does nothing. If it is not \c NULL,
  *                  it must point to an initialized ECDH context.
  */
-void mbedtls_ecdh_free( mbedtls_ecdh_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_ecdh_free( mbedtls_ecdh_context *ctx );
 
 /**
  * \brief           This function generates an EC key pair and exports its
@@ -281,7 +283,7 @@ void mbedtls_ecdh_free( mbedtls_ecdh_context *ctx );
  *                  operations was reached: see \c mbedtls_ecp_set_max_ops().
  * \return          Another \c MBEDTLS_ERR_ECP_XXX error code on failure.
  */
-int mbedtls_ecdh_make_params( mbedtls_ecdh_context *ctx, size_t *olen,
+MBEDCRYPTO_EXPORT int mbedtls_ecdh_make_params( mbedtls_ecdh_context *ctx, size_t *olen,
                       unsigned char *buf, size_t blen,
                       int (*f_rng)(void *, unsigned char *, size_t),
                       void *p_rng );
@@ -310,7 +312,7 @@ int mbedtls_ecdh_make_params( mbedtls_ecdh_context *ctx, size_t *olen,
  * \return          An \c MBEDTLS_ERR_ECP_XXX error code on failure.
  *
  */
-int mbedtls_ecdh_read_params( mbedtls_ecdh_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_ecdh_read_params( mbedtls_ecdh_context *ctx,
                               const unsigned char **buf,
                               const unsigned char *end );
 
@@ -333,7 +335,7 @@ int mbedtls_ecdh_read_params( mbedtls_ecdh_context *ctx,
  * \return          Another \c MBEDTLS_ERR_ECP_XXX error code on failure.
  *
  */
-int mbedtls_ecdh_get_params( mbedtls_ecdh_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_ecdh_get_params( mbedtls_ecdh_context *ctx,
                              const mbedtls_ecp_keypair *key,
                              mbedtls_ecdh_side side );
 
@@ -363,7 +365,7 @@ int mbedtls_ecdh_get_params( mbedtls_ecdh_context *ctx,
  *                  operations was reached: see \c mbedtls_ecp_set_max_ops().
  * \return          Another \c MBEDTLS_ERR_ECP_XXX error code on failure.
  */
-int mbedtls_ecdh_make_public( mbedtls_ecdh_context *ctx, size_t *olen,
+MBEDCRYPTO_EXPORT int mbedtls_ecdh_make_public( mbedtls_ecdh_context *ctx, size_t *olen,
                       unsigned char *buf, size_t blen,
                       int (*f_rng)(void *, unsigned char *, size_t),
                       void *p_rng );
@@ -387,7 +389,7 @@ int mbedtls_ecdh_make_public( mbedtls_ecdh_context *ctx, size_t *olen,
  * \return      \c 0 on success.
  * \return      An \c MBEDTLS_ERR_ECP_XXX error code on failure.
  */
-int mbedtls_ecdh_read_public( mbedtls_ecdh_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_ecdh_read_public( mbedtls_ecdh_context *ctx,
                               const unsigned char *buf, size_t blen );
 
 /**
@@ -420,7 +422,7 @@ int mbedtls_ecdh_read_public( mbedtls_ecdh_context *ctx,
  *                  operations was reached: see \c mbedtls_ecp_set_max_ops().
  * \return          Another \c MBEDTLS_ERR_ECP_XXX error code on failure.
  */
-int mbedtls_ecdh_calc_secret( mbedtls_ecdh_context *ctx, size_t *olen,
+MBEDCRYPTO_EXPORT int mbedtls_ecdh_calc_secret( mbedtls_ecdh_context *ctx, size_t *olen,
                       unsigned char *buf, size_t blen,
                       int (*f_rng)(void *, unsigned char *, size_t),
                       void *p_rng );
@@ -438,7 +440,7 @@ int mbedtls_ecdh_calc_secret( mbedtls_ecdh_context *ctx, size_t *olen,
  *
  * \param ctx       The ECDH context to use. This must be initialized.
  */
-void mbedtls_ecdh_enable_restart( mbedtls_ecdh_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_ecdh_enable_restart( mbedtls_ecdh_context *ctx );
 #endif /* MBEDTLS_ECP_RESTARTABLE */
 
 #ifdef __cplusplus

--- a/include/mbedtls/ecdsa.h
+++ b/include/mbedtls/ecdsa.h
@@ -38,6 +38,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include "mbedtls/ecp.h"
 #include "mbedtls/md.h"
 
@@ -133,7 +135,7 @@ typedef void mbedtls_ecdsa_restart_ctx;
  *
  * \return         \c 1 if the group can be used, \c 0 otherwise
  */
-int mbedtls_ecdsa_can_do( mbedtls_ecp_group_id gid );
+MBEDCRYPTO_EXPORT int mbedtls_ecdsa_can_do( mbedtls_ecp_group_id gid );
 
 /**
  * \brief           This function computes the ECDSA signature of a
@@ -171,7 +173,7 @@ int mbedtls_ecdsa_can_do( mbedtls_ecp_group_id gid );
  * \return          An \c MBEDTLS_ERR_ECP_XXX
  *                  or \c MBEDTLS_MPI_XXX error code on failure.
  */
-int mbedtls_ecdsa_sign( mbedtls_ecp_group *grp, mbedtls_mpi *r, mbedtls_mpi *s,
+MBEDCRYPTO_EXPORT int mbedtls_ecdsa_sign( mbedtls_ecp_group *grp, mbedtls_mpi *r, mbedtls_mpi *s,
                 const mbedtls_mpi *d, const unsigned char *buf, size_t blen,
                 int (*f_rng)(void *, unsigned char *, size_t), void *p_rng );
 
@@ -230,7 +232,7 @@ int mbedtls_ecdsa_sign( mbedtls_ecp_group *grp, mbedtls_mpi *r, mbedtls_mpi *s,
  * \return          An \c MBEDTLS_ERR_ECP_XXX or \c MBEDTLS_MPI_XXX
  *                  error code on failure.
  */
-int mbedtls_ecdsa_sign_det( mbedtls_ecp_group *grp, mbedtls_mpi *r,
+MBEDCRYPTO_EXPORT int mbedtls_ecdsa_sign_det( mbedtls_ecp_group *grp, mbedtls_mpi *r,
                             mbedtls_mpi *s, const mbedtls_mpi *d,
                             const unsigned char *buf, size_t blen,
                             mbedtls_md_type_t md_alg ) MBEDTLS_DEPRECATED;
@@ -276,7 +278,7 @@ int mbedtls_ecdsa_sign_det( mbedtls_ecp_group *grp, mbedtls_mpi *r,
  * \return          An \c MBEDTLS_ERR_ECP_XXX or \c MBEDTLS_MPI_XXX
  *                  error code on failure.
  */
-int mbedtls_ecdsa_sign_det_ext( mbedtls_ecp_group *grp, mbedtls_mpi *r,
+MBEDCRYPTO_EXPORT int mbedtls_ecdsa_sign_det_ext( mbedtls_ecp_group *grp, mbedtls_mpi *r,
                             mbedtls_mpi *s, const mbedtls_mpi *d,
                             const unsigned char *buf, size_t blen,
                             mbedtls_md_type_t md_alg,
@@ -316,7 +318,7 @@ int mbedtls_ecdsa_sign_det_ext( mbedtls_ecp_group *grp, mbedtls_mpi *r,
  * \return          An \c MBEDTLS_ERR_ECP_XXX or \c MBEDTLS_MPI_XXX
  *                  error code on failure for any other reason.
  */
-int mbedtls_ecdsa_verify( mbedtls_ecp_group *grp,
+MBEDCRYPTO_EXPORT int mbedtls_ecdsa_verify( mbedtls_ecp_group *grp,
                           const unsigned char *buf, size_t blen,
                           const mbedtls_ecp_point *Q, const mbedtls_mpi *r,
                           const mbedtls_mpi *s);
@@ -369,7 +371,7 @@ int mbedtls_ecdsa_verify( mbedtls_ecp_group *grp,
  * \return          An \c MBEDTLS_ERR_ECP_XXX, \c MBEDTLS_ERR_MPI_XXX or
  *                  \c MBEDTLS_ERR_ASN1_XXX error code on failure.
  */
-int mbedtls_ecdsa_write_signature( mbedtls_ecdsa_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_ecdsa_write_signature( mbedtls_ecdsa_context *ctx,
                                    mbedtls_md_type_t md_alg,
                            const unsigned char *hash, size_t hlen,
                            unsigned char *sig, size_t *slen,
@@ -415,7 +417,7 @@ int mbedtls_ecdsa_write_signature( mbedtls_ecdsa_context *ctx,
  * \return          Another \c MBEDTLS_ERR_ECP_XXX, \c MBEDTLS_ERR_MPI_XXX or
  *                  \c MBEDTLS_ERR_ASN1_XXX error code on failure.
  */
-int mbedtls_ecdsa_write_signature_restartable( mbedtls_ecdsa_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_ecdsa_write_signature_restartable( mbedtls_ecdsa_context *ctx,
                            mbedtls_md_type_t md_alg,
                            const unsigned char *hash, size_t hlen,
                            unsigned char *sig, size_t *slen,
@@ -473,7 +475,7 @@ int mbedtls_ecdsa_write_signature_restartable( mbedtls_ecdsa_context *ctx,
  * \return          An \c MBEDTLS_ERR_ECP_XXX, \c MBEDTLS_ERR_MPI_XXX or
  *                  \c MBEDTLS_ERR_ASN1_XXX error code on failure.
  */
-int mbedtls_ecdsa_write_signature_det( mbedtls_ecdsa_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_ecdsa_write_signature_det( mbedtls_ecdsa_context *ctx,
                                const unsigned char *hash, size_t hlen,
                                unsigned char *sig, size_t *slen,
                                mbedtls_md_type_t md_alg ) MBEDTLS_DEPRECATED;
@@ -508,7 +510,7 @@ int mbedtls_ecdsa_write_signature_det( mbedtls_ecdsa_context *ctx,
  * \return          An \c MBEDTLS_ERR_ECP_XXX or \c MBEDTLS_ERR_MPI_XXX
  *                  error code on failure for any other reason.
  */
-int mbedtls_ecdsa_read_signature( mbedtls_ecdsa_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_ecdsa_read_signature( mbedtls_ecdsa_context *ctx,
                           const unsigned char *hash, size_t hlen,
                           const unsigned char *sig, size_t slen );
 
@@ -543,7 +545,7 @@ int mbedtls_ecdsa_read_signature( mbedtls_ecdsa_context *ctx,
  * \return          Another \c MBEDTLS_ERR_ECP_XXX or \c MBEDTLS_ERR_MPI_XXX
  *                  error code on failure for any other reason.
  */
-int mbedtls_ecdsa_read_signature_restartable( mbedtls_ecdsa_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_ecdsa_read_signature_restartable( mbedtls_ecdsa_context *ctx,
                           const unsigned char *hash, size_t hlen,
                           const unsigned char *sig, size_t slen,
                           mbedtls_ecdsa_restart_ctx *rs_ctx );
@@ -564,7 +566,7 @@ int mbedtls_ecdsa_read_signature_restartable( mbedtls_ecdsa_context *ctx,
  * \return         \c 0 on success.
  * \return         An \c MBEDTLS_ERR_ECP_XXX code on failure.
  */
-int mbedtls_ecdsa_genkey( mbedtls_ecdsa_context *ctx, mbedtls_ecp_group_id gid,
+MBEDCRYPTO_EXPORT int mbedtls_ecdsa_genkey( mbedtls_ecdsa_context *ctx, mbedtls_ecp_group_id gid,
                   int (*f_rng)(void *, unsigned char *, size_t), void *p_rng );
 
 /**
@@ -582,7 +584,7 @@ int mbedtls_ecdsa_genkey( mbedtls_ecdsa_context *ctx, mbedtls_ecp_group_id gid,
  * \return          \c 0 on success.
  * \return          An \c MBEDTLS_ERR_ECP_XXX code on failure.
  */
-int mbedtls_ecdsa_from_keypair( mbedtls_ecdsa_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_ecdsa_from_keypair( mbedtls_ecdsa_context *ctx,
                                 const mbedtls_ecp_keypair *key );
 
 /**
@@ -591,7 +593,7 @@ int mbedtls_ecdsa_from_keypair( mbedtls_ecdsa_context *ctx,
  * \param ctx       The ECDSA context to initialize.
  *                  This must not be \c NULL.
  */
-void mbedtls_ecdsa_init( mbedtls_ecdsa_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_ecdsa_init( mbedtls_ecdsa_context *ctx );
 
 /**
  * \brief           This function frees an ECDSA context.
@@ -600,7 +602,7 @@ void mbedtls_ecdsa_init( mbedtls_ecdsa_context *ctx );
  *                  in which case this function does nothing. If it
  *                  is not \c NULL, it must be initialized.
  */
-void mbedtls_ecdsa_free( mbedtls_ecdsa_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_ecdsa_free( mbedtls_ecdsa_context *ctx );
 
 #if defined(MBEDTLS_ECP_RESTARTABLE)
 /**
@@ -609,7 +611,7 @@ void mbedtls_ecdsa_free( mbedtls_ecdsa_context *ctx );
  * \param ctx       The restart context to initialize.
  *                  This must not be \c NULL.
  */
-void mbedtls_ecdsa_restart_init( mbedtls_ecdsa_restart_ctx *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_ecdsa_restart_init( mbedtls_ecdsa_restart_ctx *ctx );
 
 /**
  * \brief           Free the components of a restart context.
@@ -618,7 +620,7 @@ void mbedtls_ecdsa_restart_init( mbedtls_ecdsa_restart_ctx *ctx );
  *                  in which case this function does nothing. If it
  *                  is not \c NULL, it must be initialized.
  */
-void mbedtls_ecdsa_restart_free( mbedtls_ecdsa_restart_ctx *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_ecdsa_restart_free( mbedtls_ecdsa_restart_ctx *ctx );
 #endif /* MBEDTLS_ECP_RESTARTABLE */
 
 #ifdef __cplusplus

--- a/include/mbedtls/ecjpake.h
+++ b/include/mbedtls/ecjpake.h
@@ -46,6 +46,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include "mbedtls/ecp.h"
 #include "mbedtls/md.h"
 
@@ -102,7 +104,7 @@ typedef struct mbedtls_ecjpake_context
  * \param ctx       The ECJPAKE context to initialize.
  *                  This must not be \c NULL.
  */
-void mbedtls_ecjpake_init( mbedtls_ecjpake_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_ecjpake_init( mbedtls_ecjpake_context *ctx );
 
 /**
  * \brief           Set up an ECJPAKE context for use.
@@ -125,7 +127,7 @@ void mbedtls_ecjpake_init( mbedtls_ecjpake_context *ctx );
  * \return          \c 0 if successful.
  * \return          A negative error code on failure.
  */
-int mbedtls_ecjpake_setup( mbedtls_ecjpake_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_ecjpake_setup( mbedtls_ecjpake_context *ctx,
                            mbedtls_ecjpake_role role,
                            mbedtls_md_type_t hash,
                            mbedtls_ecp_group_id curve,
@@ -141,7 +143,7 @@ int mbedtls_ecjpake_setup( mbedtls_ecjpake_context *ctx,
  * \return          \c 0 if the context is ready for use.
  * \return          #MBEDTLS_ERR_ECP_BAD_INPUT_DATA otherwise.
  */
-int mbedtls_ecjpake_check( const mbedtls_ecjpake_context *ctx );
+MBEDCRYPTO_EXPORT int mbedtls_ecjpake_check( const mbedtls_ecjpake_context *ctx );
 
 /**
  * \brief           Generate and write the first round message
@@ -162,7 +164,7 @@ int mbedtls_ecjpake_check( const mbedtls_ecjpake_context *ctx );
  * \return          \c 0 if successful.
  * \return          A negative error code on failure.
  */
-int mbedtls_ecjpake_write_round_one( mbedtls_ecjpake_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_ecjpake_write_round_one( mbedtls_ecjpake_context *ctx,
                             unsigned char *buf, size_t len, size_t *olen,
                             int (*f_rng)(void *, unsigned char *, size_t),
                             void *p_rng );
@@ -181,7 +183,7 @@ int mbedtls_ecjpake_write_round_one( mbedtls_ecjpake_context *ctx,
  * \return          \c 0 if successful.
  * \return          A negative error code on failure.
  */
-int mbedtls_ecjpake_read_round_one( mbedtls_ecjpake_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_ecjpake_read_round_one( mbedtls_ecjpake_context *ctx,
                                     const unsigned char *buf,
                                     size_t len );
 
@@ -203,7 +205,7 @@ int mbedtls_ecjpake_read_round_one( mbedtls_ecjpake_context *ctx,
  * \return          \c 0 if successful.
  * \return          A negative error code on failure.
  */
-int mbedtls_ecjpake_write_round_two( mbedtls_ecjpake_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_ecjpake_write_round_two( mbedtls_ecjpake_context *ctx,
                             unsigned char *buf, size_t len, size_t *olen,
                             int (*f_rng)(void *, unsigned char *, size_t),
                             void *p_rng );
@@ -221,7 +223,7 @@ int mbedtls_ecjpake_write_round_two( mbedtls_ecjpake_context *ctx,
  * \return          \c 0 if successful.
  * \return          A negative error code on failure.
  */
-int mbedtls_ecjpake_read_round_two( mbedtls_ecjpake_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_ecjpake_read_round_two( mbedtls_ecjpake_context *ctx,
                                     const unsigned char *buf,
                                     size_t len );
 
@@ -243,7 +245,7 @@ int mbedtls_ecjpake_read_round_two( mbedtls_ecjpake_context *ctx,
  * \return          \c 0 if successful.
  * \return          A negative error code on failure.
  */
-int mbedtls_ecjpake_derive_secret( mbedtls_ecjpake_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_ecjpake_derive_secret( mbedtls_ecjpake_context *ctx,
                             unsigned char *buf, size_t len, size_t *olen,
                             int (*f_rng)(void *, unsigned char *, size_t),
                             void *p_rng );
@@ -256,7 +258,7 @@ int mbedtls_ecjpake_derive_secret( mbedtls_ecjpake_context *ctx,
  *                  in which case this function does nothing. If it is not
  *                  \c NULL, it must point to an initialized ECJPAKE context.
  */
-void mbedtls_ecjpake_free( mbedtls_ecjpake_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_ecjpake_free( mbedtls_ecjpake_context *ctx );
 
 #if defined(MBEDTLS_SELF_TEST)
 
@@ -265,7 +267,7 @@ void mbedtls_ecjpake_free( mbedtls_ecjpake_context *ctx );
  *
  * \return         0 if successful, or 1 if a test failed
  */
-int mbedtls_ecjpake_self_test( int verbose );
+MBEDCRYPTO_EXPORT int mbedtls_ecjpake_self_test( int verbose );
 
 #endif /* MBEDTLS_SELF_TEST */
 

--- a/include/mbedtls/ecp.h
+++ b/include/mbedtls/ecp.h
@@ -42,6 +42,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include "mbedtls/bignum.h"
 
 /*
@@ -313,7 +315,7 @@ typedef struct
  * \return          \c 0 if doing \p ops basic ops is still allowed,
  * \return          #MBEDTLS_ERR_ECP_IN_PROGRESS otherwise.
  */
-int mbedtls_ecp_check_budget( const mbedtls_ecp_group *grp,
+MBEDCRYPTO_EXPORT int mbedtls_ecp_check_budget( const mbedtls_ecp_group *grp,
                               mbedtls_ecp_restart_ctx *rs_ctx,
                               unsigned ops );
 
@@ -416,7 +418,7 @@ mbedtls_ecp_keypair;
  *
  * \note            This setting is currently ignored by Curve25519.
  */
-void mbedtls_ecp_set_max_ops( unsigned max_ops );
+MBEDCRYPTO_EXPORT void mbedtls_ecp_set_max_ops( unsigned max_ops );
 
 /**
  * \brief           Check if restart is enabled (max_ops != 0)
@@ -424,13 +426,13 @@ void mbedtls_ecp_set_max_ops( unsigned max_ops );
  * \return          \c 0 if \c max_ops == 0 (restart disabled)
  * \return          \c 1 otherwise (restart enabled)
  */
-int mbedtls_ecp_restart_is_enabled( void );
+MBEDCRYPTO_EXPORT int mbedtls_ecp_restart_is_enabled( void );
 #endif /* MBEDTLS_ECP_RESTARTABLE */
 
 /*
  * Get the type of a curve
  */
-mbedtls_ecp_curve_type mbedtls_ecp_get_type( const mbedtls_ecp_group *grp );
+MBEDCRYPTO_EXPORT mbedtls_ecp_curve_type mbedtls_ecp_get_type( const mbedtls_ecp_group *grp );
 
 /**
  * \brief           This function retrieves the information defined in
@@ -445,7 +447,7 @@ mbedtls_ecp_curve_type mbedtls_ecp_get_type( const mbedtls_ecp_group *grp );
  *
  * \return          A statically allocated array. The last entry is 0.
  */
-const mbedtls_ecp_curve_info *mbedtls_ecp_curve_list( void );
+MBEDCRYPTO_EXPORT const mbedtls_ecp_curve_info *mbedtls_ecp_curve_list( void );
 
 /**
  * \brief           This function retrieves the list of internal group
@@ -461,7 +463,7 @@ const mbedtls_ecp_curve_info *mbedtls_ecp_curve_list( void );
  * \return          A statically allocated array,
  *                  terminated with MBEDTLS_ECP_DP_NONE.
  */
-const mbedtls_ecp_group_id *mbedtls_ecp_grp_id_list( void );
+MBEDCRYPTO_EXPORT const mbedtls_ecp_group_id *mbedtls_ecp_grp_id_list( void );
 
 /**
  * \brief           This function retrieves curve information from an internal
@@ -472,7 +474,7 @@ const mbedtls_ecp_group_id *mbedtls_ecp_grp_id_list( void );
  * \return          The associated curve information on success.
  * \return          NULL on failure.
  */
-const mbedtls_ecp_curve_info *mbedtls_ecp_curve_info_from_grp_id( mbedtls_ecp_group_id grp_id );
+MBEDCRYPTO_EXPORT const mbedtls_ecp_curve_info *mbedtls_ecp_curve_info_from_grp_id( mbedtls_ecp_group_id grp_id );
 
 /**
  * \brief           This function retrieves curve information from a TLS
@@ -483,7 +485,7 @@ const mbedtls_ecp_curve_info *mbedtls_ecp_curve_info_from_grp_id( mbedtls_ecp_gr
  * \return          The associated curve information on success.
  * \return          NULL on failure.
  */
-const mbedtls_ecp_curve_info *mbedtls_ecp_curve_info_from_tls_id( uint16_t tls_id );
+MBEDCRYPTO_EXPORT const mbedtls_ecp_curve_info *mbedtls_ecp_curve_info_from_tls_id( uint16_t tls_id );
 
 /**
  * \brief           This function retrieves curve information from a
@@ -494,14 +496,14 @@ const mbedtls_ecp_curve_info *mbedtls_ecp_curve_info_from_tls_id( uint16_t tls_i
  * \return          The associated curve information on success.
  * \return          NULL on failure.
  */
-const mbedtls_ecp_curve_info *mbedtls_ecp_curve_info_from_name( const char *name );
+MBEDCRYPTO_EXPORT const mbedtls_ecp_curve_info *mbedtls_ecp_curve_info_from_name( const char *name );
 
 /**
  * \brief           This function initializes a point as zero.
  *
  * \param pt        The point to initialize.
  */
-void mbedtls_ecp_point_init( mbedtls_ecp_point *pt );
+MBEDCRYPTO_EXPORT void mbedtls_ecp_point_init( mbedtls_ecp_point *pt );
 
 /**
  * \brief           This function initializes an ECP group context
@@ -512,21 +514,21 @@ void mbedtls_ecp_point_init( mbedtls_ecp_point *pt );
  *                  mbedtls_ecp_group_load() or mbedtls_ecp_tls_read_group()
  *                  functions.
  */
-void mbedtls_ecp_group_init( mbedtls_ecp_group *grp );
+MBEDCRYPTO_EXPORT void mbedtls_ecp_group_init( mbedtls_ecp_group *grp );
 
 /**
  * \brief           This function initializes a key pair as an invalid one.
  *
  * \param key       The key pair to initialize.
  */
-void mbedtls_ecp_keypair_init( mbedtls_ecp_keypair *key );
+MBEDCRYPTO_EXPORT void mbedtls_ecp_keypair_init( mbedtls_ecp_keypair *key );
 
 /**
  * \brief           This function frees the components of a point.
  *
  * \param pt        The point to free.
  */
-void mbedtls_ecp_point_free( mbedtls_ecp_point *pt );
+MBEDCRYPTO_EXPORT void mbedtls_ecp_point_free( mbedtls_ecp_point *pt );
 
 /**
  * \brief           This function frees the components of an ECP group.
@@ -535,7 +537,7 @@ void mbedtls_ecp_point_free( mbedtls_ecp_point *pt );
  *                  case this function returns immediately. If it is not
  *                  \c NULL, it must point to an initialized ECP group.
  */
-void mbedtls_ecp_group_free( mbedtls_ecp_group *grp );
+MBEDCRYPTO_EXPORT void mbedtls_ecp_group_free( mbedtls_ecp_group *grp );
 
 /**
  * \brief           This function frees the components of a key pair.
@@ -544,7 +546,7 @@ void mbedtls_ecp_group_free( mbedtls_ecp_group *grp );
  *                  case this function returns immediately. If it is not
  *                  \c NULL, it must point to an initialized ECP key pair.
  */
-void mbedtls_ecp_keypair_free( mbedtls_ecp_keypair *key );
+MBEDCRYPTO_EXPORT void mbedtls_ecp_keypair_free( mbedtls_ecp_keypair *key );
 
 #if defined(MBEDTLS_ECP_RESTARTABLE)
 /**
@@ -553,7 +555,7 @@ void mbedtls_ecp_keypair_free( mbedtls_ecp_keypair *key );
  * \param ctx       The restart context to initialize. This must
  *                  not be \c NULL.
  */
-void mbedtls_ecp_restart_init( mbedtls_ecp_restart_ctx *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_ecp_restart_init( mbedtls_ecp_restart_ctx *ctx );
 
 /**
  * \brief           Free the components of a restart context.
@@ -562,7 +564,7 @@ void mbedtls_ecp_restart_init( mbedtls_ecp_restart_ctx *ctx );
  *                  case this function returns immediately. If it is not
  *                  \c NULL, it must point to an initialized restart context.
  */
-void mbedtls_ecp_restart_free( mbedtls_ecp_restart_ctx *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_ecp_restart_free( mbedtls_ecp_restart_ctx *ctx );
 #endif /* MBEDTLS_ECP_RESTARTABLE */
 
 /**
@@ -576,7 +578,7 @@ void mbedtls_ecp_restart_free( mbedtls_ecp_restart_ctx *ctx );
  * \return          #MBEDTLS_ERR_MPI_ALLOC_FAILED on memory-allocation failure.
  * \return          Another negative error code for other kinds of failure.
  */
-int mbedtls_ecp_copy( mbedtls_ecp_point *P, const mbedtls_ecp_point *Q );
+MBEDCRYPTO_EXPORT int mbedtls_ecp_copy( mbedtls_ecp_point *P, const mbedtls_ecp_point *Q );
 
 /**
  * \brief           This function copies the contents of group \p src into
@@ -589,7 +591,7 @@ int mbedtls_ecp_copy( mbedtls_ecp_point *P, const mbedtls_ecp_point *Q );
  * \return          #MBEDTLS_ERR_MPI_ALLOC_FAILED on memory-allocation failure.
  * \return          Another negative error code on other kinds of failure.
  */
-int mbedtls_ecp_group_copy( mbedtls_ecp_group *dst,
+MBEDCRYPTO_EXPORT int mbedtls_ecp_group_copy( mbedtls_ecp_group *dst,
                             const mbedtls_ecp_group *src );
 
 /**
@@ -601,7 +603,7 @@ int mbedtls_ecp_group_copy( mbedtls_ecp_group *dst,
  * \return          #MBEDTLS_ERR_MPI_ALLOC_FAILED on memory-allocation failure.
  * \return          Another negative error code on other kinds of failure.
  */
-int mbedtls_ecp_set_zero( mbedtls_ecp_point *pt );
+MBEDCRYPTO_EXPORT int mbedtls_ecp_set_zero( mbedtls_ecp_point *pt );
 
 /**
  * \brief           This function checks if a point is the point at infinity.
@@ -612,7 +614,7 @@ int mbedtls_ecp_set_zero( mbedtls_ecp_point *pt );
  * \return          \c 0 if the point is non-zero.
  * \return          A negative error code on failure.
  */
-int mbedtls_ecp_is_zero( mbedtls_ecp_point *pt );
+MBEDCRYPTO_EXPORT int mbedtls_ecp_is_zero( mbedtls_ecp_point *pt );
 
 /**
  * \brief           This function compares two points.
@@ -626,7 +628,7 @@ int mbedtls_ecp_is_zero( mbedtls_ecp_point *pt );
  * \return          \c 0 if the points are equal.
  * \return          #MBEDTLS_ERR_ECP_BAD_INPUT_DATA if the points are not equal.
  */
-int mbedtls_ecp_point_cmp( const mbedtls_ecp_point *P,
+MBEDCRYPTO_EXPORT int mbedtls_ecp_point_cmp( const mbedtls_ecp_point *P,
                            const mbedtls_ecp_point *Q );
 
 /**
@@ -641,7 +643,7 @@ int mbedtls_ecp_point_cmp( const mbedtls_ecp_point *P,
  * \return          \c 0 on success.
  * \return          An \c MBEDTLS_ERR_MPI_XXX error code on failure.
  */
-int mbedtls_ecp_point_read_string( mbedtls_ecp_point *P, int radix,
+MBEDCRYPTO_EXPORT int mbedtls_ecp_point_read_string( mbedtls_ecp_point *P, int radix,
                            const char *x, const char *y );
 
 /**
@@ -669,7 +671,7 @@ int mbedtls_ecp_point_read_string( mbedtls_ecp_point *P, int radix,
  *                  or the export for the given group is not implemented.
  * \return          Another negative error code on other kinds of failure.
  */
-int mbedtls_ecp_point_write_binary( const mbedtls_ecp_group *grp,
+MBEDCRYPTO_EXPORT int mbedtls_ecp_point_write_binary( const mbedtls_ecp_group *grp,
                                     const mbedtls_ecp_point *P,
                                     int format, size_t *olen,
                                     unsigned char *buf, size_t buflen );
@@ -696,7 +698,7 @@ int mbedtls_ecp_point_write_binary( const mbedtls_ecp_group *grp,
  * \return          #MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE if the import for the
  *                  given group is not implemented.
  */
-int mbedtls_ecp_point_read_binary( const mbedtls_ecp_group *grp,
+MBEDCRYPTO_EXPORT int mbedtls_ecp_point_read_binary( const mbedtls_ecp_group *grp,
                                    mbedtls_ecp_point *P,
                                    const unsigned char *buf, size_t ilen );
 
@@ -718,7 +720,7 @@ int mbedtls_ecp_point_read_binary( const mbedtls_ecp_group *grp,
  *                  failure.
  * \return          #MBEDTLS_ERR_ECP_BAD_INPUT_DATA if input is invalid.
  */
-int mbedtls_ecp_tls_read_point( const mbedtls_ecp_group *grp,
+MBEDCRYPTO_EXPORT int mbedtls_ecp_tls_read_point( const mbedtls_ecp_group *grp,
                                 mbedtls_ecp_point *pt,
                                 const unsigned char **buf, size_t len );
 
@@ -744,7 +746,7 @@ int mbedtls_ecp_tls_read_point( const mbedtls_ecp_group *grp,
  *                  is too small to hold the exported point.
  * \return          Another negative error code on other kinds of failure.
  */
-int mbedtls_ecp_tls_write_point( const mbedtls_ecp_group *grp,
+MBEDCRYPTO_EXPORT int mbedtls_ecp_tls_write_point( const mbedtls_ecp_group *grp,
                                  const mbedtls_ecp_point *pt,
                                  int format, size_t *olen,
                                  unsigned char *buf, size_t blen );
@@ -766,7 +768,7 @@ int mbedtls_ecp_tls_write_point( const mbedtls_ecp_group *grp,
  *                  correspond to a known group.
  * \return          Another negative error code on other kinds of failure.
  */
-int mbedtls_ecp_group_load( mbedtls_ecp_group *grp, mbedtls_ecp_group_id id );
+MBEDCRYPTO_EXPORT int mbedtls_ecp_group_load( mbedtls_ecp_group *grp, mbedtls_ecp_group_id id );
 
 /**
  * \brief           This function sets up an ECP group context from a TLS
@@ -785,7 +787,7 @@ int mbedtls_ecp_group_load( mbedtls_ecp_group *grp, mbedtls_ecp_group_id id );
  *                  recognized.
  * \return          Another negative error code on other kinds of failure.
  */
-int mbedtls_ecp_tls_read_group( mbedtls_ecp_group *grp,
+MBEDCRYPTO_EXPORT int mbedtls_ecp_tls_read_group( mbedtls_ecp_group *grp,
                                 const unsigned char **buf, size_t len );
 
 /**
@@ -806,7 +808,7 @@ int mbedtls_ecp_tls_read_group( mbedtls_ecp_group *grp,
  *                  recognized.
  * \return          Another negative error code on other kinds of failure.
  */
-int mbedtls_ecp_tls_read_group_id( mbedtls_ecp_group_id *grp,
+MBEDCRYPTO_EXPORT int mbedtls_ecp_tls_read_group_id( mbedtls_ecp_group_id *grp,
                                    const unsigned char **buf,
                                    size_t len );
 /**
@@ -827,7 +829,7 @@ int mbedtls_ecp_tls_read_group_id( mbedtls_ecp_group_id *grp,
  *                  buffer is too small to hold the exported group.
  * \return          Another negative error code on other kinds of failure.
  */
-int mbedtls_ecp_tls_write_group( const mbedtls_ecp_group *grp,
+MBEDCRYPTO_EXPORT int mbedtls_ecp_tls_write_group( const mbedtls_ecp_group *grp,
                                  size_t *olen,
                                  unsigned char *buf, size_t blen );
 
@@ -864,7 +866,7 @@ int mbedtls_ecp_tls_write_group( const mbedtls_ecp_group *grp,
  * \return          #MBEDTLS_ERR_MPI_ALLOC_FAILED on memory-allocation failure.
  * \return          Another negative error code on other kinds of failure.
  */
-int mbedtls_ecp_mul( mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
+MBEDCRYPTO_EXPORT int mbedtls_ecp_mul( mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
              const mbedtls_mpi *m, const mbedtls_ecp_point *P,
              int (*f_rng)(void *, unsigned char *, size_t), void *p_rng );
 
@@ -898,7 +900,7 @@ int mbedtls_ecp_mul( mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
  *                  operations was reached: see \c mbedtls_ecp_set_max_ops().
  * \return          Another negative error code on other kinds of failure.
  */
-int mbedtls_ecp_mul_restartable( mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
+MBEDCRYPTO_EXPORT int mbedtls_ecp_mul_restartable( mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
              const mbedtls_mpi *m, const mbedtls_ecp_point *P,
              int (*f_rng)(void *, unsigned char *, size_t), void *p_rng,
              mbedtls_ecp_restart_ctx *rs_ctx );
@@ -932,7 +934,7 @@ int mbedtls_ecp_mul_restartable( mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
  * \return          #MBEDTLS_ERR_MPI_ALLOC_FAILED on memory-allocation failure.
  * \return          Another negative error code on other kinds of failure.
  */
-int mbedtls_ecp_muladd( mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
+MBEDCRYPTO_EXPORT int mbedtls_ecp_muladd( mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
              const mbedtls_mpi *m, const mbedtls_ecp_point *P,
              const mbedtls_mpi *n, const mbedtls_ecp_point *Q );
 
@@ -970,7 +972,7 @@ int mbedtls_ecp_muladd( mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
  *                  operations was reached: see \c mbedtls_ecp_set_max_ops().
  * \return          Another negative error code on other kinds of failure.
  */
-int mbedtls_ecp_muladd_restartable(
+MBEDCRYPTO_EXPORT int mbedtls_ecp_muladd_restartable(
              mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
              const mbedtls_mpi *m, const mbedtls_ecp_point *P,
              const mbedtls_mpi *n, const mbedtls_ecp_point *Q,
@@ -1003,7 +1005,7 @@ int mbedtls_ecp_muladd_restartable(
  *                  a valid public key for the given curve.
  * \return          Another negative error code on other kinds of failure.
  */
-int mbedtls_ecp_check_pubkey( const mbedtls_ecp_group *grp,
+MBEDCRYPTO_EXPORT int mbedtls_ecp_check_pubkey( const mbedtls_ecp_group *grp,
                               const mbedtls_ecp_point *pt );
 
 /**
@@ -1025,7 +1027,7 @@ int mbedtls_ecp_check_pubkey( const mbedtls_ecp_group *grp,
  *                  private key for the given curve.
  * \return          Another negative error code on other kinds of failure.
  */
-int mbedtls_ecp_check_privkey( const mbedtls_ecp_group *grp,
+MBEDCRYPTO_EXPORT int mbedtls_ecp_check_privkey( const mbedtls_ecp_group *grp,
                                const mbedtls_mpi *d );
 
 /**
@@ -1043,7 +1045,7 @@ int mbedtls_ecp_check_privkey( const mbedtls_ecp_group *grp,
  * \return          An \c MBEDTLS_ERR_ECP_XXX or \c MBEDTLS_MPI_XXX error code
  *                  on failure.
  */
-int mbedtls_ecp_gen_privkey( const mbedtls_ecp_group *grp,
+MBEDCRYPTO_EXPORT int mbedtls_ecp_gen_privkey( const mbedtls_ecp_group *grp,
                      mbedtls_mpi *d,
                      int (*f_rng)(void *, unsigned char *, size_t),
                      void *p_rng );
@@ -1075,7 +1077,7 @@ int mbedtls_ecp_gen_privkey( const mbedtls_ecp_group *grp,
  * \return          An \c MBEDTLS_ERR_ECP_XXX or \c MBEDTLS_MPI_XXX error code
  *                  on failure.
  */
-int mbedtls_ecp_gen_keypair_base( mbedtls_ecp_group *grp,
+MBEDCRYPTO_EXPORT int mbedtls_ecp_gen_keypair_base( mbedtls_ecp_group *grp,
                                   const mbedtls_ecp_point *G,
                                   mbedtls_mpi *d, mbedtls_ecp_point *Q,
                                   int (*f_rng)(void *, unsigned char *, size_t),
@@ -1104,7 +1106,7 @@ int mbedtls_ecp_gen_keypair_base( mbedtls_ecp_group *grp,
  * \return          An \c MBEDTLS_ERR_ECP_XXX or \c MBEDTLS_MPI_XXX error code
  *                  on failure.
  */
-int mbedtls_ecp_gen_keypair( mbedtls_ecp_group *grp, mbedtls_mpi *d,
+MBEDCRYPTO_EXPORT int mbedtls_ecp_gen_keypair( mbedtls_ecp_group *grp, mbedtls_mpi *d,
                              mbedtls_ecp_point *Q,
                              int (*f_rng)(void *, unsigned char *, size_t),
                              void *p_rng );
@@ -1122,7 +1124,7 @@ int mbedtls_ecp_gen_keypair( mbedtls_ecp_group *grp, mbedtls_mpi *d,
  * \return          An \c MBEDTLS_ERR_ECP_XXX or \c MBEDTLS_MPI_XXX error code
  *                  on failure.
  */
-int mbedtls_ecp_gen_key( mbedtls_ecp_group_id grp_id, mbedtls_ecp_keypair *key,
+MBEDCRYPTO_EXPORT int mbedtls_ecp_gen_key( mbedtls_ecp_group_id grp_id, mbedtls_ecp_keypair *key,
                          int (*f_rng)(void *, unsigned char *, size_t),
                          void *p_rng );
 
@@ -1144,7 +1146,7 @@ int mbedtls_ecp_gen_key( mbedtls_ecp_group_id grp_id, mbedtls_ecp_keypair *key,
  *                  the group is not implemented.
  * \return          Another negative error code on different kinds of failure.
  */
-int mbedtls_ecp_read_key( mbedtls_ecp_group_id grp_id, mbedtls_ecp_keypair *key,
+MBEDCRYPTO_EXPORT int mbedtls_ecp_read_key( mbedtls_ecp_group_id grp_id, mbedtls_ecp_keypair *key,
                           const unsigned char *buf, size_t buflen );
 /**
  * \brief           This function checks that the keypair objects
@@ -1163,7 +1165,7 @@ int mbedtls_ecp_read_key( mbedtls_ecp_group_id grp_id, mbedtls_ecp_keypair *key,
  * \return          An \c MBEDTLS_ERR_ECP_XXX or an \c MBEDTLS_ERR_MPI_XXX
  *                  error code on calculation failure.
  */
-int mbedtls_ecp_check_pub_priv( const mbedtls_ecp_keypair *pub,
+MBEDCRYPTO_EXPORT int mbedtls_ecp_check_pub_priv( const mbedtls_ecp_keypair *pub,
                                 const mbedtls_ecp_keypair *prv );
 
 #if defined(MBEDTLS_SELF_TEST)
@@ -1174,7 +1176,7 @@ int mbedtls_ecp_check_pub_priv( const mbedtls_ecp_keypair *pub,
  * \return         \c 0 on success.
  * \return         \c 1 on failure.
  */
-int mbedtls_ecp_self_test( int verbose );
+MBEDCRYPTO_EXPORT int mbedtls_ecp_self_test( int verbose );
 
 #endif /* MBEDTLS_SELF_TEST */
 

--- a/include/mbedtls/ecp_internal.h
+++ b/include/mbedtls/ecp_internal.h
@@ -67,6 +67,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #if defined(MBEDTLS_ECP_INTERNAL_ALT)
 
 /**
@@ -95,7 +97,7 @@ unsigned char mbedtls_internal_ecp_grp_capable( const mbedtls_ecp_group *grp );
  *
  * \return          0 if successful.
  */
-int mbedtls_internal_ecp_init( const mbedtls_ecp_group *grp );
+MBEDCRYPTO_EXPORT int mbedtls_internal_ecp_init( const mbedtls_ecp_group *grp );
 
 /**
  * \brief           Frees and deallocates the Elliptic Curve Point module
@@ -103,7 +105,7 @@ int mbedtls_internal_ecp_init( const mbedtls_ecp_group *grp );
  *
  * \param grp       The pointer to the group the module was initialised for.
  */
-void mbedtls_internal_ecp_free( const mbedtls_ecp_group *grp );
+MBEDCRYPTO_EXPORT void mbedtls_internal_ecp_free( const mbedtls_ecp_group *grp );
 
 #if defined(ECP_SHORTWEIERSTRASS)
 
@@ -123,7 +125,7 @@ void mbedtls_internal_ecp_free( const mbedtls_ecp_group *grp );
  *
  * \return          0 if successful.
  */
-int mbedtls_internal_ecp_randomize_jac( const mbedtls_ecp_group *grp,
+MBEDCRYPTO_EXPORT int mbedtls_internal_ecp_randomize_jac( const mbedtls_ecp_group *grp,
         mbedtls_ecp_point *pt, int (*f_rng)(void *, unsigned char *, size_t),
         void *p_rng );
 #endif
@@ -168,7 +170,7 @@ int mbedtls_internal_ecp_randomize_jac( const mbedtls_ecp_group *grp,
  *
  * \return          0 if successful.
  */
-int mbedtls_internal_ecp_add_mixed( const mbedtls_ecp_group *grp,
+MBEDCRYPTO_EXPORT int mbedtls_internal_ecp_add_mixed( const mbedtls_ecp_group *grp,
         mbedtls_ecp_point *R, const mbedtls_ecp_point *P,
         const mbedtls_ecp_point *Q );
 #endif
@@ -193,7 +195,7 @@ int mbedtls_internal_ecp_add_mixed( const mbedtls_ecp_group *grp,
  * \return          0 if successful.
  */
 #if defined(MBEDTLS_ECP_DOUBLE_JAC_ALT)
-int mbedtls_internal_ecp_double_jac( const mbedtls_ecp_group *grp,
+MBEDCRYPTO_EXPORT int mbedtls_internal_ecp_double_jac( const mbedtls_ecp_group *grp,
         mbedtls_ecp_point *R, const mbedtls_ecp_point *P );
 #endif
 
@@ -223,7 +225,7 @@ int mbedtls_internal_ecp_double_jac( const mbedtls_ecp_group *grp,
  *                      an error if one of the points is zero.
  */
 #if defined(MBEDTLS_ECP_NORMALIZE_JAC_MANY_ALT)
-int mbedtls_internal_ecp_normalize_jac_many( const mbedtls_ecp_group *grp,
+MBEDCRYPTO_EXPORT int mbedtls_internal_ecp_normalize_jac_many( const mbedtls_ecp_group *grp,
         mbedtls_ecp_point *T[], size_t t_len );
 #endif
 
@@ -241,7 +243,7 @@ int mbedtls_internal_ecp_normalize_jac_many( const mbedtls_ecp_group *grp,
  * \return          0 if successful.
  */
 #if defined(MBEDTLS_ECP_NORMALIZE_JAC_ALT)
-int mbedtls_internal_ecp_normalize_jac( const mbedtls_ecp_group *grp,
+MBEDCRYPTO_EXPORT int mbedtls_internal_ecp_normalize_jac( const mbedtls_ecp_group *grp,
         mbedtls_ecp_point *pt );
 #endif
 
@@ -250,7 +252,7 @@ int mbedtls_internal_ecp_normalize_jac( const mbedtls_ecp_group *grp,
 #if defined(ECP_MONTGOMERY)
 
 #if defined(MBEDTLS_ECP_DOUBLE_ADD_MXZ_ALT)
-int mbedtls_internal_ecp_double_add_mxz( const mbedtls_ecp_group *grp,
+MBEDCRYPTO_EXPORT int mbedtls_internal_ecp_double_add_mxz( const mbedtls_ecp_group *grp,
         mbedtls_ecp_point *R, mbedtls_ecp_point *S, const mbedtls_ecp_point *P,
         const mbedtls_ecp_point *Q, const mbedtls_mpi *d );
 #endif
@@ -271,7 +273,7 @@ int mbedtls_internal_ecp_double_add_mxz( const mbedtls_ecp_group *grp,
  * \return          0 if successful
  */
 #if defined(MBEDTLS_ECP_RANDOMIZE_MXZ_ALT)
-int mbedtls_internal_ecp_randomize_mxz( const mbedtls_ecp_group *grp,
+MBEDCRYPTO_EXPORT int mbedtls_internal_ecp_randomize_mxz( const mbedtls_ecp_group *grp,
         mbedtls_ecp_point *P, int (*f_rng)(void *, unsigned char *, size_t),
         void *p_rng );
 #endif
@@ -287,7 +289,7 @@ int mbedtls_internal_ecp_randomize_mxz( const mbedtls_ecp_group *grp,
  * \return          0 if successful
  */
 #if defined(MBEDTLS_ECP_NORMALIZE_MXZ_ALT)
-int mbedtls_internal_ecp_normalize_mxz( const mbedtls_ecp_group *grp,
+MBEDCRYPTO_EXPORT int mbedtls_internal_ecp_normalize_mxz( const mbedtls_ecp_group *grp,
         mbedtls_ecp_point *P );
 #endif
 

--- a/include/mbedtls/entropy.h
+++ b/include/mbedtls/entropy.h
@@ -30,6 +30,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include <stddef.h>
 
 #if defined(MBEDTLS_SHA512_C) && !defined(MBEDTLS_ENTROPY_FORCE_SHA256)
@@ -147,14 +149,14 @@ mbedtls_entropy_context;
  *
  * \param ctx       Entropy context to initialize
  */
-void mbedtls_entropy_init( mbedtls_entropy_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_entropy_init( mbedtls_entropy_context *ctx );
 
 /**
  * \brief           Free the data in the context
  *
  * \param ctx       Entropy context to free
  */
-void mbedtls_entropy_free( mbedtls_entropy_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_entropy_free( mbedtls_entropy_context *ctx );
 
 /**
  * \brief           Adds an entropy source to poll
@@ -173,7 +175,7 @@ void mbedtls_entropy_free( mbedtls_entropy_context *ctx );
  *
  * \return          0 if successful or MBEDTLS_ERR_ENTROPY_MAX_SOURCES
  */
-int mbedtls_entropy_add_source( mbedtls_entropy_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_entropy_add_source( mbedtls_entropy_context *ctx,
                         mbedtls_entropy_f_source_ptr f_source, void *p_source,
                         size_t threshold, int strong );
 
@@ -185,7 +187,7 @@ int mbedtls_entropy_add_source( mbedtls_entropy_context *ctx,
  *
  * \return          0 if successful, or MBEDTLS_ERR_ENTROPY_SOURCE_FAILED
  */
-int mbedtls_entropy_gather( mbedtls_entropy_context *ctx );
+MBEDCRYPTO_EXPORT int mbedtls_entropy_gather( mbedtls_entropy_context *ctx );
 
 /**
  * \brief           Retrieve entropy from the accumulator
@@ -198,7 +200,7 @@ int mbedtls_entropy_gather( mbedtls_entropy_context *ctx );
  *
  * \return          0 if successful, or MBEDTLS_ERR_ENTROPY_SOURCE_FAILED
  */
-int mbedtls_entropy_func( void *data, unsigned char *output, size_t len );
+MBEDCRYPTO_EXPORT int mbedtls_entropy_func( void *data, unsigned char *output, size_t len );
 
 /**
  * \brief           Add data to the accumulator manually
@@ -210,7 +212,7 @@ int mbedtls_entropy_func( void *data, unsigned char *output, size_t len );
  *
  * \return          0 if successful
  */
-int mbedtls_entropy_update_manual( mbedtls_entropy_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_entropy_update_manual( mbedtls_entropy_context *ctx,
                            const unsigned char *data, size_t len );
 
 #if defined(MBEDTLS_ENTROPY_NV_SEED)
@@ -222,7 +224,7 @@ int mbedtls_entropy_update_manual( mbedtls_entropy_context *ctx,
  *
  * \return          0 if successful
  */
-int mbedtls_entropy_update_nv_seed( mbedtls_entropy_context *ctx );
+MBEDCRYPTO_EXPORT int mbedtls_entropy_update_nv_seed( mbedtls_entropy_context *ctx );
 #endif /* MBEDTLS_ENTROPY_NV_SEED */
 
 #if defined(MBEDTLS_FS_IO)
@@ -236,7 +238,7 @@ int mbedtls_entropy_update_nv_seed( mbedtls_entropy_context *ctx );
  *                      MBEDTLS_ERR_ENTROPY_FILE_IO_ERROR on file error, or
  *                      MBEDTLS_ERR_ENTROPY_SOURCE_FAILED
  */
-int mbedtls_entropy_write_seed_file( mbedtls_entropy_context *ctx, const char *path );
+MBEDCRYPTO_EXPORT int mbedtls_entropy_write_seed_file( mbedtls_entropy_context *ctx, const char *path );
 
 /**
  * \brief               Read and update a seed file. Seed is added to this
@@ -250,7 +252,7 @@ int mbedtls_entropy_write_seed_file( mbedtls_entropy_context *ctx, const char *p
  *                      MBEDTLS_ERR_ENTROPY_FILE_IO_ERROR on file error,
  *                      MBEDTLS_ERR_ENTROPY_SOURCE_FAILED
  */
-int mbedtls_entropy_update_seed_file( mbedtls_entropy_context *ctx, const char *path );
+MBEDCRYPTO_EXPORT int mbedtls_entropy_update_seed_file( mbedtls_entropy_context *ctx, const char *path );
 #endif /* MBEDTLS_FS_IO */
 
 #if defined(MBEDTLS_SELF_TEST)
@@ -262,7 +264,7 @@ int mbedtls_entropy_update_seed_file( mbedtls_entropy_context *ctx, const char *
  *
  * \return         0 if successful, or 1 if a test failed
  */
-int mbedtls_entropy_self_test( int verbose );
+MBEDCRYPTO_EXPORT int mbedtls_entropy_self_test( int verbose );
 
 #if defined(MBEDTLS_ENTROPY_HARDWARE_ALT)
 /**
@@ -278,7 +280,7 @@ int mbedtls_entropy_self_test( int verbose );
  *
  * \return         0 if successful, or 1 if a test failed
  */
-int mbedtls_entropy_source_self_test( int verbose );
+MBEDCRYPTO_EXPORT int mbedtls_entropy_source_self_test( int verbose );
 #endif /* MBEDTLS_ENTROPY_HARDWARE_ALT */
 #endif /* MBEDTLS_SELF_TEST */
 

--- a/include/mbedtls/entropy_poll.h
+++ b/include/mbedtls/entropy_poll.h
@@ -30,6 +30,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include <stddef.h>
 
 #ifdef __cplusplus
@@ -58,7 +60,7 @@ extern "C" {
 /**
  * \brief           Platform-specific entropy poll callback
  */
-int mbedtls_platform_entropy_poll( void *data,
+MBEDCRYPTO_EXPORT int mbedtls_platform_entropy_poll( void *data,
                            unsigned char *output, size_t len, size_t *olen );
 #endif
 
@@ -68,7 +70,7 @@ int mbedtls_platform_entropy_poll( void *data,
  *
  * Requires an HAVEGE state as its data pointer.
  */
-int mbedtls_havege_poll( void *data,
+MBEDCRYPTO_EXPORT int mbedtls_havege_poll( void *data,
                  unsigned char *output, size_t len, size_t *olen );
 #endif
 
@@ -76,7 +78,7 @@ int mbedtls_havege_poll( void *data,
 /**
  * \brief           mbedtls_timing_hardclock-based entropy poll callback
  */
-int mbedtls_hardclock_poll( void *data,
+MBEDCRYPTO_EXPORT int mbedtls_hardclock_poll( void *data,
                     unsigned char *output, size_t len, size_t *olen );
 #endif
 
@@ -89,7 +91,7 @@ int mbedtls_hardclock_poll( void *data,
  *
  * \note            This must accept NULL as its first argument.
  */
-int mbedtls_hardware_poll( void *data,
+MBEDCRYPTO_EXPORT int mbedtls_hardware_poll( void *data,
                            unsigned char *output, size_t len, size_t *olen );
 #endif
 
@@ -99,7 +101,7 @@ int mbedtls_hardware_poll( void *data,
  *
  * \note            This must accept NULL as its first argument.
  */
-int mbedtls_nv_seed_poll( void *data,
+MBEDCRYPTO_EXPORT int mbedtls_nv_seed_poll( void *data,
                           unsigned char *output, size_t len, size_t *olen );
 #endif
 

--- a/include/mbedtls/error.h
+++ b/include/mbedtls/error.h
@@ -30,6 +30,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include <stddef.h>
 
 /**
@@ -121,7 +123,7 @@ extern "C" {
  * \param buffer    buffer to place representation in
  * \param buflen    length of the buffer
  */
-void mbedtls_strerror( int errnum, char *buffer, size_t buflen );
+MBEDCRYPTO_EXPORT void mbedtls_strerror( int errnum, char *buffer, size_t buflen );
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/export.h
+++ b/include/mbedtls/export.h
@@ -1,0 +1,73 @@
+/**
+ * \file export.h
+ *
+ * \brief Handles export macros
+ */
+/*
+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  This file is part of mbed TLS (https://tls.mbed.org)
+ */
+
+#if _MSC_VER
+#define _DLL_EXPORT_FLAG __declspec(dllexport)
+#define _DLL_IMPORT_FLAG __declspec(dllimport)
+#elif __GNUC__ >= 4
+#define _DLL_EXPORT_FLAG __dllexport__ __attribute__((visibility("default")))
+#define _DLL_IMPORT_FLAG __dllimport__
+#else
+#define _DLL_EXPORT_FLAG
+#define _DLL_IMPORT_FLAG
+#endif
+
+#ifndef MBEDTLS_EXTERN
+#if defined(MAKING_SHARED_MBEDTLS) || defined(MAKING_MBEDTLS_SHARED)
+#define MBEDTLS_EXTERN _DLL_EXPORT_FLAG
+#define MBEDTLS_EXPORT _DLL_EXPORT_FLAG
+#elif defined(USING_SHARED_MBEDTLS) || defined(USING_MBEDTLS_SHARED)
+#define MBEDTLS_EXTERN _DLL_IMPORT_FLAG
+#define MBEDTLS_EXPORT _DLL_IMPORT_FLAG
+#else
+#define MBEDTLS_EXTERN extern
+#define MBEDTLS_EXPORT
+#endif
+#endif
+
+#ifndef MBEDX509_EXTERN
+#if defined(MAKING_SHARED_MBEDX509) || defined(MAKING_MBEDX509_SHARED)
+#define MBEDX509_EXTERN _DLL_EXPORT_FLAG
+#define MBEDX509_EXPORT _DLL_EXPORT_FLAG
+#elif defined(USING_SHARED_MBEDTLS) || defined(USING_MBEDTLS_SHARED)
+#define MBEDX509_EXTERN _DLL_IMPORT_FLAG
+#define MBEDX509_EXPORT _DLL_IMPORT_FLAG
+#else
+#define MBEDX509_EXTERN extern
+#define MBEDX509_EXPORT
+#endif
+#endif
+
+#ifndef MBEDCRYPTO_EXTERN
+#if defined(MAKING_SHARED_MBEDCRYPTO) || defined(MAKING_MBEDCRYPTO_SHARED)
+#define MBEDCRYPTO_EXTERN _DLL_EXPORT_FLAG
+#define MBEDCRYPTO_EXPORT _DLL_EXPORT_FLAG
+#elif defined(USING_SHARED_MBEDTLS) || defined(USING_MBEDTLS_SHARED)
+#define MBEDCRYPTO_EXTERN _DLL_IMPORT_FLAG
+#define MBEDCRYPTO_EXPORT _DLL_IMPORT_FLAG
+#else
+#define MBEDCRYPTO_EXTERN extern
+#define MBEDCRYPTO_EXPORT
+#endif
+#endif

--- a/include/mbedtls/gcm.h
+++ b/include/mbedtls/gcm.h
@@ -39,6 +39,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include "mbedtls/cipher.h"
 
 #include <stdint.h>
@@ -93,7 +95,7 @@ mbedtls_gcm_context;
  *
  * \param ctx       The GCM context to initialize. This must not be \c NULL.
  */
-void mbedtls_gcm_init( mbedtls_gcm_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_gcm_init( mbedtls_gcm_context *ctx );
 
 /**
  * \brief           This function associates a GCM context with a
@@ -111,7 +113,7 @@ void mbedtls_gcm_init( mbedtls_gcm_context *ctx );
  * \return          \c 0 on success.
  * \return          A cipher-specific error code on failure.
  */
-int mbedtls_gcm_setkey( mbedtls_gcm_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_gcm_setkey( mbedtls_gcm_context *ctx,
                         mbedtls_cipher_id_t cipher,
                         const unsigned char *key,
                         unsigned int keybits );
@@ -167,7 +169,7 @@ int mbedtls_gcm_setkey( mbedtls_gcm_context *ctx,
  *                  not valid or a cipher-specific error code if the encryption
  *                  or decryption failed.
  */
-int mbedtls_gcm_crypt_and_tag( mbedtls_gcm_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_gcm_crypt_and_tag( mbedtls_gcm_context *ctx,
                        int mode,
                        size_t length,
                        const unsigned char *iv,
@@ -212,7 +214,7 @@ int mbedtls_gcm_crypt_and_tag( mbedtls_gcm_context *ctx,
  *                  not valid or a cipher-specific error code if the decryption
  *                  failed.
  */
-int mbedtls_gcm_auth_decrypt( mbedtls_gcm_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_gcm_auth_decrypt( mbedtls_gcm_context *ctx,
                       size_t length,
                       const unsigned char *iv,
                       size_t iv_len,
@@ -240,7 +242,7 @@ int mbedtls_gcm_auth_decrypt( mbedtls_gcm_context *ctx,
  *
  * \return          \c 0 on success.
  */
-int mbedtls_gcm_starts( mbedtls_gcm_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_gcm_starts( mbedtls_gcm_context *ctx,
                 int mode,
                 const unsigned char *iv,
                 size_t iv_len,
@@ -272,7 +274,7 @@ int mbedtls_gcm_starts( mbedtls_gcm_context *ctx,
  * \return         \c 0 on success.
  * \return         #MBEDTLS_ERR_GCM_BAD_INPUT on failure.
  */
-int mbedtls_gcm_update( mbedtls_gcm_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_gcm_update( mbedtls_gcm_context *ctx,
                 size_t length,
                 const unsigned char *input,
                 unsigned char *output );
@@ -293,7 +295,7 @@ int mbedtls_gcm_update( mbedtls_gcm_context *ctx,
  * \return          \c 0 on success.
  * \return          #MBEDTLS_ERR_GCM_BAD_INPUT on failure.
  */
-int mbedtls_gcm_finish( mbedtls_gcm_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_gcm_finish( mbedtls_gcm_context *ctx,
                 unsigned char *tag,
                 size_t tag_len );
 
@@ -304,7 +306,7 @@ int mbedtls_gcm_finish( mbedtls_gcm_context *ctx,
  * \param ctx       The GCM context to clear. If this is \c NULL, the call has
  *                  no effect. Otherwise, this must be initialized.
  */
-void mbedtls_gcm_free( mbedtls_gcm_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_gcm_free( mbedtls_gcm_context *ctx );
 
 #if defined(MBEDTLS_SELF_TEST)
 
@@ -314,7 +316,7 @@ void mbedtls_gcm_free( mbedtls_gcm_context *ctx );
  * \return         \c 0 on success.
  * \return         \c 1 on failure.
  */
-int mbedtls_gcm_self_test( int verbose );
+MBEDCRYPTO_EXPORT int mbedtls_gcm_self_test( int verbose );
 
 #endif /* MBEDTLS_SELF_TEST */
 

--- a/include/mbedtls/havege.h
+++ b/include/mbedtls/havege.h
@@ -30,6 +30,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -55,14 +57,14 @@ mbedtls_havege_state;
  *
  * \param hs       HAVEGE state to be initialized
  */
-void mbedtls_havege_init( mbedtls_havege_state *hs );
+MBEDCRYPTO_EXPORT void mbedtls_havege_init( mbedtls_havege_state *hs );
 
 /**
  * \brief          Clear HAVEGE state
  *
  * \param hs       HAVEGE state to be cleared
  */
-void mbedtls_havege_free( mbedtls_havege_state *hs );
+MBEDCRYPTO_EXPORT void mbedtls_havege_free( mbedtls_havege_state *hs );
 
 /**
  * \brief          HAVEGE rand function
@@ -73,7 +75,7 @@ void mbedtls_havege_free( mbedtls_havege_state *hs );
  *
  * \return         0
  */
-int mbedtls_havege_random( void *p_rng, unsigned char *output, size_t len );
+MBEDCRYPTO_EXPORT int mbedtls_havege_random( void *p_rng, unsigned char *output, size_t len );
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/hkdf.h
+++ b/include/mbedtls/hkdf.h
@@ -33,6 +33,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include "mbedtls/md.h"
 
 /**
@@ -70,7 +72,7 @@ extern "C" {
  *  \return An MBEDTLS_ERR_MD_* error for errors returned from the underlying
  *          MD layer.
  */
-int mbedtls_hkdf( const mbedtls_md_info_t *md, const unsigned char *salt,
+MBEDCRYPTO_EXPORT int mbedtls_hkdf( const mbedtls_md_info_t *md, const unsigned char *salt,
                   size_t salt_len, const unsigned char *ikm, size_t ikm_len,
                   const unsigned char *info, size_t info_len,
                   unsigned char *okm, size_t okm_len );
@@ -99,7 +101,7 @@ int mbedtls_hkdf( const mbedtls_md_info_t *md, const unsigned char *salt,
  *  \return An MBEDTLS_ERR_MD_* error for errors returned from the underlying
  *          MD layer.
  */
-int mbedtls_hkdf_extract( const mbedtls_md_info_t *md,
+MBEDCRYPTO_EXPORT int mbedtls_hkdf_extract( const mbedtls_md_info_t *md,
                           const unsigned char *salt, size_t salt_len,
                           const unsigned char *ikm, size_t ikm_len,
                           unsigned char *prk );
@@ -130,7 +132,7 @@ int mbedtls_hkdf_extract( const mbedtls_md_info_t *md,
  *  \return An MBEDTLS_ERR_MD_* error for errors returned from the underlying
  *          MD layer.
  */
-int mbedtls_hkdf_expand( const mbedtls_md_info_t *md, const unsigned char *prk,
+MBEDCRYPTO_EXPORT int mbedtls_hkdf_expand( const mbedtls_md_info_t *md, const unsigned char *prk,
                          size_t prk_len, const unsigned char *info,
                          size_t info_len, unsigned char *okm, size_t okm_len );
 

--- a/include/mbedtls/hmac_drbg.h
+++ b/include/mbedtls/hmac_drbg.h
@@ -34,6 +34,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include "mbedtls/md.h"
 
 #if defined(MBEDTLS_THREADING_C)
@@ -115,7 +117,7 @@ typedef struct mbedtls_hmac_drbg_context
  *
  * \param ctx           HMAC_DRBG context to be initialized.
  */
-void mbedtls_hmac_drbg_init( mbedtls_hmac_drbg_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_hmac_drbg_init( mbedtls_hmac_drbg_context *ctx );
 
 /**
  * \brief               HMAC_DRBG initial seeding.
@@ -175,7 +177,7 @@ void mbedtls_hmac_drbg_init( mbedtls_hmac_drbg_context *ctx );
  * \return              #MBEDTLS_ERR_HMAC_DRBG_ENTROPY_SOURCE_FAILED
  *                      if the call to \p f_entropy failed.
  */
-int mbedtls_hmac_drbg_seed( mbedtls_hmac_drbg_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_hmac_drbg_seed( mbedtls_hmac_drbg_context *ctx,
                     const mbedtls_md_info_t * md_info,
                     int (*f_entropy)(void *, unsigned char *, size_t),
                     void *p_entropy,
@@ -200,7 +202,7 @@ int mbedtls_hmac_drbg_seed( mbedtls_hmac_drbg_context *ctx,
  * \return              #MBEDTLS_ERR_MD_ALLOC_FAILED if there was not enough
  *                      memory to allocate context data.
  */
-int mbedtls_hmac_drbg_seed_buf( mbedtls_hmac_drbg_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_hmac_drbg_seed_buf( mbedtls_hmac_drbg_context *ctx,
                         const mbedtls_md_info_t * md_info,
                         const unsigned char *data, size_t data_len );
 
@@ -217,7 +219,7 @@ int mbedtls_hmac_drbg_seed_buf( mbedtls_hmac_drbg_context *ctx,
  * \param ctx           The HMAC_DRBG context.
  * \param resistance    #MBEDTLS_HMAC_DRBG_PR_ON or #MBEDTLS_HMAC_DRBG_PR_OFF.
  */
-void mbedtls_hmac_drbg_set_prediction_resistance( mbedtls_hmac_drbg_context *ctx,
+MBEDCRYPTO_EXPORT void mbedtls_hmac_drbg_set_prediction_resistance( mbedtls_hmac_drbg_context *ctx,
                                           int resistance );
 
 /**
@@ -229,7 +231,7 @@ void mbedtls_hmac_drbg_set_prediction_resistance( mbedtls_hmac_drbg_context *ctx
  * \param ctx           The HMAC_DRBG context.
  * \param len           The amount of entropy to grab, in bytes.
  */
-void mbedtls_hmac_drbg_set_entropy_len( mbedtls_hmac_drbg_context *ctx,
+MBEDCRYPTO_EXPORT void mbedtls_hmac_drbg_set_entropy_len( mbedtls_hmac_drbg_context *ctx,
                                 size_t len );
 
 /**
@@ -244,7 +246,7 @@ void mbedtls_hmac_drbg_set_entropy_len( mbedtls_hmac_drbg_context *ctx,
  * \param ctx           The HMAC_DRBG context.
  * \param interval      The reseed interval.
  */
-void mbedtls_hmac_drbg_set_reseed_interval( mbedtls_hmac_drbg_context *ctx,
+MBEDCRYPTO_EXPORT void mbedtls_hmac_drbg_set_reseed_interval( mbedtls_hmac_drbg_context *ctx,
                                     int interval );
 
 /**
@@ -259,7 +261,7 @@ void mbedtls_hmac_drbg_set_reseed_interval( mbedtls_hmac_drbg_context *ctx,
  * \return              \c 0 on success, or an error from the underlying
  *                      hash calculation.
  */
-int mbedtls_hmac_drbg_update_ret( mbedtls_hmac_drbg_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_hmac_drbg_update_ret( mbedtls_hmac_drbg_context *ctx,
                        const unsigned char *additional, size_t add_len );
 
 /**
@@ -281,7 +283,7 @@ int mbedtls_hmac_drbg_update_ret( mbedtls_hmac_drbg_context *ctx,
  * \return              #MBEDTLS_ERR_HMAC_DRBG_ENTROPY_SOURCE_FAILED
  *                      if a call to the entropy function failed.
  */
-int mbedtls_hmac_drbg_reseed( mbedtls_hmac_drbg_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_hmac_drbg_reseed( mbedtls_hmac_drbg_context *ctx,
                       const unsigned char *additional, size_t len );
 
 /**
@@ -310,7 +312,7 @@ int mbedtls_hmac_drbg_reseed( mbedtls_hmac_drbg_context *ctx,
  * \return              #MBEDTLS_ERR_HMAC_DRBG_INPUT_TOO_BIG if
  *                      \p add_len > #MBEDTLS_HMAC_DRBG_MAX_INPUT.
  */
-int mbedtls_hmac_drbg_random_with_add( void *p_rng,
+MBEDCRYPTO_EXPORT int mbedtls_hmac_drbg_random_with_add( void *p_rng,
                                unsigned char *output, size_t output_len,
                                const unsigned char *additional,
                                size_t add_len );
@@ -333,14 +335,14 @@ int mbedtls_hmac_drbg_random_with_add( void *p_rng,
  * \return              #MBEDTLS_ERR_HMAC_DRBG_REQUEST_TOO_BIG if
  *                      \p out_len > #MBEDTLS_HMAC_DRBG_MAX_REQUEST.
  */
-int mbedtls_hmac_drbg_random( void *p_rng, unsigned char *output, size_t out_len );
+MBEDCRYPTO_EXPORT int mbedtls_hmac_drbg_random( void *p_rng, unsigned char *output, size_t out_len );
 
 /**
  * \brief               Free an HMAC_DRBG context
  *
  * \param ctx           The HMAC_DRBG context to free.
  */
-void mbedtls_hmac_drbg_free( mbedtls_hmac_drbg_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_hmac_drbg_free( mbedtls_hmac_drbg_context *ctx );
 
 #if ! defined(MBEDTLS_DEPRECATED_REMOVED)
 #if defined(MBEDTLS_DEPRECATED_WARNING)
@@ -378,7 +380,7 @@ MBEDTLS_DEPRECATED void mbedtls_hmac_drbg_update(
  * \return              #MBEDTLS_ERR_HMAC_DRBG_ENTROPY_SOURCE_FAILED on reseed
  *                      failure.
  */
-int mbedtls_hmac_drbg_write_seed_file( mbedtls_hmac_drbg_context *ctx, const char *path );
+MBEDCRYPTO_EXPORT int mbedtls_hmac_drbg_write_seed_file( mbedtls_hmac_drbg_context *ctx, const char *path );
 
 /**
  * \brief               This function reads and updates a seed file. The seed
@@ -394,7 +396,7 @@ int mbedtls_hmac_drbg_write_seed_file( mbedtls_hmac_drbg_context *ctx, const cha
  * \return              #MBEDTLS_ERR_HMAC_DRBG_INPUT_TOO_BIG if the existing
  *                      seed file is too large.
  */
-int mbedtls_hmac_drbg_update_seed_file( mbedtls_hmac_drbg_context *ctx, const char *path );
+MBEDCRYPTO_EXPORT int mbedtls_hmac_drbg_update_seed_file( mbedtls_hmac_drbg_context *ctx, const char *path );
 #endif /* MBEDTLS_FS_IO */
 
 
@@ -405,7 +407,7 @@ int mbedtls_hmac_drbg_update_seed_file( mbedtls_hmac_drbg_context *ctx, const ch
  * \return              \c 0 if successful.
  * \return              \c 1 if the test failed.
  */
-int mbedtls_hmac_drbg_self_test( int verbose );
+MBEDCRYPTO_EXPORT int mbedtls_hmac_drbg_self_test( int verbose );
 #endif
 
 #ifdef __cplusplus

--- a/include/mbedtls/md.h
+++ b/include/mbedtls/md.h
@@ -35,6 +35,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #define MBEDTLS_ERR_MD_FEATURE_UNAVAILABLE                -0x5080  /**< The selected feature is not available. */
 #define MBEDTLS_ERR_MD_BAD_INPUT_DATA                     -0x5100  /**< Bad input parameters to function. */
 #define MBEDTLS_ERR_MD_ALLOC_FAILED                       -0x5180  /**< Failed to allocate memory. */
@@ -109,7 +111,7 @@ typedef struct mbedtls_md_context_t
  *                  message-digest enumeration #mbedtls_md_type_t.
  *                  The last entry is 0.
  */
-const int *mbedtls_md_list( void );
+MBEDCRYPTO_EXPORT const int *mbedtls_md_list( void );
 
 /**
  * \brief           This function returns the message-digest information
@@ -120,7 +122,7 @@ const int *mbedtls_md_list( void );
  * \return          The message-digest information associated with \p md_name.
  * \return          NULL if the associated message-digest information is not found.
  */
-const mbedtls_md_info_t *mbedtls_md_info_from_string( const char *md_name );
+MBEDCRYPTO_EXPORT const mbedtls_md_info_t *mbedtls_md_info_from_string( const char *md_name );
 
 /**
  * \brief           This function returns the message-digest information
@@ -131,7 +133,7 @@ const mbedtls_md_info_t *mbedtls_md_info_from_string( const char *md_name );
  * \return          The message-digest information associated with \p md_type.
  * \return          NULL if the associated message-digest information is not found.
  */
-const mbedtls_md_info_t *mbedtls_md_info_from_type( mbedtls_md_type_t md_type );
+MBEDCRYPTO_EXPORT const mbedtls_md_info_t *mbedtls_md_info_from_type( mbedtls_md_type_t md_type );
 
 /**
  * \brief           This function initializes a message-digest context without
@@ -141,7 +143,7 @@ const mbedtls_md_info_t *mbedtls_md_info_from_type( mbedtls_md_type_t md_type );
  *                  context for mbedtls_md_setup() for binding it to a
  *                  message-digest algorithm.
  */
-void mbedtls_md_init( mbedtls_md_context_t *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_md_init( mbedtls_md_context_t *ctx );
 
 /**
  * \brief           This function clears the internal structure of \p ctx and
@@ -156,7 +158,7 @@ void mbedtls_md_init( mbedtls_md_context_t *ctx );
  *                  You must not call this function if you have not called
  *                  mbedtls_md_init().
  */
-void mbedtls_md_free( mbedtls_md_context_t *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_md_free( mbedtls_md_context_t *ctx );
 
 #if ! defined(MBEDTLS_DEPRECATED_REMOVED)
 #if defined(MBEDTLS_DEPRECATED_WARNING)
@@ -182,7 +184,7 @@ void mbedtls_md_free( mbedtls_md_context_t *ctx );
  *                  failure.
  * \return          #MBEDTLS_ERR_MD_ALLOC_FAILED on memory-allocation failure.
  */
-int mbedtls_md_init_ctx( mbedtls_md_context_t *ctx, const mbedtls_md_info_t *md_info ) MBEDTLS_DEPRECATED;
+MBEDCRYPTO_EXPORT int mbedtls_md_init_ctx( mbedtls_md_context_t *ctx, const mbedtls_md_info_t *md_info ) MBEDTLS_DEPRECATED;
 #undef MBEDTLS_DEPRECATED
 #endif /* MBEDTLS_DEPRECATED_REMOVED */
 
@@ -205,7 +207,7 @@ int mbedtls_md_init_ctx( mbedtls_md_context_t *ctx, const mbedtls_md_info_t *md_
  *                  failure.
  * \return          #MBEDTLS_ERR_MD_ALLOC_FAILED on memory-allocation failure.
  */
-int mbedtls_md_setup( mbedtls_md_context_t *ctx, const mbedtls_md_info_t *md_info, int hmac );
+MBEDCRYPTO_EXPORT int mbedtls_md_setup( mbedtls_md_context_t *ctx, const mbedtls_md_info_t *md_info, int hmac );
 
 /**
  * \brief           This function clones the state of an message-digest
@@ -226,7 +228,7 @@ int mbedtls_md_setup( mbedtls_md_context_t *ctx, const mbedtls_md_info_t *md_inf
  * \return          \c 0 on success.
  * \return          #MBEDTLS_ERR_MD_BAD_INPUT_DATA on parameter-verification failure.
  */
-int mbedtls_md_clone( mbedtls_md_context_t *dst,
+MBEDCRYPTO_EXPORT int mbedtls_md_clone( mbedtls_md_context_t *dst,
                       const mbedtls_md_context_t *src );
 
 /**
@@ -238,7 +240,7 @@ int mbedtls_md_clone( mbedtls_md_context_t *dst,
  *
  * \return          The size of the message-digest output in Bytes.
  */
-unsigned char mbedtls_md_get_size( const mbedtls_md_info_t *md_info );
+MBEDCRYPTO_EXPORT unsigned char mbedtls_md_get_size( const mbedtls_md_info_t *md_info );
 
 /**
  * \brief           This function extracts the message-digest type from the
@@ -249,7 +251,7 @@ unsigned char mbedtls_md_get_size( const mbedtls_md_info_t *md_info );
  *
  * \return          The type of the message digest.
  */
-mbedtls_md_type_t mbedtls_md_get_type( const mbedtls_md_info_t *md_info );
+MBEDCRYPTO_EXPORT mbedtls_md_type_t mbedtls_md_get_type( const mbedtls_md_info_t *md_info );
 
 /**
  * \brief           This function extracts the message-digest name from the
@@ -260,7 +262,7 @@ mbedtls_md_type_t mbedtls_md_get_type( const mbedtls_md_info_t *md_info );
  *
  * \return          The name of the message digest.
  */
-const char *mbedtls_md_get_name( const mbedtls_md_info_t *md_info );
+MBEDCRYPTO_EXPORT const char *mbedtls_md_get_name( const mbedtls_md_info_t *md_info );
 
 /**
  * \brief           This function starts a message-digest computation.
@@ -275,7 +277,7 @@ const char *mbedtls_md_get_name( const mbedtls_md_info_t *md_info );
  * \return          #MBEDTLS_ERR_MD_BAD_INPUT_DATA on parameter-verification
  *                  failure.
  */
-int mbedtls_md_starts( mbedtls_md_context_t *ctx );
+MBEDCRYPTO_EXPORT int mbedtls_md_starts( mbedtls_md_context_t *ctx );
 
 /**
  * \brief           This function feeds an input buffer into an ongoing
@@ -293,7 +295,7 @@ int mbedtls_md_starts( mbedtls_md_context_t *ctx );
  * \return          #MBEDTLS_ERR_MD_BAD_INPUT_DATA on parameter-verification
  *                  failure.
  */
-int mbedtls_md_update( mbedtls_md_context_t *ctx, const unsigned char *input, size_t ilen );
+MBEDCRYPTO_EXPORT int mbedtls_md_update( mbedtls_md_context_t *ctx, const unsigned char *input, size_t ilen );
 
 /**
  * \brief           This function finishes the digest operation,
@@ -313,7 +315,7 @@ int mbedtls_md_update( mbedtls_md_context_t *ctx, const unsigned char *input, si
  * \return          #MBEDTLS_ERR_MD_BAD_INPUT_DATA on parameter-verification
  *                  failure.
  */
-int mbedtls_md_finish( mbedtls_md_context_t *ctx, unsigned char *output );
+MBEDCRYPTO_EXPORT int mbedtls_md_finish( mbedtls_md_context_t *ctx, unsigned char *output );
 
 /**
  * \brief          This function calculates the message-digest of a buffer,
@@ -333,7 +335,7 @@ int mbedtls_md_finish( mbedtls_md_context_t *ctx, unsigned char *output );
  * \return         #MBEDTLS_ERR_MD_BAD_INPUT_DATA on parameter-verification
  *                 failure.
  */
-int mbedtls_md( const mbedtls_md_info_t *md_info, const unsigned char *input, size_t ilen,
+MBEDCRYPTO_EXPORT int mbedtls_md( const mbedtls_md_info_t *md_info, const unsigned char *input, size_t ilen,
         unsigned char *output );
 
 #if defined(MBEDTLS_FS_IO)
@@ -354,7 +356,7 @@ int mbedtls_md( const mbedtls_md_info_t *md_info, const unsigned char *input, si
  *                 the file pointed by \p path.
  * \return         #MBEDTLS_ERR_MD_BAD_INPUT_DATA if \p md_info was NULL.
  */
-int mbedtls_md_file( const mbedtls_md_info_t *md_info, const char *path,
+MBEDCRYPTO_EXPORT int mbedtls_md_file( const mbedtls_md_info_t *md_info, const char *path,
                      unsigned char *output );
 #endif /* MBEDTLS_FS_IO */
 
@@ -376,7 +378,7 @@ int mbedtls_md_file( const mbedtls_md_info_t *md_info, const char *path,
  * \return          #MBEDTLS_ERR_MD_BAD_INPUT_DATA on parameter-verification
  *                  failure.
  */
-int mbedtls_md_hmac_starts( mbedtls_md_context_t *ctx, const unsigned char *key,
+MBEDCRYPTO_EXPORT int mbedtls_md_hmac_starts( mbedtls_md_context_t *ctx, const unsigned char *key,
                     size_t keylen );
 
 /**
@@ -398,7 +400,7 @@ int mbedtls_md_hmac_starts( mbedtls_md_context_t *ctx, const unsigned char *key,
  * \return          #MBEDTLS_ERR_MD_BAD_INPUT_DATA on parameter-verification
  *                  failure.
  */
-int mbedtls_md_hmac_update( mbedtls_md_context_t *ctx, const unsigned char *input,
+MBEDCRYPTO_EXPORT int mbedtls_md_hmac_update( mbedtls_md_context_t *ctx, const unsigned char *input,
                     size_t ilen );
 
 /**
@@ -419,7 +421,7 @@ int mbedtls_md_hmac_update( mbedtls_md_context_t *ctx, const unsigned char *inpu
  * \return          #MBEDTLS_ERR_MD_BAD_INPUT_DATA on parameter-verification
  *                  failure.
  */
-int mbedtls_md_hmac_finish( mbedtls_md_context_t *ctx, unsigned char *output);
+MBEDCRYPTO_EXPORT int mbedtls_md_hmac_finish( mbedtls_md_context_t *ctx, unsigned char *output);
 
 /**
  * \brief           This function prepares to authenticate a new message with
@@ -436,7 +438,7 @@ int mbedtls_md_hmac_finish( mbedtls_md_context_t *ctx, unsigned char *output);
  * \return          #MBEDTLS_ERR_MD_BAD_INPUT_DATA on parameter-verification
  *                  failure.
  */
-int mbedtls_md_hmac_reset( mbedtls_md_context_t *ctx );
+MBEDCRYPTO_EXPORT int mbedtls_md_hmac_reset( mbedtls_md_context_t *ctx );
 
 /**
  * \brief          This function calculates the full generic HMAC
@@ -460,12 +462,12 @@ int mbedtls_md_hmac_reset( mbedtls_md_context_t *ctx );
  * \return         #MBEDTLS_ERR_MD_BAD_INPUT_DATA on parameter-verification
  *                 failure.
  */
-int mbedtls_md_hmac( const mbedtls_md_info_t *md_info, const unsigned char *key, size_t keylen,
+MBEDCRYPTO_EXPORT int mbedtls_md_hmac( const mbedtls_md_info_t *md_info, const unsigned char *key, size_t keylen,
                 const unsigned char *input, size_t ilen,
                 unsigned char *output );
 
 /* Internal use */
-int mbedtls_md_process( mbedtls_md_context_t *ctx, const unsigned char *data );
+MBEDCRYPTO_EXPORT int mbedtls_md_process( mbedtls_md_context_t *ctx, const unsigned char *data );
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/md2.h
+++ b/include/mbedtls/md2.h
@@ -35,6 +35,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include <stddef.h>
 
 /* MBEDTLS_ERR_MD2_HW_ACCEL_FAILED is deprecated and should not be used. */
@@ -79,7 +81,7 @@ mbedtls_md2_context;
  *                 stronger message digests instead.
  *
  */
-void mbedtls_md2_init( mbedtls_md2_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_md2_init( mbedtls_md2_context *ctx );
 
 /**
  * \brief          Clear MD2 context
@@ -91,7 +93,7 @@ void mbedtls_md2_init( mbedtls_md2_context *ctx );
  *                 stronger message digests instead.
  *
  */
-void mbedtls_md2_free( mbedtls_md2_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_md2_free( mbedtls_md2_context *ctx );
 
 /**
  * \brief          Clone (the state of) an MD2 context
@@ -104,7 +106,7 @@ void mbedtls_md2_free( mbedtls_md2_context *ctx );
  *                 stronger message digests instead.
  *
  */
-void mbedtls_md2_clone( mbedtls_md2_context *dst,
+MBEDCRYPTO_EXPORT void mbedtls_md2_clone( mbedtls_md2_context *dst,
                         const mbedtls_md2_context *src );
 
 /**
@@ -119,7 +121,7 @@ void mbedtls_md2_clone( mbedtls_md2_context *dst,
  *                 stronger message digests instead.
  *
  */
-int mbedtls_md2_starts_ret( mbedtls_md2_context *ctx );
+MBEDCRYPTO_EXPORT int mbedtls_md2_starts_ret( mbedtls_md2_context *ctx );
 
 /**
  * \brief          MD2 process buffer
@@ -135,7 +137,7 @@ int mbedtls_md2_starts_ret( mbedtls_md2_context *ctx );
  *                 stronger message digests instead.
  *
  */
-int mbedtls_md2_update_ret( mbedtls_md2_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_md2_update_ret( mbedtls_md2_context *ctx,
                             const unsigned char *input,
                             size_t ilen );
 
@@ -152,7 +154,7 @@ int mbedtls_md2_update_ret( mbedtls_md2_context *ctx,
  *                 stronger message digests instead.
  *
  */
-int mbedtls_md2_finish_ret( mbedtls_md2_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_md2_finish_ret( mbedtls_md2_context *ctx,
                             unsigned char output[16] );
 
 /**
@@ -167,7 +169,7 @@ int mbedtls_md2_finish_ret( mbedtls_md2_context *ctx,
  *                 stronger message digests instead.
  *
  */
-int mbedtls_internal_md2_process( mbedtls_md2_context *ctx );
+MBEDCRYPTO_EXPORT int mbedtls_internal_md2_process( mbedtls_md2_context *ctx );
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
 #if defined(MBEDTLS_DEPRECATED_WARNING)
@@ -252,7 +254,7 @@ MBEDTLS_DEPRECATED void mbedtls_md2_process( mbedtls_md2_context *ctx );
  *                 stronger message digests instead.
  *
  */
-int mbedtls_md2_ret( const unsigned char *input,
+MBEDCRYPTO_EXPORT int mbedtls_md2_ret( const unsigned char *input,
                      size_t ilen,
                      unsigned char output[16] );
 
@@ -295,7 +297,7 @@ MBEDTLS_DEPRECATED void mbedtls_md2( const unsigned char *input,
  *                 stronger message digests instead.
  *
  */
-int mbedtls_md2_self_test( int verbose );
+MBEDCRYPTO_EXPORT int mbedtls_md2_self_test( int verbose );
 
 #endif /* MBEDTLS_SELF_TEST */
 

--- a/include/mbedtls/md4.h
+++ b/include/mbedtls/md4.h
@@ -35,6 +35,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -79,7 +81,7 @@ mbedtls_md4_context;
  *                 stronger message digests instead.
  *
  */
-void mbedtls_md4_init( mbedtls_md4_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_md4_init( mbedtls_md4_context *ctx );
 
 /**
  * \brief          Clear MD4 context
@@ -91,7 +93,7 @@ void mbedtls_md4_init( mbedtls_md4_context *ctx );
  *                 stronger message digests instead.
  *
  */
-void mbedtls_md4_free( mbedtls_md4_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_md4_free( mbedtls_md4_context *ctx );
 
 /**
  * \brief          Clone (the state of) an MD4 context
@@ -104,7 +106,7 @@ void mbedtls_md4_free( mbedtls_md4_context *ctx );
  *                 stronger message digests instead.
  *
  */
-void mbedtls_md4_clone( mbedtls_md4_context *dst,
+MBEDCRYPTO_EXPORT void mbedtls_md4_clone( mbedtls_md4_context *dst,
                         const mbedtls_md4_context *src );
 
 /**
@@ -118,7 +120,7 @@ void mbedtls_md4_clone( mbedtls_md4_context *dst,
  *                 constitutes a security risk. We recommend considering
  *                 stronger message digests instead.
  */
-int mbedtls_md4_starts_ret( mbedtls_md4_context *ctx );
+MBEDCRYPTO_EXPORT int mbedtls_md4_starts_ret( mbedtls_md4_context *ctx );
 
 /**
  * \brief          MD4 process buffer
@@ -134,7 +136,7 @@ int mbedtls_md4_starts_ret( mbedtls_md4_context *ctx );
  *                 stronger message digests instead.
  *
  */
-int mbedtls_md4_update_ret( mbedtls_md4_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_md4_update_ret( mbedtls_md4_context *ctx,
                             const unsigned char *input,
                             size_t ilen );
 
@@ -151,7 +153,7 @@ int mbedtls_md4_update_ret( mbedtls_md4_context *ctx,
  *                 stronger message digests instead.
  *
  */
-int mbedtls_md4_finish_ret( mbedtls_md4_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_md4_finish_ret( mbedtls_md4_context *ctx,
                             unsigned char output[16] );
 
 /**
@@ -167,7 +169,7 @@ int mbedtls_md4_finish_ret( mbedtls_md4_context *ctx,
  *                 stronger message digests instead.
  *
  */
-int mbedtls_internal_md4_process( mbedtls_md4_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_internal_md4_process( mbedtls_md4_context *ctx,
                                   const unsigned char data[64] );
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
@@ -257,7 +259,7 @@ MBEDTLS_DEPRECATED void mbedtls_md4_process( mbedtls_md4_context *ctx,
  *                 stronger message digests instead.
  *
  */
-int mbedtls_md4_ret( const unsigned char *input,
+MBEDCRYPTO_EXPORT int mbedtls_md4_ret( const unsigned char *input,
                      size_t ilen,
                      unsigned char output[16] );
 
@@ -300,7 +302,7 @@ MBEDTLS_DEPRECATED void mbedtls_md4( const unsigned char *input,
  *                 stronger message digests instead.
  *
  */
-int mbedtls_md4_self_test( int verbose );
+MBEDCRYPTO_EXPORT int mbedtls_md4_self_test( int verbose );
 
 #endif /* MBEDTLS_SELF_TEST */
 

--- a/include/mbedtls/md5.h
+++ b/include/mbedtls/md5.h
@@ -34,6 +34,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -78,7 +80,7 @@ mbedtls_md5_context;
  *                 stronger message digests instead.
  *
  */
-void mbedtls_md5_init( mbedtls_md5_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_md5_init( mbedtls_md5_context *ctx );
 
 /**
  * \brief          Clear MD5 context
@@ -90,7 +92,7 @@ void mbedtls_md5_init( mbedtls_md5_context *ctx );
  *                 stronger message digests instead.
  *
  */
-void mbedtls_md5_free( mbedtls_md5_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_md5_free( mbedtls_md5_context *ctx );
 
 /**
  * \brief          Clone (the state of) an MD5 context
@@ -103,7 +105,7 @@ void mbedtls_md5_free( mbedtls_md5_context *ctx );
  *                 stronger message digests instead.
  *
  */
-void mbedtls_md5_clone( mbedtls_md5_context *dst,
+MBEDCRYPTO_EXPORT void mbedtls_md5_clone( mbedtls_md5_context *dst,
                         const mbedtls_md5_context *src );
 
 /**
@@ -118,7 +120,7 @@ void mbedtls_md5_clone( mbedtls_md5_context *dst,
  *                 stronger message digests instead.
  *
  */
-int mbedtls_md5_starts_ret( mbedtls_md5_context *ctx );
+MBEDCRYPTO_EXPORT int mbedtls_md5_starts_ret( mbedtls_md5_context *ctx );
 
 /**
  * \brief          MD5 process buffer
@@ -134,7 +136,7 @@ int mbedtls_md5_starts_ret( mbedtls_md5_context *ctx );
  *                 stronger message digests instead.
  *
  */
-int mbedtls_md5_update_ret( mbedtls_md5_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_md5_update_ret( mbedtls_md5_context *ctx,
                             const unsigned char *input,
                             size_t ilen );
 
@@ -151,7 +153,7 @@ int mbedtls_md5_update_ret( mbedtls_md5_context *ctx,
  *                 stronger message digests instead.
  *
  */
-int mbedtls_md5_finish_ret( mbedtls_md5_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_md5_finish_ret( mbedtls_md5_context *ctx,
                             unsigned char output[16] );
 
 /**
@@ -167,7 +169,7 @@ int mbedtls_md5_finish_ret( mbedtls_md5_context *ctx,
  *                 stronger message digests instead.
  *
  */
-int mbedtls_internal_md5_process( mbedtls_md5_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_internal_md5_process( mbedtls_md5_context *ctx,
                                   const unsigned char data[64] );
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
@@ -257,7 +259,7 @@ MBEDTLS_DEPRECATED void mbedtls_md5_process( mbedtls_md5_context *ctx,
  *                 stronger message digests instead.
  *
  */
-int mbedtls_md5_ret( const unsigned char *input,
+MBEDCRYPTO_EXPORT int mbedtls_md5_ret( const unsigned char *input,
                      size_t ilen,
                      unsigned char output[16] );
 
@@ -300,7 +302,7 @@ MBEDTLS_DEPRECATED void mbedtls_md5( const unsigned char *input,
  *                 stronger message digests instead.
  *
  */
-int mbedtls_md5_self_test( int verbose );
+MBEDCRYPTO_EXPORT int mbedtls_md5_self_test( int verbose );
 
 #endif /* MBEDTLS_SELF_TEST */
 

--- a/include/mbedtls/memory_buffer_alloc.h
+++ b/include/mbedtls/memory_buffer_alloc.h
@@ -30,6 +30,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include <stddef.h>
 
 /**
@@ -70,12 +72,12 @@ extern "C" {
  * \param buf   buffer to use as heap
  * \param len   size of the buffer
  */
-void mbedtls_memory_buffer_alloc_init( unsigned char *buf, size_t len );
+MBEDCRYPTO_EXPORT void mbedtls_memory_buffer_alloc_init( unsigned char *buf, size_t len );
 
 /**
  * \brief   Free the mutex for thread-safety and clear remaining memory
  */
-void mbedtls_memory_buffer_alloc_free( void );
+MBEDCRYPTO_EXPORT void mbedtls_memory_buffer_alloc_free( void );
 
 /**
  * \brief   Determine when the allocator should automatically verify the state
@@ -85,7 +87,7 @@ void mbedtls_memory_buffer_alloc_free( void );
  * \param verify    One of MBEDTLS_MEMORY_VERIFY_NONE, MBEDTLS_MEMORY_VERIFY_ALLOC,
  *                  MBEDTLS_MEMORY_VERIFY_FREE or MBEDTLS_MEMORY_VERIFY_ALWAYS
  */
-void mbedtls_memory_buffer_set_verify( int verify );
+MBEDCRYPTO_EXPORT void mbedtls_memory_buffer_set_verify( int verify );
 
 #if defined(MBEDTLS_MEMORY_DEBUG)
 /**
@@ -94,7 +96,7 @@ void mbedtls_memory_buffer_set_verify( int verify );
  *          Prints out a list of 'still allocated' blocks and their stack
  *          trace if MBEDTLS_MEMORY_BACKTRACE is defined.
  */
-void mbedtls_memory_buffer_alloc_status( void );
+MBEDCRYPTO_EXPORT void mbedtls_memory_buffer_alloc_status( void );
 
 /**
  * \brief   Get the peak heap usage so far
@@ -104,12 +106,12 @@ void mbedtls_memory_buffer_alloc_status( void );
  *                      into smaller blocks but larger than the requested size.
  * \param max_blocks    Peak number of blocks in use, including free and used
  */
-void mbedtls_memory_buffer_alloc_max_get( size_t *max_used, size_t *max_blocks );
+MBEDCRYPTO_EXPORT void mbedtls_memory_buffer_alloc_max_get( size_t *max_used, size_t *max_blocks );
 
 /**
  * \brief   Reset peak statistics
  */
-void mbedtls_memory_buffer_alloc_max_reset( void );
+MBEDCRYPTO_EXPORT void mbedtls_memory_buffer_alloc_max_reset( void );
 
 /**
  * \brief   Get the current heap usage
@@ -119,7 +121,7 @@ void mbedtls_memory_buffer_alloc_max_reset( void );
  *                      into smaller blocks but larger than the requested size.
  * \param cur_blocks    Current number of blocks in use, including free and used
  */
-void mbedtls_memory_buffer_alloc_cur_get( size_t *cur_used, size_t *cur_blocks );
+MBEDCRYPTO_EXPORT void mbedtls_memory_buffer_alloc_cur_get( size_t *cur_used, size_t *cur_blocks );
 #endif /* MBEDTLS_MEMORY_DEBUG */
 
 /**
@@ -133,7 +135,7 @@ void mbedtls_memory_buffer_alloc_cur_get( size_t *cur_used, size_t *cur_blocks )
  *
  * \return             0 if verified, 1 otherwise
  */
-int mbedtls_memory_buffer_alloc_verify( void );
+MBEDCRYPTO_EXPORT int mbedtls_memory_buffer_alloc_verify( void );
 
 #if defined(MBEDTLS_SELF_TEST)
 /**
@@ -141,7 +143,7 @@ int mbedtls_memory_buffer_alloc_verify( void );
  *
  * \return         0 if successful, or 1 if a test failed
  */
-int mbedtls_memory_buffer_alloc_self_test( int verbose );
+MBEDCRYPTO_EXPORT int mbedtls_memory_buffer_alloc_self_test( int verbose );
 #endif
 
 #ifdef __cplusplus

--- a/include/mbedtls/nist_kw.h
+++ b/include/mbedtls/nist_kw.h
@@ -43,6 +43,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include "mbedtls/cipher.h"
 
 #ifdef __cplusplus
@@ -82,7 +84,7 @@ typedef struct {
  * \param ctx       The key wrapping context to initialize.
  *
  */
-void mbedtls_nist_kw_init( mbedtls_nist_kw_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_nist_kw_init( mbedtls_nist_kw_context *ctx );
 
 /**
  * \brief           This function initializes the key wrapping context set in the
@@ -100,7 +102,7 @@ void mbedtls_nist_kw_init( mbedtls_nist_kw_context *ctx );
  *                  which are not supported.
  * \return          cipher-specific error code on failure of the underlying cipher.
  */
-int mbedtls_nist_kw_setkey( mbedtls_nist_kw_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_nist_kw_setkey( mbedtls_nist_kw_context *ctx,
                             mbedtls_cipher_id_t cipher,
                             const unsigned char *key,
                             unsigned int keybits,
@@ -112,7 +114,7 @@ int mbedtls_nist_kw_setkey( mbedtls_nist_kw_context *ctx,
  *
  * \param ctx       The key wrapping context to clear.
  */
-void mbedtls_nist_kw_free( mbedtls_nist_kw_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_nist_kw_free( mbedtls_nist_kw_context *ctx );
 
 /**
  * \brief           This function encrypts a buffer using key wrapping.
@@ -135,7 +137,7 @@ void mbedtls_nist_kw_free( mbedtls_nist_kw_context *ctx );
  * \return          \c MBEDTLS_ERR_CIPHER_BAD_INPUT_DATA for invalid input length.
  * \return          cipher-specific error code on failure of the underlying cipher.
  */
-int mbedtls_nist_kw_wrap( mbedtls_nist_kw_context *ctx, mbedtls_nist_kw_mode_t mode,
+MBEDCRYPTO_EXPORT int mbedtls_nist_kw_wrap( mbedtls_nist_kw_context *ctx, mbedtls_nist_kw_mode_t mode,
                           const unsigned char *input, size_t in_len,
                           unsigned char *output, size_t* out_len, size_t out_size );
 
@@ -162,7 +164,7 @@ int mbedtls_nist_kw_wrap( mbedtls_nist_kw_context *ctx, mbedtls_nist_kw_mode_t m
  * \return          \c MBEDTLS_ERR_CIPHER_AUTH_FAILED for verification failure of the ciphertext.
  * \return          cipher-specific error code on failure of the underlying cipher.
  */
-int mbedtls_nist_kw_unwrap( mbedtls_nist_kw_context *ctx, mbedtls_nist_kw_mode_t mode,
+MBEDCRYPTO_EXPORT int mbedtls_nist_kw_unwrap( mbedtls_nist_kw_context *ctx, mbedtls_nist_kw_mode_t mode,
                             const unsigned char *input, size_t in_len,
                             unsigned char *output, size_t* out_len, size_t out_size);
 
@@ -174,7 +176,7 @@ int mbedtls_nist_kw_unwrap( mbedtls_nist_kw_context *ctx, mbedtls_nist_kw_mode_t
  * \return         \c 0 on success.
  * \return         \c 1 on failure.
  */
-int mbedtls_nist_kw_self_test( int verbose );
+MBEDCRYPTO_EXPORT int mbedtls_nist_kw_self_test( int verbose );
 #endif /* MBEDTLS_SELF_TEST && MBEDTLS_AES_C */
 
 #ifdef __cplusplus

--- a/include/mbedtls/oid.h
+++ b/include/mbedtls/oid.h
@@ -30,6 +30,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include "mbedtls/asn1.h"
 #include "mbedtls/pk.h"
 
@@ -458,7 +460,7 @@ typedef struct mbedtls_oid_descriptor_t
  * \return          Length of the string written (excluding final NULL) or
  *                  MBEDTLS_ERR_OID_BUF_TOO_SMALL in case of error
  */
-int mbedtls_oid_get_numeric_string( char *buf, size_t size, const mbedtls_asn1_buf *oid );
+MBEDCRYPTO_EXPORT int mbedtls_oid_get_numeric_string( char *buf, size_t size, const mbedtls_asn1_buf *oid );
 
 /**
  * \brief          Translate an X.509 extension OID into local values
@@ -468,7 +470,7 @@ int mbedtls_oid_get_numeric_string( char *buf, size_t size, const mbedtls_asn1_b
  *
  * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
  */
-int mbedtls_oid_get_x509_ext_type( const mbedtls_asn1_buf *oid, int *ext_type );
+MBEDCRYPTO_EXPORT int mbedtls_oid_get_x509_ext_type( const mbedtls_asn1_buf *oid, int *ext_type );
 
 /**
  * \brief          Translate an X.509 attribute type OID into the short name
@@ -479,7 +481,7 @@ int mbedtls_oid_get_x509_ext_type( const mbedtls_asn1_buf *oid, int *ext_type );
  *
  * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
  */
-int mbedtls_oid_get_attr_short_name( const mbedtls_asn1_buf *oid, const char **short_name );
+MBEDCRYPTO_EXPORT int mbedtls_oid_get_attr_short_name( const mbedtls_asn1_buf *oid, const char **short_name );
 
 /**
  * \brief          Translate PublicKeyAlgorithm OID into pk_type
@@ -489,7 +491,7 @@ int mbedtls_oid_get_attr_short_name( const mbedtls_asn1_buf *oid, const char **s
  *
  * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
  */
-int mbedtls_oid_get_pk_alg( const mbedtls_asn1_buf *oid, mbedtls_pk_type_t *pk_alg );
+MBEDCRYPTO_EXPORT int mbedtls_oid_get_pk_alg( const mbedtls_asn1_buf *oid, mbedtls_pk_type_t *pk_alg );
 
 /**
  * \brief          Translate pk_type into PublicKeyAlgorithm OID
@@ -500,7 +502,7 @@ int mbedtls_oid_get_pk_alg( const mbedtls_asn1_buf *oid, mbedtls_pk_type_t *pk_a
  *
  * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
  */
-int mbedtls_oid_get_oid_by_pk_alg( mbedtls_pk_type_t pk_alg,
+MBEDCRYPTO_EXPORT int mbedtls_oid_get_oid_by_pk_alg( mbedtls_pk_type_t pk_alg,
                            const char **oid, size_t *olen );
 
 #if defined(MBEDTLS_ECP_C)
@@ -512,7 +514,7 @@ int mbedtls_oid_get_oid_by_pk_alg( mbedtls_pk_type_t pk_alg,
  *
  * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
  */
-int mbedtls_oid_get_ec_grp( const mbedtls_asn1_buf *oid, mbedtls_ecp_group_id *grp_id );
+MBEDCRYPTO_EXPORT int mbedtls_oid_get_ec_grp( const mbedtls_asn1_buf *oid, mbedtls_ecp_group_id *grp_id );
 
 /**
  * \brief          Translate EC group identifier into NamedCurve OID
@@ -523,7 +525,7 @@ int mbedtls_oid_get_ec_grp( const mbedtls_asn1_buf *oid, mbedtls_ecp_group_id *g
  *
  * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
  */
-int mbedtls_oid_get_oid_by_ec_grp( mbedtls_ecp_group_id grp_id,
+MBEDCRYPTO_EXPORT int mbedtls_oid_get_oid_by_ec_grp( mbedtls_ecp_group_id grp_id,
                            const char **oid, size_t *olen );
 #endif /* MBEDTLS_ECP_C */
 
@@ -537,7 +539,7 @@ int mbedtls_oid_get_oid_by_ec_grp( mbedtls_ecp_group_id grp_id,
  *
  * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
  */
-int mbedtls_oid_get_sig_alg( const mbedtls_asn1_buf *oid,
+MBEDCRYPTO_EXPORT int mbedtls_oid_get_sig_alg( const mbedtls_asn1_buf *oid,
                      mbedtls_md_type_t *md_alg, mbedtls_pk_type_t *pk_alg );
 
 /**
@@ -548,7 +550,7 @@ int mbedtls_oid_get_sig_alg( const mbedtls_asn1_buf *oid,
  *
  * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
  */
-int mbedtls_oid_get_sig_alg_desc( const mbedtls_asn1_buf *oid, const char **desc );
+MBEDCRYPTO_EXPORT int mbedtls_oid_get_sig_alg_desc( const mbedtls_asn1_buf *oid, const char **desc );
 
 /**
  * \brief          Translate md_type and pk_type into SignatureAlgorithm OID
@@ -560,7 +562,7 @@ int mbedtls_oid_get_sig_alg_desc( const mbedtls_asn1_buf *oid, const char **desc
  *
  * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
  */
-int mbedtls_oid_get_oid_by_sig_alg( mbedtls_pk_type_t pk_alg, mbedtls_md_type_t md_alg,
+MBEDCRYPTO_EXPORT int mbedtls_oid_get_oid_by_sig_alg( mbedtls_pk_type_t pk_alg, mbedtls_md_type_t md_alg,
                             const char **oid, size_t *olen );
 
 /**
@@ -571,7 +573,7 @@ int mbedtls_oid_get_oid_by_sig_alg( mbedtls_pk_type_t pk_alg, mbedtls_md_type_t 
  *
  * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
  */
-int mbedtls_oid_get_md_alg( const mbedtls_asn1_buf *oid, mbedtls_md_type_t *md_alg );
+MBEDCRYPTO_EXPORT int mbedtls_oid_get_md_alg( const mbedtls_asn1_buf *oid, mbedtls_md_type_t *md_alg );
 
 /**
  * \brief          Translate hmac algorithm OID into md_type
@@ -581,7 +583,7 @@ int mbedtls_oid_get_md_alg( const mbedtls_asn1_buf *oid, mbedtls_md_type_t *md_a
  *
  * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
  */
-int mbedtls_oid_get_md_hmac( const mbedtls_asn1_buf *oid, mbedtls_md_type_t *md_hmac );
+MBEDCRYPTO_EXPORT int mbedtls_oid_get_md_hmac( const mbedtls_asn1_buf *oid, mbedtls_md_type_t *md_hmac );
 #endif /* MBEDTLS_MD_C */
 
 /**
@@ -592,7 +594,7 @@ int mbedtls_oid_get_md_hmac( const mbedtls_asn1_buf *oid, mbedtls_md_type_t *md_
  *
  * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
  */
-int mbedtls_oid_get_extended_key_usage( const mbedtls_asn1_buf *oid, const char **desc );
+MBEDCRYPTO_EXPORT int mbedtls_oid_get_extended_key_usage( const mbedtls_asn1_buf *oid, const char **desc );
 
 /**
  * \brief          Translate certificate policies OID into description
@@ -602,7 +604,7 @@ int mbedtls_oid_get_extended_key_usage( const mbedtls_asn1_buf *oid, const char 
  *
  * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
  */
-int mbedtls_oid_get_certificate_policies( const mbedtls_asn1_buf *oid, const char **desc );
+MBEDCRYPTO_EXPORT int mbedtls_oid_get_certificate_policies( const mbedtls_asn1_buf *oid, const char **desc );
 
 /**
  * \brief          Translate md_type into hash algorithm OID
@@ -613,7 +615,7 @@ int mbedtls_oid_get_certificate_policies( const mbedtls_asn1_buf *oid, const cha
  *
  * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
  */
-int mbedtls_oid_get_oid_by_md( mbedtls_md_type_t md_alg, const char **oid, size_t *olen );
+MBEDCRYPTO_EXPORT int mbedtls_oid_get_oid_by_md( mbedtls_md_type_t md_alg, const char **oid, size_t *olen );
 
 #if defined(MBEDTLS_CIPHER_C)
 /**
@@ -624,7 +626,7 @@ int mbedtls_oid_get_oid_by_md( mbedtls_md_type_t md_alg, const char **oid, size_
  *
  * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
  */
-int mbedtls_oid_get_cipher_alg( const mbedtls_asn1_buf *oid, mbedtls_cipher_type_t *cipher_alg );
+MBEDCRYPTO_EXPORT int mbedtls_oid_get_cipher_alg( const mbedtls_asn1_buf *oid, mbedtls_cipher_type_t *cipher_alg );
 #endif /* MBEDTLS_CIPHER_C */
 
 #if defined(MBEDTLS_PKCS12_C)
@@ -638,7 +640,7 @@ int mbedtls_oid_get_cipher_alg( const mbedtls_asn1_buf *oid, mbedtls_cipher_type
  *
  * \return         0 if successful, or MBEDTLS_ERR_OID_NOT_FOUND
  */
-int mbedtls_oid_get_pkcs12_pbe_alg( const mbedtls_asn1_buf *oid, mbedtls_md_type_t *md_alg,
+MBEDCRYPTO_EXPORT int mbedtls_oid_get_pkcs12_pbe_alg( const mbedtls_asn1_buf *oid, mbedtls_md_type_t *md_alg,
                             mbedtls_cipher_type_t *cipher_alg );
 #endif /* MBEDTLS_PKCS12_C */
 

--- a/include/mbedtls/padlock.h
+++ b/include/mbedtls/padlock.h
@@ -34,6 +34,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include "mbedtls/aes.h"
 
 #define MBEDTLS_ERR_PADLOCK_DATA_MISALIGNED               -0x0030  /**< Input data should be aligned. */
@@ -75,7 +77,7 @@ extern "C" {
  *
  * \return         1 if CPU has support for the feature, 0 otherwise
  */
-int mbedtls_padlock_has_support( int feature );
+MBEDCRYPTO_EXPORT int mbedtls_padlock_has_support( int feature );
 
 /**
  * \brief          Internal PadLock AES-ECB block en(de)cryption
@@ -90,7 +92,7 @@ int mbedtls_padlock_has_support( int feature );
  *
  * \return         0 if success, 1 if operation failed
  */
-int mbedtls_padlock_xcryptecb( mbedtls_aes_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_padlock_xcryptecb( mbedtls_aes_context *ctx,
                                int mode,
                                const unsigned char input[16],
                                unsigned char output[16] );
@@ -110,7 +112,7 @@ int mbedtls_padlock_xcryptecb( mbedtls_aes_context *ctx,
  *
  * \return         0 if success, 1 if operation failed
  */
-int mbedtls_padlock_xcryptcbc( mbedtls_aes_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_padlock_xcryptcbc( mbedtls_aes_context *ctx,
                                int mode,
                                size_t length,
                                unsigned char iv[16],

--- a/include/mbedtls/pem.h
+++ b/include/mbedtls/pem.h
@@ -30,6 +30,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include <stddef.h>
 
 /**
@@ -70,7 +72,7 @@ mbedtls_pem_context;
  *
  * \param ctx   context to be initialized
  */
-void mbedtls_pem_init( mbedtls_pem_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_pem_init( mbedtls_pem_context *ctx );
 
 /**
  * \brief       Read a buffer for PEM information and store the resulting
@@ -94,7 +96,7 @@ void mbedtls_pem_init( mbedtls_pem_context *ctx );
  *
  * \return          0 on success, or a specific PEM error code
  */
-int mbedtls_pem_read_buffer( mbedtls_pem_context *ctx, const char *header, const char *footer,
+MBEDCRYPTO_EXPORT int mbedtls_pem_read_buffer( mbedtls_pem_context *ctx, const char *header, const char *footer,
                      const unsigned char *data,
                      const unsigned char *pwd,
                      size_t pwdlen, size_t *use_len );
@@ -104,7 +106,7 @@ int mbedtls_pem_read_buffer( mbedtls_pem_context *ctx, const char *header, const
  *
  * \param ctx   context to be freed
  */
-void mbedtls_pem_free( mbedtls_pem_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_pem_free( mbedtls_pem_context *ctx );
 #endif /* MBEDTLS_PEM_PARSE_C */
 
 #if defined(MBEDTLS_PEM_WRITE_C)
@@ -134,7 +136,7 @@ void mbedtls_pem_free( mbedtls_pem_context *ctx );
  *                  the required minimum size of \p buf.
  * \return          Another PEM or BASE64 error code on other kinds of failure.
  */
-int mbedtls_pem_write_buffer( const char *header, const char *footer,
+MBEDCRYPTO_EXPORT int mbedtls_pem_write_buffer( const char *header, const char *footer,
                       const unsigned char *der_data, size_t der_len,
                       unsigned char *buf, size_t buf_len, size_t *olen );
 #endif /* MBEDTLS_PEM_WRITE_C */

--- a/include/mbedtls/pk.h
+++ b/include/mbedtls/pk.h
@@ -31,6 +31,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include "mbedtls/md.h"
 
 #if defined(MBEDTLS_RSA_C)
@@ -251,7 +253,7 @@ typedef size_t (*mbedtls_pk_rsa_alt_key_len_func)( void *ctx );
  *
  * \return          The PK info associated with the type or NULL if not found.
  */
-const mbedtls_pk_info_t *mbedtls_pk_info_from_type( mbedtls_pk_type_t pk_type );
+MBEDCRYPTO_EXPORT const mbedtls_pk_info_t *mbedtls_pk_info_from_type( mbedtls_pk_type_t pk_type );
 
 /**
  * \brief           Initialize a #mbedtls_pk_context (as NONE).
@@ -259,7 +261,7 @@ const mbedtls_pk_info_t *mbedtls_pk_info_from_type( mbedtls_pk_type_t pk_type );
  * \param ctx       The context to initialize.
  *                  This must not be \c NULL.
  */
-void mbedtls_pk_init( mbedtls_pk_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_pk_init( mbedtls_pk_context *ctx );
 
 /**
  * \brief           Free the components of a #mbedtls_pk_context.
@@ -272,7 +274,7 @@ void mbedtls_pk_init( mbedtls_pk_context *ctx );
  *                  PSA key and you still need to call psa_destroy_key()
  *                  independently if you want to destroy that key.
  */
-void mbedtls_pk_free( mbedtls_pk_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_pk_free( mbedtls_pk_context *ctx );
 
 #if defined(MBEDTLS_ECDSA_C) && defined(MBEDTLS_ECP_RESTARTABLE)
 /**
@@ -281,7 +283,7 @@ void mbedtls_pk_free( mbedtls_pk_context *ctx );
  * \param ctx       The context to initialize.
  *                  This must not be \c NULL.
  */
-void mbedtls_pk_restart_init( mbedtls_pk_restart_ctx *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_pk_restart_init( mbedtls_pk_restart_ctx *ctx );
 
 /**
  * \brief           Free the components of a restart context
@@ -289,7 +291,7 @@ void mbedtls_pk_restart_init( mbedtls_pk_restart_ctx *ctx );
  * \param ctx       The context to clear. It must have been initialized.
  *                  If this is \c NULL, this function does nothing.
  */
-void mbedtls_pk_restart_free( mbedtls_pk_restart_ctx *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_pk_restart_free( mbedtls_pk_restart_ctx *ctx );
 #endif /* MBEDTLS_ECDSA_C && MBEDTLS_ECP_RESTARTABLE */
 
 /**
@@ -307,7 +309,7 @@ void mbedtls_pk_restart_free( mbedtls_pk_restart_ctx *ctx );
  * \note            For contexts holding an RSA-alt key, use
  *                  \c mbedtls_pk_setup_rsa_alt() instead.
  */
-int mbedtls_pk_setup( mbedtls_pk_context *ctx, const mbedtls_pk_info_t *info );
+MBEDCRYPTO_EXPORT int mbedtls_pk_setup( mbedtls_pk_context *ctx, const mbedtls_pk_info_t *info );
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
 /**
@@ -338,7 +340,7 @@ int mbedtls_pk_setup( mbedtls_pk_context *ctx, const mbedtls_pk_info_t *info );
  *                  ECC key pair.
  * \return          #MBEDTLS_ERR_PK_ALLOC_FAILED on allocation failure.
  */
-int mbedtls_pk_setup_opaque( mbedtls_pk_context *ctx, const psa_key_handle_t key );
+MBEDCRYPTO_EXPORT int mbedtls_pk_setup_opaque( mbedtls_pk_context *ctx, const psa_key_handle_t key );
 #endif /* MBEDTLS_USE_PSA_CRYPTO */
 
 #if defined(MBEDTLS_PK_RSA_ALT_SUPPORT)
@@ -357,7 +359,7 @@ int mbedtls_pk_setup_opaque( mbedtls_pk_context *ctx, const psa_key_handle_t key
  *
  * \note            This function replaces \c mbedtls_pk_setup() for RSA-alt.
  */
-int mbedtls_pk_setup_rsa_alt( mbedtls_pk_context *ctx, void * key,
+MBEDCRYPTO_EXPORT int mbedtls_pk_setup_rsa_alt( mbedtls_pk_context *ctx, void * key,
                          mbedtls_pk_rsa_alt_decrypt_func decrypt_func,
                          mbedtls_pk_rsa_alt_sign_func sign_func,
                          mbedtls_pk_rsa_alt_key_len_func key_len_func );
@@ -370,7 +372,7 @@ int mbedtls_pk_setup_rsa_alt( mbedtls_pk_context *ctx, void * key,
  *
  * \return          Key size in bits, or 0 on error
  */
-size_t mbedtls_pk_get_bitlen( const mbedtls_pk_context *ctx );
+MBEDCRYPTO_EXPORT size_t mbedtls_pk_get_bitlen( const mbedtls_pk_context *ctx );
 
 /**
  * \brief           Get the length in bytes of the underlying key
@@ -396,7 +398,7 @@ static inline size_t mbedtls_pk_get_len( const mbedtls_pk_context *ctx )
  *                  been initialized but not set up, or that has been
  *                  cleared with mbedtls_pk_free().
  */
-int mbedtls_pk_can_do( const mbedtls_pk_context *ctx, mbedtls_pk_type_t type );
+MBEDCRYPTO_EXPORT int mbedtls_pk_can_do( const mbedtls_pk_context *ctx, mbedtls_pk_type_t type );
 
 /**
  * \brief           Verify signature (including padding if relevant).
@@ -422,7 +424,7 @@ int mbedtls_pk_can_do( const mbedtls_pk_context *ctx, mbedtls_pk_type_t type );
  *
  * \note            md_alg may be MBEDTLS_MD_NONE, only if hash_len != 0
  */
-int mbedtls_pk_verify( mbedtls_pk_context *ctx, mbedtls_md_type_t md_alg,
+MBEDCRYPTO_EXPORT int mbedtls_pk_verify( mbedtls_pk_context *ctx, mbedtls_md_type_t md_alg,
                const unsigned char *hash, size_t hash_len,
                const unsigned char *sig, size_t sig_len );
 
@@ -446,7 +448,7 @@ int mbedtls_pk_verify( mbedtls_pk_context *ctx, mbedtls_md_type_t md_alg,
  * \return          #MBEDTLS_ERR_ECP_IN_PROGRESS if maximum number of
  *                  operations was reached: see \c mbedtls_ecp_set_max_ops().
  */
-int mbedtls_pk_verify_restartable( mbedtls_pk_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_pk_verify_restartable( mbedtls_pk_context *ctx,
                mbedtls_md_type_t md_alg,
                const unsigned char *hash, size_t hash_len,
                const unsigned char *sig, size_t sig_len,
@@ -481,7 +483,7 @@ int mbedtls_pk_verify_restartable( mbedtls_pk_context *ctx,
  *                  to a mbedtls_pk_rsassa_pss_options structure,
  *                  otherwise it must be NULL.
  */
-int mbedtls_pk_verify_ext( mbedtls_pk_type_t type, const void *options,
+MBEDCRYPTO_EXPORT int mbedtls_pk_verify_ext( mbedtls_pk_type_t type, const void *options,
                    mbedtls_pk_context *ctx, mbedtls_md_type_t md_alg,
                    const unsigned char *hash, size_t hash_len,
                    const unsigned char *sig, size_t sig_len );
@@ -516,7 +518,7 @@ int mbedtls_pk_verify_ext( mbedtls_pk_type_t type, const void *options,
  * \note            For RSA, md_alg may be MBEDTLS_MD_NONE if hash_len != 0.
  *                  For ECDSA, md_alg may never be MBEDTLS_MD_NONE.
  */
-int mbedtls_pk_sign( mbedtls_pk_context *ctx, mbedtls_md_type_t md_alg,
+MBEDCRYPTO_EXPORT int mbedtls_pk_sign( mbedtls_pk_context *ctx, mbedtls_md_type_t md_alg,
              const unsigned char *hash, size_t hash_len,
              unsigned char *sig, size_t *sig_len,
              int (*f_rng)(void *, unsigned char *, size_t), void *p_rng );
@@ -549,7 +551,7 @@ int mbedtls_pk_sign( mbedtls_pk_context *ctx, mbedtls_md_type_t md_alg,
  * \return          #MBEDTLS_ERR_ECP_IN_PROGRESS if maximum number of
  *                  operations was reached: see \c mbedtls_ecp_set_max_ops().
  */
-int mbedtls_pk_sign_restartable( mbedtls_pk_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_pk_sign_restartable( mbedtls_pk_context *ctx,
              mbedtls_md_type_t md_alg,
              const unsigned char *hash, size_t hash_len,
              unsigned char *sig, size_t *sig_len,
@@ -573,7 +575,7 @@ int mbedtls_pk_sign_restartable( mbedtls_pk_context *ctx,
  *
  * \return          0 on success, or a specific error code.
  */
-int mbedtls_pk_decrypt( mbedtls_pk_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_pk_decrypt( mbedtls_pk_context *ctx,
                 const unsigned char *input, size_t ilen,
                 unsigned char *output, size_t *olen, size_t osize,
                 int (*f_rng)(void *, unsigned char *, size_t), void *p_rng );
@@ -594,7 +596,7 @@ int mbedtls_pk_decrypt( mbedtls_pk_context *ctx,
  *
  * \return          0 on success, or a specific error code.
  */
-int mbedtls_pk_encrypt( mbedtls_pk_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_pk_encrypt( mbedtls_pk_context *ctx,
                 const unsigned char *input, size_t ilen,
                 unsigned char *output, size_t *olen, size_t osize,
                 int (*f_rng)(void *, unsigned char *, size_t), void *p_rng );
@@ -611,7 +613,7 @@ int mbedtls_pk_encrypt( mbedtls_pk_context *ctx,
  * \return          #MBEDTLS_ERR_PK_BAD_INPUT_DATA if a context is invalid.
  * \return          Another non-zero value if the keys do not match.
  */
-int mbedtls_pk_check_pair( const mbedtls_pk_context *pub, const mbedtls_pk_context *prv );
+MBEDCRYPTO_EXPORT int mbedtls_pk_check_pair( const mbedtls_pk_context *pub, const mbedtls_pk_context *prv );
 
 /**
  * \brief           Export debug information
@@ -621,7 +623,7 @@ int mbedtls_pk_check_pair( const mbedtls_pk_context *pub, const mbedtls_pk_conte
  *
  * \return          0 on success or MBEDTLS_ERR_PK_BAD_INPUT_DATA
  */
-int mbedtls_pk_debug( const mbedtls_pk_context *ctx, mbedtls_pk_debug_item *items );
+MBEDCRYPTO_EXPORT int mbedtls_pk_debug( const mbedtls_pk_context *ctx, mbedtls_pk_debug_item *items );
 
 /**
  * \brief           Access the type name
@@ -630,7 +632,7 @@ int mbedtls_pk_debug( const mbedtls_pk_context *ctx, mbedtls_pk_debug_item *item
  *
  * \return          Type name on success, or "invalid PK"
  */
-const char * mbedtls_pk_get_name( const mbedtls_pk_context *ctx );
+MBEDCRYPTO_EXPORT const char * mbedtls_pk_get_name( const mbedtls_pk_context *ctx );
 
 /**
  * \brief           Get the key type
@@ -640,7 +642,7 @@ const char * mbedtls_pk_get_name( const mbedtls_pk_context *ctx );
  * \return          Type on success.
  * \return          #MBEDTLS_PK_NONE for a context that has not been set up.
  */
-mbedtls_pk_type_t mbedtls_pk_get_type( const mbedtls_pk_context *ctx );
+MBEDCRYPTO_EXPORT mbedtls_pk_type_t mbedtls_pk_get_type( const mbedtls_pk_context *ctx );
 
 #if defined(MBEDTLS_PK_PARSE_C)
 /** \ingroup pk_module */
@@ -672,7 +674,7 @@ mbedtls_pk_type_t mbedtls_pk_get_type( const mbedtls_pk_context *ctx );
  *
  * \return          0 if successful, or a specific PK or PEM error code
  */
-int mbedtls_pk_parse_key( mbedtls_pk_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_pk_parse_key( mbedtls_pk_context *ctx,
                   const unsigned char *key, size_t keylen,
                   const unsigned char *pwd, size_t pwdlen );
 
@@ -698,7 +700,7 @@ int mbedtls_pk_parse_key( mbedtls_pk_context *ctx,
  *
  * \return          0 if successful, or a specific PK or PEM error code
  */
-int mbedtls_pk_parse_public_key( mbedtls_pk_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_pk_parse_public_key( mbedtls_pk_context *ctx,
                          const unsigned char *key, size_t keylen );
 
 #if defined(MBEDTLS_FS_IO)
@@ -723,7 +725,7 @@ int mbedtls_pk_parse_public_key( mbedtls_pk_context *ctx,
  *
  * \return          0 if successful, or a specific PK or PEM error code
  */
-int mbedtls_pk_parse_keyfile( mbedtls_pk_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_pk_parse_keyfile( mbedtls_pk_context *ctx,
                       const char *path, const char *password );
 
 /** \ingroup pk_module */
@@ -743,7 +745,7 @@ int mbedtls_pk_parse_keyfile( mbedtls_pk_context *ctx,
  *
  * \return          0 if successful, or a specific PK or PEM error code
  */
-int mbedtls_pk_parse_public_keyfile( mbedtls_pk_context *ctx, const char *path );
+MBEDCRYPTO_EXPORT int mbedtls_pk_parse_public_keyfile( mbedtls_pk_context *ctx, const char *path );
 #endif /* MBEDTLS_FS_IO */
 #endif /* MBEDTLS_PK_PARSE_C */
 
@@ -761,7 +763,7 @@ int mbedtls_pk_parse_public_keyfile( mbedtls_pk_context *ctx, const char *path )
  * \return          length of data written if successful, or a specific
  *                  error code
  */
-int mbedtls_pk_write_key_der( mbedtls_pk_context *ctx, unsigned char *buf, size_t size );
+MBEDCRYPTO_EXPORT int mbedtls_pk_write_key_der( mbedtls_pk_context *ctx, unsigned char *buf, size_t size );
 
 /**
  * \brief           Write a public key to a SubjectPublicKeyInfo DER structure
@@ -776,7 +778,7 @@ int mbedtls_pk_write_key_der( mbedtls_pk_context *ctx, unsigned char *buf, size_
  * \return          length of data written if successful, or a specific
  *                  error code
  */
-int mbedtls_pk_write_pubkey_der( mbedtls_pk_context *ctx, unsigned char *buf, size_t size );
+MBEDCRYPTO_EXPORT int mbedtls_pk_write_pubkey_der( mbedtls_pk_context *ctx, unsigned char *buf, size_t size );
 
 #if defined(MBEDTLS_PEM_WRITE_C)
 /**
@@ -789,7 +791,7 @@ int mbedtls_pk_write_pubkey_der( mbedtls_pk_context *ctx, unsigned char *buf, si
  *
  * \return          0 if successful, or a specific error code
  */
-int mbedtls_pk_write_pubkey_pem( mbedtls_pk_context *ctx, unsigned char *buf, size_t size );
+MBEDCRYPTO_EXPORT int mbedtls_pk_write_pubkey_pem( mbedtls_pk_context *ctx, unsigned char *buf, size_t size );
 
 /**
  * \brief           Write a private key to a PKCS#1 or SEC1 PEM string
@@ -801,7 +803,7 @@ int mbedtls_pk_write_pubkey_pem( mbedtls_pk_context *ctx, unsigned char *buf, si
  *
  * \return          0 if successful, or a specific error code
  */
-int mbedtls_pk_write_key_pem( mbedtls_pk_context *ctx, unsigned char *buf, size_t size );
+MBEDCRYPTO_EXPORT int mbedtls_pk_write_key_pem( mbedtls_pk_context *ctx, unsigned char *buf, size_t size );
 #endif /* MBEDTLS_PEM_WRITE_C */
 #endif /* MBEDTLS_PK_WRITE_C */
 
@@ -821,7 +823,7 @@ int mbedtls_pk_write_key_pem( mbedtls_pk_context *ctx, unsigned char *buf, size_
  *
  * \return          0 if successful, or a specific PK error code
  */
-int mbedtls_pk_parse_subpubkey( unsigned char **p, const unsigned char *end,
+MBEDCRYPTO_EXPORT int mbedtls_pk_parse_subpubkey( unsigned char **p, const unsigned char *end,
                         mbedtls_pk_context *pk );
 #endif /* MBEDTLS_PK_PARSE_C */
 
@@ -836,7 +838,7 @@ int mbedtls_pk_parse_subpubkey( unsigned char **p, const unsigned char *end,
  *
  * \return          the length written or a negative error code
  */
-int mbedtls_pk_write_pubkey( unsigned char **p, unsigned char *start,
+MBEDCRYPTO_EXPORT int mbedtls_pk_write_pubkey( unsigned char **p, unsigned char *start,
                      const mbedtls_pk_context *key );
 #endif /* MBEDTLS_PK_WRITE_C */
 
@@ -845,7 +847,7 @@ int mbedtls_pk_write_pubkey( unsigned char **p, unsigned char *start,
  * know you do.
  */
 #if defined(MBEDTLS_FS_IO)
-int mbedtls_pk_load_file( const char *path, unsigned char **buf, size_t *n );
+MBEDCRYPTO_EXPORT int mbedtls_pk_load_file( const char *path, unsigned char **buf, size_t *n );
 #endif
 
 #if defined(MBEDTLS_USE_PSA_CRYPTO)
@@ -869,7 +871,7 @@ int mbedtls_pk_load_file( const char *path, unsigned char **buf, size_t *n );
  * \return          \c 0 if successful.
  * \return          An Mbed TLS error code otherwise.
  */
-int mbedtls_pk_wrap_as_opaque( mbedtls_pk_context *pk,
+MBEDCRYPTO_EXPORT int mbedtls_pk_wrap_as_opaque( mbedtls_pk_context *pk,
                                psa_key_handle_t *handle,
                                psa_algorithm_t hash_alg );
 #endif /* MBEDTLS_USE_PSA_CRYPTO */

--- a/include/mbedtls/pkcs12.h
+++ b/include/mbedtls/pkcs12.h
@@ -30,6 +30,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include "mbedtls/md.h"
 #include "mbedtls/cipher.h"
 #include "mbedtls/asn1.h"
@@ -68,7 +70,7 @@ extern "C" {
  *
  * \return           0 if successful, or a MBEDTLS_ERR_XXX code
  */
-int mbedtls_pkcs12_pbe_sha1_rc4_128( mbedtls_asn1_buf *pbe_params, int mode,
+MBEDCRYPTO_EXPORT int mbedtls_pkcs12_pbe_sha1_rc4_128( mbedtls_asn1_buf *pbe_params, int mode,
                              const unsigned char *pwd,  size_t pwdlen,
                              const unsigned char *input, size_t len,
                              unsigned char *output );
@@ -89,7 +91,7 @@ int mbedtls_pkcs12_pbe_sha1_rc4_128( mbedtls_asn1_buf *pbe_params, int mode,
  *
  * \return           0 if successful, or a MBEDTLS_ERR_XXX code
  */
-int mbedtls_pkcs12_pbe( mbedtls_asn1_buf *pbe_params, int mode,
+MBEDCRYPTO_EXPORT int mbedtls_pkcs12_pbe( mbedtls_asn1_buf *pbe_params, int mode,
                 mbedtls_cipher_type_t cipher_type, mbedtls_md_type_t md_type,
                 const unsigned char *pwd,  size_t pwdlen,
                 const unsigned char *input, size_t len,
@@ -118,7 +120,7 @@ int mbedtls_pkcs12_pbe( mbedtls_asn1_buf *pbe_params, int mode,
  *
  * \return          0 if successful, or a MD, BIGNUM type error.
  */
-int mbedtls_pkcs12_derivation( unsigned char *data, size_t datalen,
+MBEDCRYPTO_EXPORT int mbedtls_pkcs12_derivation( unsigned char *data, size_t datalen,
                        const unsigned char *pwd, size_t pwdlen,
                        const unsigned char *salt, size_t saltlen,
                        mbedtls_md_type_t mbedtls_md, int id, int iterations );

--- a/include/mbedtls/pkcs5.h
+++ b/include/mbedtls/pkcs5.h
@@ -32,6 +32,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include "mbedtls/asn1.h"
 #include "mbedtls/md.h"
 
@@ -65,7 +67,7 @@ extern "C" {
  *
  * \returns        0 on success, or a MBEDTLS_ERR_XXX code if verification fails.
  */
-int mbedtls_pkcs5_pbes2( const mbedtls_asn1_buf *pbe_params, int mode,
+MBEDCRYPTO_EXPORT int mbedtls_pkcs5_pbes2( const mbedtls_asn1_buf *pbe_params, int mode,
                  const unsigned char *pwd,  size_t pwdlen,
                  const unsigned char *data, size_t datalen,
                  unsigned char *output );
@@ -86,7 +88,7 @@ int mbedtls_pkcs5_pbes2( const mbedtls_asn1_buf *pbe_params, int mode,
  *
  * \returns        0 on success, or a MBEDTLS_ERR_XXX code if verification fails.
  */
-int mbedtls_pkcs5_pbkdf2_hmac( mbedtls_md_context_t *ctx, const unsigned char *password,
+MBEDCRYPTO_EXPORT int mbedtls_pkcs5_pbkdf2_hmac( mbedtls_md_context_t *ctx, const unsigned char *password,
                        size_t plen, const unsigned char *salt, size_t slen,
                        unsigned int iteration_count,
                        uint32_t key_length, unsigned char *output );
@@ -98,7 +100,7 @@ int mbedtls_pkcs5_pbkdf2_hmac( mbedtls_md_context_t *ctx, const unsigned char *p
  *
  * \return         0 if successful, or 1 if the test failed
  */
-int mbedtls_pkcs5_self_test( int verbose );
+MBEDCRYPTO_EXPORT int mbedtls_pkcs5_self_test( int verbose );
 
 #endif /* MBEDTLS_SELF_TEST */
 

--- a/include/mbedtls/platform.h
+++ b/include/mbedtls/platform.h
@@ -39,6 +39,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #if defined(MBEDTLS_HAVE_TIME)
 #include "mbedtls/platform_time.h"
 #endif
@@ -140,8 +142,8 @@ extern "C" {
 #else
 /* For size_t */
 #include <stddef.h>
-extern void *mbedtls_calloc( size_t n, size_t size );
-extern void mbedtls_free( void *ptr );
+MBEDCRYPTO_EXTERN void *mbedtls_calloc( size_t n, size_t size );
+MBEDCRYPTO_EXTERN void mbedtls_free( void *ptr );
 
 /**
  * \brief               This function dynamically sets the memory-management
@@ -152,7 +154,7 @@ extern void mbedtls_free( void *ptr );
  *
  * \return              \c 0.
  */
-int mbedtls_platform_set_calloc_free( void * (*calloc_func)( size_t, size_t ),
+MBEDCRYPTO_EXPORT int mbedtls_platform_set_calloc_free( void * (*calloc_func)( size_t, size_t ),
                               void (*free_func)( void * ) );
 #endif /* MBEDTLS_PLATFORM_FREE_MACRO && MBEDTLS_PLATFORM_CALLOC_MACRO */
 #else /* !MBEDTLS_PLATFORM_MEMORY */
@@ -166,7 +168,7 @@ int mbedtls_platform_set_calloc_free( void * (*calloc_func)( size_t, size_t ),
 #if defined(MBEDTLS_PLATFORM_FPRINTF_ALT)
 /* We need FILE * */
 #include <stdio.h>
-extern int (*mbedtls_fprintf)( FILE *stream, const char *format, ... );
+MBEDCRYPTO_EXTERN int (*mbedtls_fprintf)( FILE *stream, const char *format, ... );
 
 /**
  * \brief                This function dynamically configures the fprintf
@@ -177,7 +179,7 @@ extern int (*mbedtls_fprintf)( FILE *stream, const char *format, ... );
  *
  * \return               \c 0.
  */
-int mbedtls_platform_set_fprintf( int (*fprintf_func)( FILE *stream, const char *,
+MBEDCRYPTO_EXPORT int mbedtls_platform_set_fprintf( int (*fprintf_func)( FILE *stream, const char *,
                                                ... ) );
 #else
 #if defined(MBEDTLS_PLATFORM_FPRINTF_MACRO)
@@ -191,7 +193,7 @@ int mbedtls_platform_set_fprintf( int (*fprintf_func)( FILE *stream, const char 
  * The function pointers for printf
  */
 #if defined(MBEDTLS_PLATFORM_PRINTF_ALT)
-extern int (*mbedtls_printf)( const char *format, ... );
+MBEDCRYPTO_EXTERN int (*mbedtls_printf)( const char *format, ... );
 
 /**
  * \brief               This function dynamically configures the snprintf
@@ -202,7 +204,7 @@ extern int (*mbedtls_printf)( const char *format, ... );
  *
  * \return              \c 0 on success.
  */
-int mbedtls_platform_set_printf( int (*printf_func)( const char *, ... ) );
+MBEDCRYPTO_EXPORT int mbedtls_platform_set_printf( int (*printf_func)( const char *, ... ) );
 #else /* !MBEDTLS_PLATFORM_PRINTF_ALT */
 #if defined(MBEDTLS_PLATFORM_PRINTF_MACRO)
 #define mbedtls_printf     MBEDTLS_PLATFORM_PRINTF_MACRO
@@ -222,11 +224,11 @@ int mbedtls_platform_set_printf( int (*printf_func)( const char *, ... ) );
  */
 #if defined(MBEDTLS_PLATFORM_HAS_NON_CONFORMING_SNPRINTF)
 /* For Windows (inc. MSYS2), we provide our own fixed implementation */
-int mbedtls_platform_win32_snprintf( char *s, size_t n, const char *fmt, ... );
+MBEDCRYPTO_EXPORT int mbedtls_platform_win32_snprintf( char *s, size_t n, const char *fmt, ... );
 #endif
 
 #if defined(MBEDTLS_PLATFORM_SNPRINTF_ALT)
-extern int (*mbedtls_snprintf)( char * s, size_t n, const char * format, ... );
+MBEDCRYPTO_EXTERN int (*mbedtls_snprintf)( char * s, size_t n, const char * format, ... );
 
 /**
  * \brief                 This function allows configuring a custom
@@ -236,7 +238,7 @@ extern int (*mbedtls_snprintf)( char * s, size_t n, const char * format, ... );
  *
  * \return                \c 0 on success.
  */
-int mbedtls_platform_set_snprintf( int (*snprintf_func)( char * s, size_t n,
+MBEDCRYPTO_EXPORT int mbedtls_platform_set_snprintf( int (*snprintf_func)( char * s, size_t n,
                                                  const char * format, ... ) );
 #else /* MBEDTLS_PLATFORM_SNPRINTF_ALT */
 #if defined(MBEDTLS_PLATFORM_SNPRINTF_MACRO)
@@ -258,12 +260,12 @@ int mbedtls_platform_set_snprintf( int (*snprintf_func)( char * s, size_t n,
 #if defined(MBEDTLS_PLATFORM_HAS_NON_CONFORMING_VSNPRINTF)
 #include <stdarg.h>
 /* For Older Windows (inc. MSYS2), we provide our own fixed implementation */
-int mbedtls_platform_win32_vsnprintf( char *s, size_t n, const char *fmt, va_list arg );
+MBEDCRYPTO_EXPORT int mbedtls_platform_win32_vsnprintf( char *s, size_t n, const char *fmt, va_list arg );
 #endif
 
 #if defined(MBEDTLS_PLATFORM_VSNPRINTF_ALT)
 #include <stdarg.h>
-extern int (*mbedtls_vsnprintf)( char * s, size_t n, const char * format, va_list arg );
+MBEDCRYPTO_EXTERN int (*mbedtls_vsnprintf)( char * s, size_t n, const char * format, va_list arg );
 
 /**
  * \brief   Set your own snprintf function pointer
@@ -272,7 +274,7 @@ extern int (*mbedtls_vsnprintf)( char * s, size_t n, const char * format, va_lis
  *
  * \return  \c 0
  */
-int mbedtls_platform_set_vsnprintf( int (*vsnprintf_func)( char * s, size_t n,
+MBEDCRYPTO_EXPORT int mbedtls_platform_set_vsnprintf( int (*vsnprintf_func)( char * s, size_t n,
                                                  const char * format, va_list arg ) );
 #else /* MBEDTLS_PLATFORM_VSNPRINTF_ALT */
 #if defined(MBEDTLS_PLATFORM_VSNPRINTF_MACRO)
@@ -286,7 +288,7 @@ int mbedtls_platform_set_vsnprintf( int (*vsnprintf_func)( char * s, size_t n,
  * The function pointers for exit
  */
 #if defined(MBEDTLS_PLATFORM_EXIT_ALT)
-extern void (*mbedtls_exit)( int status );
+MBEDCRYPTO_EXTERN void (*mbedtls_exit)( int status );
 
 /**
  * \brief             This function dynamically configures the exit
@@ -297,7 +299,7 @@ extern void (*mbedtls_exit)( int status );
  *
  * \return            \c 0 on success.
  */
-int mbedtls_platform_set_exit( void (*exit_func)( int status ) );
+MBEDCRYPTO_EXPORT int mbedtls_platform_set_exit( void (*exit_func)( int status ) );
 #else
 #if defined(MBEDTLS_PLATFORM_EXIT_MACRO)
 #define mbedtls_exit   MBEDTLS_PLATFORM_EXIT_MACRO
@@ -329,13 +331,13 @@ int mbedtls_platform_set_exit( void (*exit_func)( int status ) );
 #if defined(MBEDTLS_ENTROPY_NV_SEED)
 #if !defined(MBEDTLS_PLATFORM_NO_STD_FUNCTIONS) && defined(MBEDTLS_FS_IO)
 /* Internal standard platform definitions */
-int mbedtls_platform_std_nv_seed_read( unsigned char *buf, size_t buf_len );
-int mbedtls_platform_std_nv_seed_write( unsigned char *buf, size_t buf_len );
+MBEDCRYPTO_EXPORT int mbedtls_platform_std_nv_seed_read( unsigned char *buf, size_t buf_len );
+MBEDCRYPTO_EXPORT int mbedtls_platform_std_nv_seed_write( unsigned char *buf, size_t buf_len );
 #endif
 
 #if defined(MBEDTLS_PLATFORM_NV_SEED_ALT)
-extern int (*mbedtls_nv_seed_read)( unsigned char *buf, size_t buf_len );
-extern int (*mbedtls_nv_seed_write)( unsigned char *buf, size_t buf_len );
+MBEDCRYPTO_EXTERN int (*mbedtls_nv_seed_read)( unsigned char *buf, size_t buf_len );
+MBEDCRYPTO_EXTERN int (*mbedtls_nv_seed_write)( unsigned char *buf, size_t buf_len );
 
 /**
  * \brief   This function allows configuring custom seed file writing and
@@ -346,7 +348,7 @@ extern int (*mbedtls_nv_seed_write)( unsigned char *buf, size_t buf_len );
  *
  * \return  \c 0 on success.
  */
-int mbedtls_platform_set_nv_seed(
+MBEDCRYPTO_EXPORT int mbedtls_platform_set_nv_seed(
             int (*nv_seed_read_func)( unsigned char *buf, size_t buf_len ),
             int (*nv_seed_write_func)( unsigned char *buf, size_t buf_len )
             );
@@ -395,7 +397,7 @@ mbedtls_platform_context;
  *
  * \return  \c 0 on success.
  */
-int mbedtls_platform_setup( mbedtls_platform_context *ctx );
+MBEDCRYPTO_EXPORT int mbedtls_platform_setup( mbedtls_platform_context *ctx );
 /**
  * \brief   This function performs any platform teardown operations.
  *
@@ -410,7 +412,7 @@ int mbedtls_platform_setup( mbedtls_platform_context *ctx );
  * \param   ctx     The platform context.
  *
  */
-void mbedtls_platform_teardown( mbedtls_platform_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_platform_teardown( mbedtls_platform_context *ctx );
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/platform_time.h
+++ b/include/mbedtls/platform_time.h
@@ -30,6 +30,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -66,7 +68,7 @@ extern mbedtls_time_t (*mbedtls_time)( mbedtls_time_t* time );
  *
  * \return              0
  */
-int mbedtls_platform_set_time( mbedtls_time_t (*time_func)( mbedtls_time_t* time ) );
+MBEDCRYPTO_EXPORT int mbedtls_platform_set_time( mbedtls_time_t (*time_func)( mbedtls_time_t* time ) );
 #else
 #if defined(MBEDTLS_PLATFORM_TIME_MACRO)
 #define mbedtls_time    MBEDTLS_PLATFORM_TIME_MACRO

--- a/include/mbedtls/platform_util.h
+++ b/include/mbedtls/platform_util.h
@@ -31,6 +31,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include <stddef.h>
 #if defined(MBEDTLS_HAVE_TIME_DATE)
 #include "mbedtls/platform_time.h"
@@ -80,7 +82,7 @@ extern "C" {
  * \param file  The file where the assertion failed.
  * \param line  The line in the file where the assertion failed.
  */
-void mbedtls_param_failed( const char *failure_condition,
+MBEDCRYPTO_EXPORT void mbedtls_param_failed( const char *failure_condition,
                            const char *file,
                            int line );
 #endif /* MBEDTLS_PARAM_FAILED */
@@ -156,7 +158,7 @@ MBEDTLS_DEPRECATED typedef int mbedtls_deprecated_numeric_constant_t;
  * \param len   Length of the buffer in bytes
  *
  */
-void mbedtls_platform_zeroize( void *buf, size_t len );
+MBEDCRYPTO_EXPORT void mbedtls_platform_zeroize( void *buf, size_t len );
 
 #if defined(MBEDTLS_HAVE_TIME_DATE)
 /**
@@ -185,7 +187,7 @@ void mbedtls_platform_zeroize( void *buf, size_t len );
  * \return      Pointer to an object of type struct tm on success, otherwise
  *              NULL
  */
-struct tm *mbedtls_platform_gmtime_r( const mbedtls_time_t *tt,
+MBEDCRYPTO_EXPORT struct tm *mbedtls_platform_gmtime_r( const mbedtls_time_t *tt,
                                       struct tm *tm_buf );
 #endif /* MBEDTLS_HAVE_TIME_DATE */
 

--- a/include/mbedtls/poly1305.h
+++ b/include/mbedtls/poly1305.h
@@ -39,6 +39,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include <stdint.h>
 #include <stddef.h>
 
@@ -87,7 +89,7 @@ mbedtls_poly1305_context;
  * \param ctx       The Poly1305 context to initialize. This must
  *                  not be \c NULL.
  */
-void mbedtls_poly1305_init( mbedtls_poly1305_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_poly1305_init( mbedtls_poly1305_context *ctx );
 
 /**
  * \brief           This function releases and clears the specified
@@ -97,7 +99,7 @@ void mbedtls_poly1305_init( mbedtls_poly1305_context *ctx );
  *                  case this function is a no-op. If it is not \c NULL, it must
  *                  point to an initialized Poly1305 context.
  */
-void mbedtls_poly1305_free( mbedtls_poly1305_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_poly1305_free( mbedtls_poly1305_context *ctx );
 
 /**
  * \brief           This function sets the one-time authentication key.
@@ -112,7 +114,7 @@ void mbedtls_poly1305_free( mbedtls_poly1305_context *ctx );
  * \return          \c 0 on success.
  * \return          A negative error code on failure.
  */
-int mbedtls_poly1305_starts( mbedtls_poly1305_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_poly1305_starts( mbedtls_poly1305_context *ctx,
                              const unsigned char key[32] );
 
 /**
@@ -133,7 +135,7 @@ int mbedtls_poly1305_starts( mbedtls_poly1305_context *ctx,
  * \return          \c 0 on success.
  * \return          A negative error code on failure.
  */
-int mbedtls_poly1305_update( mbedtls_poly1305_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_poly1305_update( mbedtls_poly1305_context *ctx,
                              const unsigned char *input,
                              size_t ilen );
 
@@ -149,7 +151,7 @@ int mbedtls_poly1305_update( mbedtls_poly1305_context *ctx,
  * \return          \c 0 on success.
  * \return          A negative error code on failure.
  */
-int mbedtls_poly1305_finish( mbedtls_poly1305_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_poly1305_finish( mbedtls_poly1305_context *ctx,
                              unsigned char mac[16] );
 
 /**
@@ -170,7 +172,7 @@ int mbedtls_poly1305_finish( mbedtls_poly1305_context *ctx,
  * \return          \c 0 on success.
  * \return          A negative error code on failure.
  */
-int mbedtls_poly1305_mac( const unsigned char key[32],
+MBEDCRYPTO_EXPORT int mbedtls_poly1305_mac( const unsigned char key[32],
                           const unsigned char *input,
                           size_t ilen,
                           unsigned char mac[16] );
@@ -182,7 +184,7 @@ int mbedtls_poly1305_mac( const unsigned char key[32],
  * \return          \c 0 on success.
  * \return          \c 1 on failure.
  */
-int mbedtls_poly1305_self_test( int verbose );
+MBEDCRYPTO_EXPORT int mbedtls_poly1305_self_test( int verbose );
 #endif /* MBEDTLS_SELF_TEST */
 
 #ifdef __cplusplus

--- a/include/mbedtls/ripemd160.h
+++ b/include/mbedtls/ripemd160.h
@@ -30,6 +30,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -65,14 +67,14 @@ mbedtls_ripemd160_context;
  *
  * \param ctx      RIPEMD-160 context to be initialized
  */
-void mbedtls_ripemd160_init( mbedtls_ripemd160_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_ripemd160_init( mbedtls_ripemd160_context *ctx );
 
 /**
  * \brief          Clear RIPEMD-160 context
  *
  * \param ctx      RIPEMD-160 context to be cleared
  */
-void mbedtls_ripemd160_free( mbedtls_ripemd160_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_ripemd160_free( mbedtls_ripemd160_context *ctx );
 
 /**
  * \brief          Clone (the state of) an RIPEMD-160 context
@@ -80,7 +82,7 @@ void mbedtls_ripemd160_free( mbedtls_ripemd160_context *ctx );
  * \param dst      The destination context
  * \param src      The context to be cloned
  */
-void mbedtls_ripemd160_clone( mbedtls_ripemd160_context *dst,
+MBEDCRYPTO_EXPORT void mbedtls_ripemd160_clone( mbedtls_ripemd160_context *dst,
                         const mbedtls_ripemd160_context *src );
 
 /**
@@ -90,7 +92,7 @@ void mbedtls_ripemd160_clone( mbedtls_ripemd160_context *dst,
  *
  * \return         0 if successful
  */
-int mbedtls_ripemd160_starts_ret( mbedtls_ripemd160_context *ctx );
+MBEDCRYPTO_EXPORT int mbedtls_ripemd160_starts_ret( mbedtls_ripemd160_context *ctx );
 
 /**
  * \brief          RIPEMD-160 process buffer
@@ -101,7 +103,7 @@ int mbedtls_ripemd160_starts_ret( mbedtls_ripemd160_context *ctx );
  *
  * \return         0 if successful
  */
-int mbedtls_ripemd160_update_ret( mbedtls_ripemd160_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_ripemd160_update_ret( mbedtls_ripemd160_context *ctx,
                                   const unsigned char *input,
                                   size_t ilen );
 
@@ -113,7 +115,7 @@ int mbedtls_ripemd160_update_ret( mbedtls_ripemd160_context *ctx,
  *
  * \return         0 if successful
  */
-int mbedtls_ripemd160_finish_ret( mbedtls_ripemd160_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_ripemd160_finish_ret( mbedtls_ripemd160_context *ctx,
                                   unsigned char output[20] );
 
 /**
@@ -124,7 +126,7 @@ int mbedtls_ripemd160_finish_ret( mbedtls_ripemd160_context *ctx,
  *
  * \return         0 if successful
  */
-int mbedtls_internal_ripemd160_process( mbedtls_ripemd160_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_internal_ripemd160_process( mbedtls_ripemd160_context *ctx,
                                         const unsigned char data[64] );
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
@@ -193,7 +195,7 @@ MBEDTLS_DEPRECATED void mbedtls_ripemd160_process(
  *
  * \return         0 if successful
  */
-int mbedtls_ripemd160_ret( const unsigned char *input,
+MBEDCRYPTO_EXPORT int mbedtls_ripemd160_ret( const unsigned char *input,
                            size_t ilen,
                            unsigned char output[20] );
 
@@ -226,7 +228,7 @@ MBEDTLS_DEPRECATED void mbedtls_ripemd160( const unsigned char *input,
  *
  * \return         0 if successful, or 1 if the test failed
  */
-int mbedtls_ripemd160_self_test( int verbose );
+MBEDCRYPTO_EXPORT int mbedtls_ripemd160_self_test( int verbose );
 
 #endif /* MBEDTLS_SELF_TEST */
 

--- a/include/mbedtls/rsa.h
+++ b/include/mbedtls/rsa.h
@@ -36,6 +36,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include "mbedtls/bignum.h"
 #include "mbedtls/md.h"
 
@@ -165,7 +167,7 @@ mbedtls_rsa_context;
  *                 \p padding is #MBEDTLS_RSA_PKCS_V21. It is unused
  *                 otherwise.
  */
-void mbedtls_rsa_init( mbedtls_rsa_context *ctx,
+MBEDCRYPTO_EXPORT void mbedtls_rsa_init( mbedtls_rsa_context *ctx,
                        int padding,
                        int hash_id );
 
@@ -198,7 +200,7 @@ void mbedtls_rsa_init( mbedtls_rsa_context *ctx,
  * \return         \c 0 on success.
  * \return         A non-zero error code on failure.
  */
-int mbedtls_rsa_import( mbedtls_rsa_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_rsa_import( mbedtls_rsa_context *ctx,
                         const mbedtls_mpi *N,
                         const mbedtls_mpi *P, const mbedtls_mpi *Q,
                         const mbedtls_mpi *D, const mbedtls_mpi *E );
@@ -237,7 +239,7 @@ int mbedtls_rsa_import( mbedtls_rsa_context *ctx,
  * \return         \c 0 on success.
  * \return         A non-zero error code on failure.
  */
-int mbedtls_rsa_import_raw( mbedtls_rsa_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_rsa_import_raw( mbedtls_rsa_context *ctx,
                             unsigned char const *N, size_t N_len,
                             unsigned char const *P, size_t P_len,
                             unsigned char const *Q, size_t Q_len,
@@ -276,7 +278,7 @@ int mbedtls_rsa_import_raw( mbedtls_rsa_context *ctx,
  *                 failed.
  *
  */
-int mbedtls_rsa_complete( mbedtls_rsa_context *ctx );
+MBEDCRYPTO_EXPORT int mbedtls_rsa_complete( mbedtls_rsa_context *ctx );
 
 /**
  * \brief          This function exports the core parameters of an RSA key.
@@ -318,7 +320,7 @@ int mbedtls_rsa_complete( mbedtls_rsa_context *ctx );
  * \return         A non-zero return code on any other failure.
  *
  */
-int mbedtls_rsa_export( const mbedtls_rsa_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_rsa_export( const mbedtls_rsa_context *ctx,
                         mbedtls_mpi *N, mbedtls_mpi *P, mbedtls_mpi *Q,
                         mbedtls_mpi *D, mbedtls_mpi *E );
 
@@ -369,7 +371,7 @@ int mbedtls_rsa_export( const mbedtls_rsa_context *ctx,
  *                 functionality or because of security policies.
  * \return         A non-zero return code on any other failure.
  */
-int mbedtls_rsa_export_raw( const mbedtls_rsa_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_rsa_export_raw( const mbedtls_rsa_context *ctx,
                             unsigned char *N, size_t N_len,
                             unsigned char *P, size_t P_len,
                             unsigned char *Q, size_t Q_len,
@@ -395,7 +397,7 @@ int mbedtls_rsa_export_raw( const mbedtls_rsa_context *ctx,
  * \return         A non-zero error code on failure.
  *
  */
-int mbedtls_rsa_export_crt( const mbedtls_rsa_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_rsa_export_crt( const mbedtls_rsa_context *ctx,
                             mbedtls_mpi *DP, mbedtls_mpi *DQ, mbedtls_mpi *QP );
 
 /**
@@ -407,7 +409,7 @@ int mbedtls_rsa_export_crt( const mbedtls_rsa_context *ctx,
  *                 #MBEDTLS_RSA_PKCS_V15 or #MBEDTLS_RSA_PKCS_V21.
  * \param hash_id  The #MBEDTLS_RSA_PKCS_V21 hash identifier.
  */
-void mbedtls_rsa_set_padding( mbedtls_rsa_context *ctx, int padding,
+MBEDCRYPTO_EXPORT void mbedtls_rsa_set_padding( mbedtls_rsa_context *ctx, int padding,
                               int hash_id );
 
 /**
@@ -418,7 +420,7 @@ void mbedtls_rsa_set_padding( mbedtls_rsa_context *ctx, int padding,
  * \return         The length of the RSA modulus in Bytes.
  *
  */
-size_t mbedtls_rsa_get_len( const mbedtls_rsa_context *ctx );
+MBEDCRYPTO_EXPORT size_t mbedtls_rsa_get_len( const mbedtls_rsa_context *ctx );
 
 /**
  * \brief          This function generates an RSA keypair.
@@ -438,7 +440,7 @@ size_t mbedtls_rsa_get_len( const mbedtls_rsa_context *ctx );
  * \return         \c 0 on success.
  * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
  */
-int mbedtls_rsa_gen_key( mbedtls_rsa_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_rsa_gen_key( mbedtls_rsa_context *ctx,
                          int (*f_rng)(void *, unsigned char *, size_t),
                          void *p_rng,
                          unsigned int nbits, int exponent );
@@ -457,7 +459,7 @@ int mbedtls_rsa_gen_key( mbedtls_rsa_context *ctx,
  * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
  *
  */
-int mbedtls_rsa_check_pubkey( const mbedtls_rsa_context *ctx );
+MBEDCRYPTO_EXPORT int mbedtls_rsa_check_pubkey( const mbedtls_rsa_context *ctx );
 
 /**
  * \brief      This function checks if a context contains an RSA private key
@@ -495,7 +497,7 @@ int mbedtls_rsa_check_pubkey( const mbedtls_rsa_context *ctx );
  * \return     \c 0 on success.
  * \return     An \c MBEDTLS_ERR_RSA_XXX error code on failure.
  */
-int mbedtls_rsa_check_privkey( const mbedtls_rsa_context *ctx );
+MBEDCRYPTO_EXPORT int mbedtls_rsa_check_privkey( const mbedtls_rsa_context *ctx );
 
 /**
  * \brief          This function checks a public-private RSA key pair.
@@ -508,7 +510,7 @@ int mbedtls_rsa_check_privkey( const mbedtls_rsa_context *ctx );
  * \return         \c 0 on success.
  * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
  */
-int mbedtls_rsa_check_pub_priv( const mbedtls_rsa_context *pub,
+MBEDCRYPTO_EXPORT int mbedtls_rsa_check_pub_priv( const mbedtls_rsa_context *pub,
                                 const mbedtls_rsa_context *prv );
 
 /**
@@ -530,7 +532,7 @@ int mbedtls_rsa_check_pub_priv( const mbedtls_rsa_context *pub,
  * \return         \c 0 on success.
  * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
  */
-int mbedtls_rsa_public( mbedtls_rsa_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_rsa_public( mbedtls_rsa_context *ctx,
                 const unsigned char *input,
                 unsigned char *output );
 
@@ -565,7 +567,7 @@ int mbedtls_rsa_public( mbedtls_rsa_context *ctx,
  * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
  *
  */
-int mbedtls_rsa_private( mbedtls_rsa_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_rsa_private( mbedtls_rsa_context *ctx,
                  int (*f_rng)(void *, unsigned char *, size_t),
                  void *p_rng,
                  const unsigned char *input,
@@ -610,7 +612,7 @@ int mbedtls_rsa_private( mbedtls_rsa_context *ctx,
  * \return         \c 0 on success.
  * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
  */
-int mbedtls_rsa_pkcs1_encrypt( mbedtls_rsa_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_rsa_pkcs1_encrypt( mbedtls_rsa_context *ctx,
                        int (*f_rng)(void *, unsigned char *, size_t),
                        void *p_rng,
                        int mode, size_t ilen,
@@ -651,7 +653,7 @@ int mbedtls_rsa_pkcs1_encrypt( mbedtls_rsa_context *ctx,
  * \return         \c 0 on success.
  * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
  */
-int mbedtls_rsa_rsaes_pkcs1_v15_encrypt( mbedtls_rsa_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_rsa_rsaes_pkcs1_v15_encrypt( mbedtls_rsa_context *ctx,
                                  int (*f_rng)(void *, unsigned char *, size_t),
                                  void *p_rng,
                                  int mode, size_t ilen,
@@ -696,7 +698,7 @@ int mbedtls_rsa_rsaes_pkcs1_v15_encrypt( mbedtls_rsa_context *ctx,
  * \return           \c 0 on success.
  * \return           An \c MBEDTLS_ERR_RSA_XXX error code on failure.
  */
-int mbedtls_rsa_rsaes_oaep_encrypt( mbedtls_rsa_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_rsa_rsaes_oaep_encrypt( mbedtls_rsa_context *ctx,
                             int (*f_rng)(void *, unsigned char *, size_t),
                             void *p_rng,
                             int mode,
@@ -749,7 +751,7 @@ int mbedtls_rsa_rsaes_oaep_encrypt( mbedtls_rsa_context *ctx,
  * \return         \c 0 on success.
  * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
  */
-int mbedtls_rsa_pkcs1_decrypt( mbedtls_rsa_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_rsa_pkcs1_decrypt( mbedtls_rsa_context *ctx,
                        int (*f_rng)(void *, unsigned char *, size_t),
                        void *p_rng,
                        int mode, size_t *olen,
@@ -799,7 +801,7 @@ int mbedtls_rsa_pkcs1_decrypt( mbedtls_rsa_context *ctx,
  * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
  *
  */
-int mbedtls_rsa_rsaes_pkcs1_v15_decrypt( mbedtls_rsa_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_rsa_rsaes_pkcs1_v15_decrypt( mbedtls_rsa_context *ctx,
                                  int (*f_rng)(void *, unsigned char *, size_t),
                                  void *p_rng,
                                  int mode, size_t *olen,
@@ -853,7 +855,7 @@ int mbedtls_rsa_rsaes_pkcs1_v15_decrypt( mbedtls_rsa_context *ctx,
  * \return         \c 0 on success.
  * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
  */
-int mbedtls_rsa_rsaes_oaep_decrypt( mbedtls_rsa_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_rsa_rsaes_oaep_decrypt( mbedtls_rsa_context *ctx,
                             int (*f_rng)(void *, unsigned char *, size_t),
                             void *p_rng,
                             int mode,
@@ -913,7 +915,7 @@ int mbedtls_rsa_rsaes_oaep_decrypt( mbedtls_rsa_context *ctx,
  * \return         \c 0 if the signing operation was successful.
  * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
  */
-int mbedtls_rsa_pkcs1_sign( mbedtls_rsa_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_rsa_pkcs1_sign( mbedtls_rsa_context *ctx,
                     int (*f_rng)(void *, unsigned char *, size_t),
                     void *p_rng,
                     int mode,
@@ -961,7 +963,7 @@ int mbedtls_rsa_pkcs1_sign( mbedtls_rsa_context *ctx,
  * \return         \c 0 if the signing operation was successful.
  * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
  */
-int mbedtls_rsa_rsassa_pkcs1_v15_sign( mbedtls_rsa_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_rsa_rsassa_pkcs1_v15_sign( mbedtls_rsa_context *ctx,
                                int (*f_rng)(void *, unsigned char *, size_t),
                                void *p_rng,
                                int mode,
@@ -1023,7 +1025,7 @@ int mbedtls_rsa_rsassa_pkcs1_v15_sign( mbedtls_rsa_context *ctx,
  * \return         \c 0 if the signing operation was successful.
  * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
  */
-int mbedtls_rsa_rsassa_pss_sign( mbedtls_rsa_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_rsa_rsassa_pss_sign( mbedtls_rsa_context *ctx,
                          int (*f_rng)(void *, unsigned char *, size_t),
                          void *p_rng,
                          int mode,
@@ -1076,7 +1078,7 @@ int mbedtls_rsa_rsassa_pss_sign( mbedtls_rsa_context *ctx,
  * \return         \c 0 if the verify operation was successful.
  * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
  */
-int mbedtls_rsa_pkcs1_verify( mbedtls_rsa_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_rsa_pkcs1_verify( mbedtls_rsa_context *ctx,
                       int (*f_rng)(void *, unsigned char *, size_t),
                       void *p_rng,
                       int mode,
@@ -1122,7 +1124,7 @@ int mbedtls_rsa_pkcs1_verify( mbedtls_rsa_context *ctx,
  * \return         \c 0 if the verify operation was successful.
  * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
  */
-int mbedtls_rsa_rsassa_pkcs1_v15_verify( mbedtls_rsa_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_rsa_rsassa_pkcs1_v15_verify( mbedtls_rsa_context *ctx,
                                  int (*f_rng)(void *, unsigned char *, size_t),
                                  void *p_rng,
                                  int mode,
@@ -1179,7 +1181,7 @@ int mbedtls_rsa_rsassa_pkcs1_v15_verify( mbedtls_rsa_context *ctx,
  * \return         \c 0 if the verify operation was successful.
  * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
  */
-int mbedtls_rsa_rsassa_pss_verify( mbedtls_rsa_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_rsa_rsassa_pss_verify( mbedtls_rsa_context *ctx,
                            int (*f_rng)(void *, unsigned char *, size_t),
                            void *p_rng,
                            int mode,
@@ -1227,7 +1229,7 @@ int mbedtls_rsa_rsassa_pss_verify( mbedtls_rsa_context *ctx,
  * \return         \c 0 if the verify operation was successful.
  * \return         An \c MBEDTLS_ERR_RSA_XXX error code on failure.
  */
-int mbedtls_rsa_rsassa_pss_verify_ext( mbedtls_rsa_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_rsa_rsassa_pss_verify_ext( mbedtls_rsa_context *ctx,
                                int (*f_rng)(void *, unsigned char *, size_t),
                                void *p_rng,
                                int mode,
@@ -1247,7 +1249,7 @@ int mbedtls_rsa_rsassa_pss_verify_ext( mbedtls_rsa_context *ctx,
  * \return         \c 0 on success.
  * \return         #MBEDTLS_ERR_MPI_ALLOC_FAILED on memory allocation failure.
  */
-int mbedtls_rsa_copy( mbedtls_rsa_context *dst, const mbedtls_rsa_context *src );
+MBEDCRYPTO_EXPORT int mbedtls_rsa_copy( mbedtls_rsa_context *dst, const mbedtls_rsa_context *src );
 
 /**
  * \brief          This function frees the components of an RSA key.
@@ -1256,7 +1258,7 @@ int mbedtls_rsa_copy( mbedtls_rsa_context *dst, const mbedtls_rsa_context *src )
  *                 this function is a no-op. If it is not \c NULL, it must
  *                 point to an initialized RSA context.
  */
-void mbedtls_rsa_free( mbedtls_rsa_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_rsa_free( mbedtls_rsa_context *ctx );
 
 #if defined(MBEDTLS_SELF_TEST)
 
@@ -1266,7 +1268,7 @@ void mbedtls_rsa_free( mbedtls_rsa_context *ctx );
  * \return         \c 0 on success.
  * \return         \c 1 on failure.
  */
-int mbedtls_rsa_self_test( int verbose );
+MBEDCRYPTO_EXPORT int mbedtls_rsa_self_test( int verbose );
 
 #endif /* MBEDTLS_SELF_TEST */
 

--- a/include/mbedtls/rsa_internal.h
+++ b/include/mbedtls/rsa_internal.h
@@ -63,6 +63,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include "mbedtls/bignum.h"
 
 #ifdef __cplusplus
@@ -94,7 +96,7 @@ extern "C" {
  *                 use the helper function \c mbedtls_rsa_validate_params.
  *
  */
-int mbedtls_rsa_deduce_primes( mbedtls_mpi const *N, mbedtls_mpi const *E,
+MBEDCRYPTO_EXPORT int mbedtls_rsa_deduce_primes( mbedtls_mpi const *N, mbedtls_mpi const *E,
                                mbedtls_mpi const *D,
                                mbedtls_mpi *P, mbedtls_mpi *Q );
 
@@ -119,7 +121,7 @@ int mbedtls_rsa_deduce_primes( mbedtls_mpi const *N, mbedtls_mpi const *E,
  * \note           This function does not check whether P and Q are primes.
  *
  */
-int mbedtls_rsa_deduce_private_exponent( mbedtls_mpi const *P,
+MBEDCRYPTO_EXPORT int mbedtls_rsa_deduce_private_exponent( mbedtls_mpi const *P,
                                          mbedtls_mpi const *Q,
                                          mbedtls_mpi const *E,
                                          mbedtls_mpi *D );
@@ -145,7 +147,7 @@ int mbedtls_rsa_deduce_private_exponent( mbedtls_mpi const *P,
  *                 prime and whether D is a valid private exponent.
  *
  */
-int mbedtls_rsa_deduce_crt( const mbedtls_mpi *P, const mbedtls_mpi *Q,
+MBEDCRYPTO_EXPORT int mbedtls_rsa_deduce_crt( const mbedtls_mpi *P, const mbedtls_mpi *Q,
                             const mbedtls_mpi *D, mbedtls_mpi *DP,
                             mbedtls_mpi *DQ, mbedtls_mpi *QP );
 
@@ -180,7 +182,7 @@ int mbedtls_rsa_deduce_crt( const mbedtls_mpi *P, const mbedtls_mpi *Q,
  *                 to perform specific checks only. E.g., calling it with
  *                 (-,P,-,-,-) and a PRNG amounts to a primality check for P.
  */
-int mbedtls_rsa_validate_params( const mbedtls_mpi *N, const mbedtls_mpi *P,
+MBEDCRYPTO_EXPORT int mbedtls_rsa_validate_params( const mbedtls_mpi *N, const mbedtls_mpi *P,
                                  const mbedtls_mpi *Q, const mbedtls_mpi *D,
                                  const mbedtls_mpi *E,
                                  int (*f_rng)(void *, unsigned char *, size_t),
@@ -215,7 +217,7 @@ int mbedtls_rsa_validate_params( const mbedtls_mpi *N, const mbedtls_mpi *P,
  *                 to perform specific checks only. E.g., calling it with the
  *                 parameters (P, -, D, DP, -, -) will check DP = D mod P-1.
  */
-int mbedtls_rsa_validate_crt( const mbedtls_mpi *P,  const mbedtls_mpi *Q,
+MBEDCRYPTO_EXPORT int mbedtls_rsa_validate_crt( const mbedtls_mpi *P,  const mbedtls_mpi *Q,
                               const mbedtls_mpi *D,  const mbedtls_mpi *DP,
                               const mbedtls_mpi *DQ, const mbedtls_mpi *QP );
 

--- a/include/mbedtls/sha1.h
+++ b/include/mbedtls/sha1.h
@@ -37,6 +37,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -83,7 +85,7 @@ mbedtls_sha1_context;
  *                 This must not be \c NULL.
  *
  */
-void mbedtls_sha1_init( mbedtls_sha1_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_sha1_init( mbedtls_sha1_context *ctx );
 
 /**
  * \brief          This function clears a SHA-1 context.
@@ -98,7 +100,7 @@ void mbedtls_sha1_init( mbedtls_sha1_context *ctx );
  *                 SHA-1 context.
  *
  */
-void mbedtls_sha1_free( mbedtls_sha1_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_sha1_free( mbedtls_sha1_context *ctx );
 
 /**
  * \brief          This function clones the state of a SHA-1 context.
@@ -111,7 +113,7 @@ void mbedtls_sha1_free( mbedtls_sha1_context *ctx );
  * \param src      The SHA-1 context to clone from. This must be initialized.
  *
  */
-void mbedtls_sha1_clone( mbedtls_sha1_context *dst,
+MBEDCRYPTO_EXPORT void mbedtls_sha1_clone( mbedtls_sha1_context *dst,
                          const mbedtls_sha1_context *src );
 
 /**
@@ -127,7 +129,7 @@ void mbedtls_sha1_clone( mbedtls_sha1_context *dst,
  * \return         A negative error code on failure.
  *
  */
-int mbedtls_sha1_starts_ret( mbedtls_sha1_context *ctx );
+MBEDCRYPTO_EXPORT int mbedtls_sha1_starts_ret( mbedtls_sha1_context *ctx );
 
 /**
  * \brief          This function feeds an input buffer into an ongoing SHA-1
@@ -146,7 +148,7 @@ int mbedtls_sha1_starts_ret( mbedtls_sha1_context *ctx );
  * \return         \c 0 on success.
  * \return         A negative error code on failure.
  */
-int mbedtls_sha1_update_ret( mbedtls_sha1_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_sha1_update_ret( mbedtls_sha1_context *ctx,
                              const unsigned char *input,
                              size_t ilen );
 
@@ -166,7 +168,7 @@ int mbedtls_sha1_update_ret( mbedtls_sha1_context *ctx,
  * \return         \c 0 on success.
  * \return         A negative error code on failure.
  */
-int mbedtls_sha1_finish_ret( mbedtls_sha1_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_sha1_finish_ret( mbedtls_sha1_context *ctx,
                              unsigned char output[20] );
 
 /**
@@ -184,7 +186,7 @@ int mbedtls_sha1_finish_ret( mbedtls_sha1_context *ctx,
  * \return         A negative error code on failure.
  *
  */
-int mbedtls_internal_sha1_process( mbedtls_sha1_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_internal_sha1_process( mbedtls_sha1_context *ctx,
                                    const unsigned char data[64] );
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
@@ -289,7 +291,7 @@ MBEDTLS_DEPRECATED void mbedtls_sha1_process( mbedtls_sha1_context *ctx,
  * \return         A negative error code on failure.
  *
  */
-int mbedtls_sha1_ret( const unsigned char *input,
+MBEDCRYPTO_EXPORT int mbedtls_sha1_ret( const unsigned char *input,
                       size_t ilen,
                       unsigned char output[20] );
 
@@ -341,7 +343,7 @@ MBEDTLS_DEPRECATED void mbedtls_sha1( const unsigned char *input,
  * \return         \c 1 on failure.
  *
  */
-int mbedtls_sha1_self_test( int verbose );
+MBEDCRYPTO_EXPORT int mbedtls_sha1_self_test( int verbose );
 
 #endif /* MBEDTLS_SELF_TEST */
 

--- a/include/mbedtls/sha256.h
+++ b/include/mbedtls/sha256.h
@@ -33,6 +33,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -74,7 +76,7 @@ mbedtls_sha256_context;
  *
  * \param ctx      The SHA-256 context to initialize. This must not be \c NULL.
  */
-void mbedtls_sha256_init( mbedtls_sha256_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_sha256_init( mbedtls_sha256_context *ctx );
 
 /**
  * \brief          This function clears a SHA-256 context.
@@ -83,7 +85,7 @@ void mbedtls_sha256_init( mbedtls_sha256_context *ctx );
  *                 case this function returns immediately. If it is not \c NULL,
  *                 it must point to an initialized SHA-256 context.
  */
-void mbedtls_sha256_free( mbedtls_sha256_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_sha256_free( mbedtls_sha256_context *ctx );
 
 /**
  * \brief          This function clones the state of a SHA-256 context.
@@ -91,7 +93,7 @@ void mbedtls_sha256_free( mbedtls_sha256_context *ctx );
  * \param dst      The destination context. This must be initialized.
  * \param src      The context to clone. This must be initialized.
  */
-void mbedtls_sha256_clone( mbedtls_sha256_context *dst,
+MBEDCRYPTO_EXPORT void mbedtls_sha256_clone( mbedtls_sha256_context *dst,
                            const mbedtls_sha256_context *src );
 
 /**
@@ -105,7 +107,7 @@ void mbedtls_sha256_clone( mbedtls_sha256_context *dst,
  * \return         \c 0 on success.
  * \return         A negative error code on failure.
  */
-int mbedtls_sha256_starts_ret( mbedtls_sha256_context *ctx, int is224 );
+MBEDCRYPTO_EXPORT int mbedtls_sha256_starts_ret( mbedtls_sha256_context *ctx, int is224 );
 
 /**
  * \brief          This function feeds an input buffer into an ongoing
@@ -120,7 +122,7 @@ int mbedtls_sha256_starts_ret( mbedtls_sha256_context *ctx, int is224 );
  * \return         \c 0 on success.
  * \return         A negative error code on failure.
  */
-int mbedtls_sha256_update_ret( mbedtls_sha256_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_sha256_update_ret( mbedtls_sha256_context *ctx,
                                const unsigned char *input,
                                size_t ilen );
 
@@ -136,7 +138,7 @@ int mbedtls_sha256_update_ret( mbedtls_sha256_context *ctx,
  * \return         \c 0 on success.
  * \return         A negative error code on failure.
  */
-int mbedtls_sha256_finish_ret( mbedtls_sha256_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_sha256_finish_ret( mbedtls_sha256_context *ctx,
                                unsigned char output[32] );
 
 /**
@@ -151,7 +153,7 @@ int mbedtls_sha256_finish_ret( mbedtls_sha256_context *ctx,
  * \return         \c 0 on success.
  * \return         A negative error code on failure.
  */
-int mbedtls_internal_sha256_process( mbedtls_sha256_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_internal_sha256_process( mbedtls_sha256_context *ctx,
                                      const unsigned char data[64] );
 
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
@@ -238,7 +240,7 @@ MBEDTLS_DEPRECATED void mbedtls_sha256_process( mbedtls_sha256_context *ctx,
  * \param is224    Determines which function to use. This must be
  *                 either \c 0 for SHA-256, or \c 1 for SHA-224.
  */
-int mbedtls_sha256_ret( const unsigned char *input,
+MBEDCRYPTO_EXPORT int mbedtls_sha256_ret( const unsigned char *input,
                         size_t ilen,
                         unsigned char output[32],
                         int is224 );
@@ -286,7 +288,7 @@ MBEDTLS_DEPRECATED void mbedtls_sha256( const unsigned char *input,
  * \return         \c 0 on success.
  * \return         \c 1 on failure.
  */
-int mbedtls_sha256_self_test( int verbose );
+MBEDCRYPTO_EXPORT int mbedtls_sha256_self_test( int verbose );
 
 #endif /* MBEDTLS_SELF_TEST */
 

--- a/include/mbedtls/sha512.h
+++ b/include/mbedtls/sha512.h
@@ -32,6 +32,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -74,7 +76,7 @@ mbedtls_sha512_context;
  * \param ctx      The SHA-512 context to initialize. This must
  *                 not be \c NULL.
  */
-void mbedtls_sha512_init( mbedtls_sha512_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_sha512_init( mbedtls_sha512_context *ctx );
 
 /**
  * \brief          This function clears a SHA-512 context.
@@ -84,7 +86,7 @@ void mbedtls_sha512_init( mbedtls_sha512_context *ctx );
  *                 is not \c NULL, it must point to an initialized
  *                 SHA-512 context.
  */
-void mbedtls_sha512_free( mbedtls_sha512_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_sha512_free( mbedtls_sha512_context *ctx );
 
 /**
  * \brief          This function clones the state of a SHA-512 context.
@@ -92,7 +94,7 @@ void mbedtls_sha512_free( mbedtls_sha512_context *ctx );
  * \param dst      The destination context. This must be initialized.
  * \param src      The context to clone. This must be initialized.
  */
-void mbedtls_sha512_clone( mbedtls_sha512_context *dst,
+MBEDCRYPTO_EXPORT void mbedtls_sha512_clone( mbedtls_sha512_context *dst,
                            const mbedtls_sha512_context *src );
 
 /**
@@ -106,7 +108,7 @@ void mbedtls_sha512_clone( mbedtls_sha512_context *dst,
  * \return         \c 0 on success.
  * \return         A negative error code on failure.
  */
-int mbedtls_sha512_starts_ret( mbedtls_sha512_context *ctx, int is384 );
+MBEDCRYPTO_EXPORT int mbedtls_sha512_starts_ret( mbedtls_sha512_context *ctx, int is384 );
 
 /**
  * \brief          This function feeds an input buffer into an ongoing
@@ -121,7 +123,7 @@ int mbedtls_sha512_starts_ret( mbedtls_sha512_context *ctx, int is384 );
  * \return         \c 0 on success.
  * \return         A negative error code on failure.
  */
-int mbedtls_sha512_update_ret( mbedtls_sha512_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_sha512_update_ret( mbedtls_sha512_context *ctx,
                     const unsigned char *input,
                     size_t ilen );
 
@@ -138,7 +140,7 @@ int mbedtls_sha512_update_ret( mbedtls_sha512_context *ctx,
  * \return         \c 0 on success.
  * \return         A negative error code on failure.
  */
-int mbedtls_sha512_finish_ret( mbedtls_sha512_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_sha512_finish_ret( mbedtls_sha512_context *ctx,
                                unsigned char output[64] );
 
 /**
@@ -152,7 +154,7 @@ int mbedtls_sha512_finish_ret( mbedtls_sha512_context *ctx,
  * \return         \c 0 on success.
  * \return         A negative error code on failure.
  */
-int mbedtls_internal_sha512_process( mbedtls_sha512_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_internal_sha512_process( mbedtls_sha512_context *ctx,
                                      const unsigned char data[128] );
 #if !defined(MBEDTLS_DEPRECATED_REMOVED)
 #if defined(MBEDTLS_DEPRECATED_WARNING)
@@ -242,7 +244,7 @@ MBEDTLS_DEPRECATED void mbedtls_sha512_process(
  * \return         \c 0 on success.
  * \return         A negative error code on failure.
  */
-int mbedtls_sha512_ret( const unsigned char *input,
+MBEDCRYPTO_EXPORT int mbedtls_sha512_ret( const unsigned char *input,
                         size_t ilen,
                         unsigned char output[64],
                         int is384 );
@@ -290,7 +292,7 @@ MBEDTLS_DEPRECATED void mbedtls_sha512( const unsigned char *input,
  * \return         \c 0 on success.
  * \return         \c 1 on failure.
  */
-int mbedtls_sha512_self_test( int verbose );
+MBEDCRYPTO_EXPORT int mbedtls_sha512_self_test( int verbose );
 #endif /* MBEDTLS_SELF_TEST */
 
 #ifdef __cplusplus

--- a/include/mbedtls/threading.h
+++ b/include/mbedtls/threading.h
@@ -30,6 +30,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include <stdlib.h>
 
 #ifdef __cplusplus
@@ -74,7 +76,7 @@ typedef struct mbedtls_threading_mutex_t
  * \param mutex_lock    the lock function implementation
  * \param mutex_unlock  the unlock function implementation
  */
-void mbedtls_threading_set_alt( void (*mutex_init)( mbedtls_threading_mutex_t * ),
+MBEDCRYPTO_EXPORT void mbedtls_threading_set_alt( void (*mutex_init)( mbedtls_threading_mutex_t * ),
                        void (*mutex_free)( mbedtls_threading_mutex_t * ),
                        int (*mutex_lock)( mbedtls_threading_mutex_t * ),
                        int (*mutex_unlock)( mbedtls_threading_mutex_t * ) );
@@ -82,7 +84,7 @@ void mbedtls_threading_set_alt( void (*mutex_init)( mbedtls_threading_mutex_t * 
 /**
  * \brief               Free global mutexes.
  */
-void mbedtls_threading_free_alt( void );
+MBEDCRYPTO_EXPORT void mbedtls_threading_free_alt( void );
 #endif /* MBEDTLS_THREADING_ALT */
 
 #if defined(MBEDTLS_THREADING_C)

--- a/include/mbedtls/timing.h
+++ b/include/mbedtls/timing.h
@@ -30,6 +30,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -62,7 +64,7 @@ typedef struct mbedtls_timing_delay_context
 #include "timing_alt.h"
 #endif /* MBEDTLS_TIMING_ALT */
 
-extern volatile int mbedtls_timing_alarmed;
+MBEDCRYPTO_EXTERN volatile int mbedtls_timing_alarmed;
 
 /**
  * \brief          Return the CPU cycle counter value
@@ -74,7 +76,7 @@ extern volatile int mbedtls_timing_alarmed;
  * \note           This value starts at an unspecified origin and
  *                 may wrap around.
  */
-unsigned long mbedtls_timing_hardclock( void );
+MBEDCRYPTO_EXPORT unsigned long mbedtls_timing_hardclock( void );
 
 /**
  * \brief          Return the elapsed time in milliseconds
@@ -93,7 +95,7 @@ unsigned long mbedtls_timing_hardclock( void );
  *                 get_timer(0) }` the value time1+time2 is only approximately
  *                 the delay since the first reset.
  */
-unsigned long mbedtls_timing_get_timer( struct mbedtls_timing_hr_time *val, int reset );
+MBEDCRYPTO_EXPORT unsigned long mbedtls_timing_get_timer( struct mbedtls_timing_hr_time *val, int reset );
 
 /**
  * \brief          Setup an alarm clock
@@ -105,7 +107,7 @@ unsigned long mbedtls_timing_get_timer( struct mbedtls_timing_hr_time *val, int 
  *                 context, this means one for the whole process, not one per
  *                 thread.
  */
-void mbedtls_set_alarm( int seconds );
+MBEDCRYPTO_EXPORT void mbedtls_set_alarm( int seconds );
 
 /**
  * \brief          Set a pair of delays to watch
@@ -121,7 +123,7 @@ void mbedtls_set_alarm( int seconds );
  * \note           To set a single delay, either use \c mbedtls_timing_set_timer
  *                 directly or use this function with int_ms == fin_ms.
  */
-void mbedtls_timing_set_delay( void *data, uint32_t int_ms, uint32_t fin_ms );
+MBEDCRYPTO_EXPORT void mbedtls_timing_set_delay( void *data, uint32_t int_ms, uint32_t fin_ms );
 
 /**
  * \brief          Get the status of delays
@@ -135,7 +137,7 @@ void mbedtls_timing_set_delay( void *data, uint32_t int_ms, uint32_t fin_ms );
  *                  1 if only the intermediate delay is passed,
  *                  2 if the final delay is passed.
  */
-int mbedtls_timing_get_delay( void *data );
+MBEDCRYPTO_EXPORT int mbedtls_timing_get_delay( void *data );
 
 #if defined(MBEDTLS_SELF_TEST)
 /**
@@ -143,7 +145,7 @@ int mbedtls_timing_get_delay( void *data );
  *
  * \return         0 if successful, or 1 if a test failed
  */
-int mbedtls_timing_self_test( int verbose );
+MBEDCRYPTO_EXPORT int mbedtls_timing_self_test( int verbose );
 #endif
 
 #ifdef __cplusplus

--- a/include/mbedtls/version.h
+++ b/include/mbedtls/version.h
@@ -34,6 +34,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 /**
  * The version number x.y.z is split into three parts.
  * Major, Minor, Patchlevel
@@ -71,7 +73,7 @@ unsigned int mbedtls_version_get_number( void );
  * \param string    The string that will receive the value.
  *                  (Should be at least 9 bytes in size)
  */
-void mbedtls_version_get_string( char *string );
+MBEDCRYPTO_EXPORT void mbedtls_version_get_string( char *string );
 
 /**
  * Get the full version string ("mbed TLS x.y.z").
@@ -82,7 +84,7 @@ void mbedtls_version_get_string( char *string );
  *                  (So the buffer should be at least 18 bytes to receive this
  *                  version string).
  */
-void mbedtls_version_get_string_full( char *string );
+MBEDCRYPTO_EXPORT void mbedtls_version_get_string_full( char *string );
 
 /**
  * \brief           Check if support for a feature was compiled into this
@@ -101,7 +103,7 @@ void mbedtls_version_get_string_full( char *string );
  *                  -2 if support for feature checking as a whole was not
  *                  compiled in.
  */
-int mbedtls_version_check_feature( const char *feature );
+MBEDCRYPTO_EXPORT int mbedtls_version_check_feature( const char *feature );
 
 #ifdef __cplusplus
 }

--- a/include/mbedtls/xtea.h
+++ b/include/mbedtls/xtea.h
@@ -30,6 +30,8 @@
 #include MBEDTLS_CONFIG_FILE
 #endif
 
+#include "mbedtls/export.h"
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -67,14 +69,14 @@ mbedtls_xtea_context;
  *
  * \param ctx      XTEA context to be initialized
  */
-void mbedtls_xtea_init( mbedtls_xtea_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_xtea_init( mbedtls_xtea_context *ctx );
 
 /**
  * \brief          Clear XTEA context
  *
  * \param ctx      XTEA context to be cleared
  */
-void mbedtls_xtea_free( mbedtls_xtea_context *ctx );
+MBEDCRYPTO_EXPORT void mbedtls_xtea_free( mbedtls_xtea_context *ctx );
 
 /**
  * \brief          XTEA key schedule
@@ -82,7 +84,7 @@ void mbedtls_xtea_free( mbedtls_xtea_context *ctx );
  * \param ctx      XTEA context to be initialized
  * \param key      the secret key
  */
-void mbedtls_xtea_setup( mbedtls_xtea_context *ctx, const unsigned char key[16] );
+MBEDCRYPTO_EXPORT void mbedtls_xtea_setup( mbedtls_xtea_context *ctx, const unsigned char key[16] );
 
 /**
  * \brief          XTEA cipher function
@@ -94,7 +96,7 @@ void mbedtls_xtea_setup( mbedtls_xtea_context *ctx, const unsigned char key[16] 
  *
  * \return         0 if successful
  */
-int mbedtls_xtea_crypt_ecb( mbedtls_xtea_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_xtea_crypt_ecb( mbedtls_xtea_context *ctx,
                     int mode,
                     const unsigned char input[8],
                     unsigned char output[8] );
@@ -113,7 +115,7 @@ int mbedtls_xtea_crypt_ecb( mbedtls_xtea_context *ctx,
  * \return         0 if successful,
  *                 MBEDTLS_ERR_XTEA_INVALID_INPUT_LENGTH if the length % 8 != 0
  */
-int mbedtls_xtea_crypt_cbc( mbedtls_xtea_context *ctx,
+MBEDCRYPTO_EXPORT int mbedtls_xtea_crypt_cbc( mbedtls_xtea_context *ctx,
                     int mode,
                     size_t length,
                     unsigned char iv[8],
@@ -128,7 +130,7 @@ int mbedtls_xtea_crypt_cbc( mbedtls_xtea_context *ctx,
  *
  * \return         0 if successful, or 1 if the test failed
  */
-int mbedtls_xtea_self_test( int verbose );
+MBEDCRYPTO_EXPORT int mbedtls_xtea_self_test( int verbose );
 
 #endif /* MBEDTLS_SELF_TEST */
 

--- a/include/psa/crypto_extra.h
+++ b/include/psa/crypto_extra.h
@@ -30,6 +30,8 @@
 #ifndef PSA_CRYPTO_EXTRA_H
 #define PSA_CRYPTO_EXTRA_H
 
+#include "mbedtls/export.h"
+
 #include "mbedtls/platform_util.h"
 
 #ifdef __cplusplus
@@ -206,7 +208,7 @@ static inline void psa_clear_key_slot_number(
  *         It is implementation-dependent whether a failure to initialize
  *         results in this error code.
  */
-psa_status_t mbedtls_psa_register_se_key(
+MBEDCRYPTO_EXPORT psa_status_t mbedtls_psa_register_se_key(
     const psa_key_attributes_t *attributes);
 
 #endif /* MBEDTLS_PSA_CRYPTO_SE_C */
@@ -221,7 +223,7 @@ psa_status_t mbedtls_psa_register_se_key(
  *
  * This is an Mbed TLS extension.
  */
-void mbedtls_psa_crypto_free( void );
+MBEDCRYPTO_EXPORT void mbedtls_psa_crypto_free( void );
 
 /** \brief Statistics about
  * resource consumption related to the PSA keystore.
@@ -259,7 +261,7 @@ typedef struct mbedtls_psa_stats_s
  *       between the application and the keystore, the service may or
  *       may not expose this function.
  */
-void mbedtls_psa_get_stats( mbedtls_psa_stats_t *stats );
+MBEDCRYPTO_EXPORT void mbedtls_psa_get_stats( mbedtls_psa_stats_t *stats );
 
 /**
  * \brief Inject an initial entropy seed for the random generator into
@@ -328,7 +330,7 @@ void mbedtls_psa_get_stats( mbedtls_psa_stats_t *stats );
  *         The library has already been initialized. It is no longer
  *         possible to call this function.
  */
-psa_status_t mbedtls_psa_inject_entropy(const uint8_t *seed,
+MBEDCRYPTO_EXPORT psa_status_t mbedtls_psa_inject_entropy(const uint8_t *seed,
                                         size_t seed_size);
 
 /** \addtogroup crypto_types

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -162,6 +162,9 @@ if(USE_SHARED_MBEDTLS_LIBRARY)
     target_include_directories(mbedcrypto
         PUBLIC ${MBEDTLS_DIR}/include/
         PUBLIC ${MBEDTLS_DIR}/crypto/include/)
+	target_compile_definitions(mbedcrypto
+		PRIVATE MAKING_SHARED_MBEDCRYPTO
+		INTERFACE USING_SHARED_MBEDTLS)
 
     install(TARGETS mbedcrypto
             DESTINATION ${LIB_INSTALL_DIR}

--- a/library/psa_crypto_invasive.h
+++ b/library/psa_crypto_invasive.h
@@ -36,6 +36,8 @@
 #include "mbedtls/config.h"
 #endif
 
+#include "mbedtls/export.h"
+
 #include "psa/crypto.h"
 
 #include "mbedtls/entropy.h"
@@ -72,7 +74,7 @@
  * \retval PSA_ERROR_BAD_STATE
  *         The library has already been initialized.
  */
-psa_status_t mbedtls_psa_crypto_configure_entropy_sources(
+MBEDCRYPTO_EXPORT psa_status_t mbedtls_psa_crypto_configure_entropy_sources(
     void (* entropy_init )( mbedtls_entropy_context *ctx ),
     void (* entropy_free )( mbedtls_entropy_context *ctx ) );
 

--- a/library/psa_crypto_storage.h
+++ b/library/psa_crypto_storage.h
@@ -29,6 +29,8 @@
 extern "C" {
 #endif
 
+#include "mbedtls/export.h"
+
 #include "psa/crypto.h"
 #include "psa/crypto_se_driver.h"
 
@@ -379,7 +381,7 @@ psa_status_t psa_crypto_stop_transaction( void );
  * \retval #PSA_ERROR_NOT_PERMITTED
  *         The entropy seed file already exists.
  */
-psa_status_t mbedtls_psa_storage_inject_entropy( const unsigned char *seed,
+MBEDCRYPTO_EXPORT psa_status_t mbedtls_psa_storage_inject_entropy( const unsigned char *seed,
                                                  size_t seed_size );
 #endif /* MBEDTLS_PSA_INJECT_ENTROPY */
 


### PR DESCRIPTION
Adds support for building and importing MSVC dynamic libraries via generated .lib files. This is part 1 of the fix for (https://github.com/ARMmbed/mbedtls/issues/470). Due to the mixing of headers and source files with no real differentiation between projects this turned out to be much harder than expected, and may not work perfectly yet.

Needs testing across many compilers, especially embedded device compilers.