### PR TITLE
Bump version to Mbed TLS 2.20.0

### DIFF
--- a/doxygen/mbedtls.doxyfile
+++ b/doxygen/mbedtls.doxyfile
@@ -28,7 +28,7 @@ DOXYFILE_ENCODING      = UTF-8
 # identify the project. Note that if you do not use Doxywizard you need
 # to put quotes around the project name if it contains spaces.
 
-PROJECT_NAME           = "mbed TLS v2.19.1"
+PROJECT_NAME           = "mbed TLS v2.20.0"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number.
 # This could be handy for archiving the generated documentation or

--- a/include/mbedtls/version.h
+++ b/include/mbedtls/version.h
@@ -39,17 +39,17 @@
  * Major, Minor, Patchlevel
  */
 #define MBEDTLS_VERSION_MAJOR  2
-#define MBEDTLS_VERSION_MINOR  19
-#define MBEDTLS_VERSION_PATCH  1
+#define MBEDTLS_VERSION_MINOR  20
+#define MBEDTLS_VERSION_PATCH  0
 
 /**
  * The single version number has the following structure:
  *    MMNNPP00
  *    Major version | Minor version | Patch version
  */
-#define MBEDTLS_VERSION_NUMBER         0x02130100
-#define MBEDTLS_VERSION_STRING         "2.19.1"
-#define MBEDTLS_VERSION_STRING_FULL    "mbed TLS 2.19.1"
+#define MBEDTLS_VERSION_NUMBER         0x02140000
+#define MBEDTLS_VERSION_STRING         "2.20.0"
+#define MBEDTLS_VERSION_STRING_FULL    "mbed TLS 2.20.0"
 
 #if defined(MBEDTLS_VERSION_C)
 

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -157,7 +157,7 @@ endif(USE_STATIC_MBEDTLS_LIBRARY)
 
 if(USE_SHARED_MBEDTLS_LIBRARY)
     add_library(mbedcrypto SHARED ${src_crypto})
-    set_target_properties(mbedcrypto PROPERTIES VERSION 2.17.0 SOVERSION 3)
+    set_target_properties(mbedcrypto PROPERTIES VERSION 2.20.0 SOVERSION 4)
     target_link_libraries(mbedcrypto ${libs})
     target_include_directories(mbedcrypto
         PUBLIC ${MBEDTLS_DIR}/include/

--- a/library/Makefile
+++ b/library/Makefile
@@ -36,7 +36,7 @@ LOCAL_CFLAGS += -fPIC -fpic
 endif
 endif
 
-SOEXT_CRYPTO=so.3
+SOEXT_CRYPTO=so.4
 
 # Set AR_DASH= (empty string) to use an ar implementation that does not accept
 # the - prefix for command line options (e.g. llvm-ar)

--- a/tests/suites/test_suite_version.data
+++ b/tests/suites/test_suite_version.data
@@ -1,8 +1,8 @@
 Check compiletime library version
-check_compiletime_version:"2.19.1"
+check_compiletime_version:"2.20.0"
 
 Check runtime library version
-check_runtime_version:"2.19.1"
+check_runtime_version:"2.20.0"
 
 Check for MBEDTLS_VERSION_C
 check_feature:"MBEDTLS_VERSION_C":0


### PR DESCRIPTION
Increase the version number to reflect the latest release.

Remarks:
- Although Mbed Crypto has its own version number it is not reported in the code yet. The in-source version still follows the main Mbed TLS version.
- The SO version needed updating as well because of an API break.
