### PR TITLE
ctr_drbg: Clarify reseed_counter values before seeding

### DIFF
--- a/include/mbedtls/ctr_drbg.h
+++ b/include/mbedtls/ctr_drbg.h
@@ -177,7 +177,9 @@ typedef struct mbedtls_ctr_drbg_context
                                  * minus one.
                                  * Before the initial seeding, this field
                                  * contains the amount of entropy in bytes
-                                 * to use as a nonce for the initial seeding.
+                                 * to use as a nonce for the initial seeding,
+                                 * or -1 if no nonce length has been explicitly
+                                 * set (see mbedtls_ctr_drbg_set_nonce_len()).
                                  */
     int prediction_resistance;  /*!< This determines whether prediction
                                      resistance is enabled, that is


### PR DESCRIPTION
Before the initial seeding, reseed_counter used to always be 0. Now, the
value depends on whether or not the user has explicitly set the amount
of data to get from the nonce (via e.g.
mbedtls_ctr_drbg_set_nonce_len()). Add comments to clarify the possible
values reseed_counter can have before the initial seeding.