### PR TITLE
Fix minor defects found by Coverity

### DIFF
--- a/library/cipher.c
+++ b/library/cipher.c
@@ -527,6 +527,10 @@ int mbedtls_cipher_update( mbedtls_cipher_context_t *ctx, const unsigned char *i
 
     *olen = 0;
     block_size = mbedtls_cipher_get_block_size( ctx );
+    if ( 0 == block_size )
+    {
+        return( MBEDTLS_ERR_CIPHER_INVALID_CONTEXT );
+    }
 
     if( ctx->cipher_info->mode == MBEDTLS_MODE_ECB )
     {
@@ -561,11 +565,6 @@ int mbedtls_cipher_update( mbedtls_cipher_context_t *ctx, const unsigned char *i
                                            ilen, input, output ) );
     }
 #endif
-
-    if ( 0 == block_size )
-    {
-        return( MBEDTLS_ERR_CIPHER_INVALID_CONTEXT );
-    }
 
     if( input == output &&
        ( ctx->unprocessed_len != 0 || ilen % block_size ) )
@@ -625,11 +624,6 @@ int mbedtls_cipher_update( mbedtls_cipher_context_t *ctx, const unsigned char *i
          */
         if( 0 != ilen )
         {
-            if( 0 == block_size )
-            {
-                return( MBEDTLS_ERR_CIPHER_INVALID_CONTEXT );
-            }
-
             /* Encryption: only cache partial blocks
              * Decryption w/ padding: always keep at least one whole block
              * Decryption w/o padding: only cache partial blocks

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -158,11 +158,10 @@ typedef enum
     }                                                             \
     while( 0 )
 
-/** Allocate memory dynamically. Exit the test if this fails, but do
- * not mark the test as failed.
+/** Allocate memory dynamically. If the allocation fails, skip the test case.
  *
  * This macro behaves like #ASSERT_ALLOC, except that if the allocation
- * fails, it jumps to the \c exit label without calling test_fail().
+ * fails, it marks the test as skipped rather than failed.
  */
 #define ASSERT_ALLOC_WEAK( pointer, length )                      \
     do                                                            \
@@ -172,8 +171,7 @@ typedef enum
         {                                                         \
             ( pointer ) = mbedtls_calloc( sizeof( *( pointer ) ), \
                                           ( length ) );           \
-            if( ( pointer ) == NULL )                             \
-                goto exit;                                        \
+            TEST_ASSUME( ( pointer ) != NULL );                   \
         }                                                         \
     }                                                             \
     while( 0 )

--- a/tests/suites/test_suite_asn1parse.function
+++ b/tests/suites/test_suite_asn1parse.function
@@ -121,6 +121,7 @@ int get_len_step( const data_t *input, size_t buffer_size,
 {
     unsigned char *buf = NULL;
     unsigned char *p = NULL;
+    unsigned char *end;
     size_t parsed_length;
     int ret;
 
@@ -130,7 +131,8 @@ int get_len_step( const data_t *input, size_t buffer_size,
     if( buffer_size == 0 )
     {
         ASSERT_ALLOC( buf, 1 );
-        p = buf + 1;
+        end = buf + 1;
+        p = end;
     }
     else
     {
@@ -145,9 +147,10 @@ int get_len_step( const data_t *input, size_t buffer_size,
             memcpy( buf, input->x, buffer_size );
         }
         p = buf;
+        end = buf + buffer_size;
     }
 
-    ret = mbedtls_asn1_get_len( &p, buf + buffer_size, &parsed_length );
+    ret = mbedtls_asn1_get_len( &p, end, &parsed_length );
 
     if( buffer_size >= input->len + actual_length )
     {

--- a/tests/suites/test_suite_ecdsa.function
+++ b/tests/suites/test_suite_ecdsa.function
@@ -500,7 +500,9 @@ void ecdsa_write_restart( int id, char *d_str, int md_alg,
     TEST_ASSERT( md_info != NULL );
 
     hlen = mbedtls_md_get_size( md_info );
-    mbedtls_md( md_info, (const unsigned char *) msg, strlen( msg ), hash );
+    TEST_ASSERT( mbedtls_md( md_info,
+                             (const unsigned char *) msg, strlen( msg ),
+                             hash ) == 0 );
 
     mbedtls_ecp_set_max_ops( max_ops );
 

--- a/tests/suites/test_suite_mpi.function
+++ b/tests/suites/test_suite_mpi.function
@@ -600,8 +600,8 @@ void mbedtls_mpi_lt_mpi_ct( int size_X, char * input_X,
     TEST_ASSERT( mbedtls_mpi_read_string( &X, 16, input_X ) == 0 );
     TEST_ASSERT( mbedtls_mpi_read_string( &Y, 16, input_Y ) == 0 );
 
-    mbedtls_mpi_grow( &X, size_X );
-    mbedtls_mpi_grow( &Y, size_Y );
+    TEST_ASSERT( mbedtls_mpi_grow( &X, size_X ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_grow( &Y, size_Y ) == 0 );
 
     TEST_ASSERT( mbedtls_mpi_lt_mpi_ct( &X, &Y, &ret ) == input_err );
     if( input_err == 0 )

--- a/tests/suites/test_suite_pk.function
+++ b/tests/suites/test_suite_pk.function
@@ -844,7 +844,9 @@ void pk_sign_verify_restart( int pk_type, int grp_id, char *d_str,
     TEST_ASSERT( md_info != NULL );
 
     hlen = mbedtls_md_get_size( md_info );
-    mbedtls_md( md_info, (const unsigned char *) msg, strlen( msg ), hash );
+    TEST_ASSERT( mbedtls_md( md_info,
+                             (const unsigned char *) msg, strlen( msg ),
+                             hash ) == 0 );
 
     mbedtls_ecp_set_max_ops( max_ops );
 


### PR DESCRIPTION
* One instance of dead code in the product. IOTCRYPT-475
* Some missing return value checks in test code.
* Several cases where test code could cause a resource leak or crash if the test fails in certain ways.
* (Found while I was looking at the code) Make `ASSERT_ALLOC_WEAK` skip the test rather than pass it if it fails, as was intended all along.

The missing return value checks should be backported where applicable. The other bugs are so minor that they don't need backporting (but can be). `ASSERT_ALLOC_WEAK` is not in the LTS branches.

### Backports

- 2.16 https://github.com/ARMmbed/mbedtls/pull/3001
- 2.7 https://github.com/ARMmbed/mbedtls/pull/3002