### PR TITLE
Fix possible error code mangling in psa_mac_verify_finish

### DIFF
--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -3030,6 +3030,8 @@ psa_status_t psa_mac_verify_finish( psa_mac_operation_t *operation,
 
     status = psa_mac_finish_internal( operation,
                                       actual_mac, sizeof( actual_mac ) );
+    if( status != PSA_SUCCESS )
+        goto cleanup;
 
     if( safer_memcmp( mac, actual_mac, mac_length ) != 0 )
         status = PSA_ERROR_INVALID_SIGNATURE;


### PR DESCRIPTION
If psa_mac_finish_internal fails (which can only happen due to bad
parameters or hardware problem), the error code was converted to
PSA_ERROR_INVALID_SIGNATURE if the uninitialized stack variable
actual_mac happened to contain the expected MAC. This is a minor bug
but it may be possible to leverage it as part of a longer attack path
in some scenarios.

Reported externally. Found by static analysis.