### PR TITLE
Avoid overwriting tls headers in submodule mode

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -5,6 +5,19 @@ if(INSTALL_MBEDTLS_HEADERS)
     file(GLOB headers "mbedtls/*.h")
     file(GLOB psa_headers "psa/*.h")
 
+    if(USE_CRYPTO_SUBMODULE)
+        # Don't overwrite mbedtls's header files!
+        # config.h is supposed to be automatically checked for compatibility
+        # in automatic builds, while the other files should not just be
+        # compatible, but also identical in theory.
+        # Practically, we don't check that in crypto but just assume that the
+        # submodule configuration is sane and trust tls's headers.
+        list(REMOVE_ITEM headers    "${CMAKE_CURRENT_SOURCE_DIR}/mbedtls/compat-1.3.h"
+                                    "${CMAKE_CURRENT_SOURCE_DIR}/mbedtls/config.h"
+                                    "${CMAKE_CURRENT_SOURCE_DIR}/mbedtls/error.h"
+                                    "${CMAKE_CURRENT_SOURCE_DIR}/mbedtls/version.h")
+    endif(USE_CRYPTO_SUBMODULE)
+
     install(FILES ${headers}
         DESTINATION include/mbedtls
         PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)

--- a/tests/scripts/all.sh
+++ b/tests/scripts/all.sh
@@ -1283,6 +1283,31 @@ component_check_generate_test_code () {
     record_status ./tests/scripts/test_generate_test_code.py
 }
 
+component_test_tls_headers_overwrite () {
+    msg "build: cmake headers check"
+    MBEDTLS_CRYPTO_DESTROOT="${PWD}/headers-check-destroot"
+    MBEDTLS_INCLUDE='include/mbedtls'
+    MBEDTLS_CRYPTO_DESTROOT_INCLUDE="${MBEDTLS_CRYPTO_DESTROOT}/${MBEDTLS_INCLUDE}"
+    scripts/config.py full
+    cmake -DUSE_CRYPTO_SUBMODULE:Bool=ON -DCMAKE_INSTALL_PREFIX:Path="${MBEDTLS_CRYPTO_DESTROOT}" .
+    make
+
+    msg "install: cmake headers check"
+    if_build_succeeded make install
+
+    msg "test: cmake headers check"
+    if_build_succeeded not test -e "${MBEDTLS_CRYPTO_DESTROOT_INCLUDE}/compat-1.3.h"
+    if_build_succeeded not test -e "${MBEDTLS_CRYPTO_DESTROOT_INCLUDE}/config.h"
+    if_build_succeeded not test -e "${MBEDTLS_CRYPTO_DESTROOT_INCLUDE}/error.h"
+    if_build_succeeded not test -e "${MBEDTLS_CRYPTO_DESTROOT_INCLUDE}/version.h"
+}
+post_test_tls_headers_overwrite () {
+    rm -rf "${PWD}/headers-check-destroot"
+}
+support_test_tls_headers_overwrite () {
+    test -n "${USE_CRYPTO_SUBMODULE}"
+}
+
 ################################################################
 #### Termination
 ################################################################


### PR DESCRIPTION
### Description (*required*)

##### Summary of change (*What the change is for and why*)

When crypto is embedded as a submodule and the cmake build system is used, it would previously overwrite some header files installed by tls.

Most of them are harmless (since they should be identical), but config.h is a special case.

tls's and crypto's config.h files differ widely in scope and overwriting the more general, bigger config.h file from tls with crypto's smaller one will make a lot of features unavailable in programs using tls.

Let's just avoid overwriting any tls header in submodule mode.

Note that this will not fix the potential issue that crypto might be using a different configuration than tls in the submodule case.

##### Documentation (*Details of any document updates required*)

N/A

----------------------------------------------------------------------------------------------------------------
### Pull request type (*required*)

    [X] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [ ] Feature update (New feature / Functionality change / New API)
    [ ] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results (*required*)

    [ ] No Tests required for this change (E.g docs only update)
    [ ] Covered by existing mbed-os tests (Greentea or Unittest)
    [X] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers (*optional*)

TBD


----------------------------------------------------------------------------------------------------------------
### Release Notes (*required for feature/major PRs*)


##### Summary of changes

N/A

##### Impact of changes

N/A

##### Migration actions required

N/A