### PR TITLE
Update Windows Crypto APIs

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -110,7 +110,7 @@ if(UNSAFE_BUILD)
 endif(UNSAFE_BUILD)
 
 if(WIN32)
-    set(libs ${libs} ws2_32)
+    set(libs ${libs} ws2_32 bcrypt)
 endif(WIN32)
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/library/Makefile
+++ b/library/Makefile
@@ -144,7 +144,7 @@ libmbedcrypto.dylib: $(OBJS_CRYPTO)
 
 libmbedcrypto.dll: $(OBJS_CRYPTO)
 	echo "  LD    $@"
-	$(CC) -shared -Wl,-soname,$@ -Wl,--out-implib,$@.a -o $@ $(OBJS_CRYPTO) -lws2_32 -lwinmm -lgdi32 -static-libgcc $(LOCAL_LDFLAGS) $(LDFLAGS)
+	$(CC) -shared -Wl,-soname,$@ -Wl,--out-implib,$@.a -o $@ $(OBJS_CRYPTO) -lws2_32 -lbcrypt -lwinmm -lgdi32 -static-libgcc $(LOCAL_LDFLAGS) $(LDFLAGS)
 
 libmbedcrypto.$(DLEXT): | libmbedcrypto.a
 

--- a/library/entropy_poll.c
+++ b/library/entropy_poll.c
@@ -62,28 +62,43 @@
 #define _WIN32_WINNT 0x0400
 #endif
 #include <windows.h>
-#include <wincrypt.h>
+#include <bcrypt.h>
+ #if defined(_MSC_VER) && _MSC_VER <= 1600
+ /* Visual Studio 2010 and earlier issue a warning when both <stdint.h> and
+  * <intsafe.h> are included, as they redefine a number of <TYPE>_MAX constants.
+  * These constants are guaranteed to be the same, though, so we suppress the
+  * warning when including intsafe.h.
+  */
+ #pragma warning( push )
+ #pragma warning( disable : 4005 )
+ #endif
+ #include <intsafe.h>
+ #if defined(_MSC_VER) && _MSC_VER <= 1600
+ #pragma warning( pop )
+ #endif
 
 int mbedtls_platform_entropy_poll( void *data, unsigned char *output, size_t len,
                            size_t *olen )
 {
-    HCRYPTPROV provider;
+    ULONG len_as_ulong = 0;
     ((void) data);
     *olen = 0;
 
-    if( CryptAcquireContext( &provider, NULL, NULL,
-                              PROV_RSA_FULL, CRYPT_VERIFYCONTEXT ) == FALSE )
+    /*
+      * BCryptGenRandom takes ULONG for size, which is smaller than size_t on
+      * 64-bit Windows platforms. Ensure len's value can be safely converted into
+      * a ULONG.
+      */
+    if ( FAILED( SizeTToULong( len, &len_as_ulong ) ) )
     {
         return( MBEDTLS_ERR_ENTROPY_SOURCE_FAILED );
     }
 
-    if( CryptGenRandom( provider, (DWORD) len, output ) == FALSE )
+    if ( !BCRYPT_SUCCESS( BCryptGenRandom( NULL, output, len_as_ulong, BCRYPT_USE_SYSTEM_PREFERRED_RNG ) ) )
     {
-        CryptReleaseContext( provider, 0 );
         return( MBEDTLS_ERR_ENTROPY_SOURCE_FAILED );
     }
 
-    CryptReleaseContext( provider, 0 );
     *olen = len;
 
     return( 0 );


### PR DESCRIPTION
## Description

This is an update on [Mbed TLS PR #1453](https://github.com/ARMmbed/mbedtls/pull/1453) to address issues building with mingw and Visual Studio when using `cmake` generated files.

To quote the original PR.

> CryptGenRandom and lstrlenW are not permitted in Windows Store apps, meaning apps that use mbedTLS can't ship in the Windows Store. Instead, use BCryptGenRandom and wcslen, respectively, which are permitted.
> 
> Also make sure conversions between size_t, ULONG, and int are always done safely; on a 64-bit platform, these types are differnt sizes.
>

Also, removed the obsolete Visual Studio 6 data files which are no longer used.

## Status
**WORK IN PROGRESS**

## Requires Backporting
NO  

## Migrations
NO

## Todos
- [X] Tests
- [] Documentation
- [] Changelog updated
- [] Backported
