### PR TITLE
Parse RSA parameters DP, DQ and QP from PKCS1 private keys

### DIFF
--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -782,25 +782,17 @@ static int pk_parse_key_pkcs1_der( mbedtls_rsa_context *rsa,
     */
 
     /* Import DP */
-    if( ( ret = mbedtls_asn1_get_tag( &p, end, &len,
-                                      MBEDTLS_ASN1_INTEGER ) ) != 0 ||
-        ( ret = mbedtls_mpi_read_binary( &rsa->DP, p, len ) ) != 0 )
-        goto cleanup;
-    p += len;
+    if( ( ret = mbedtls_asn1_get_mpi( &p, end, &rsa->DP ) ) != 0)
+       goto cleanup;
 
     /* Import DQ */
-    if( ( ret = mbedtls_asn1_get_tag( &p, end, &len,
-                                      MBEDTLS_ASN1_INTEGER ) ) != 0 ||
-        ( ret = mbedtls_mpi_read_binary( &rsa->DQ, p, len ) ) != 0 )
-        goto cleanup;
-    p += len;
+    if( ( ret = mbedtls_asn1_get_mpi( &p, end, &rsa->DQ ) ) != 0)
+       goto cleanup;
 
     /* Import QP */
-    if( ( ret = mbedtls_asn1_get_tag( &p, end, &len,
-                                      MBEDTLS_ASN1_INTEGER ) ) != 0 ||
-        ( ret = mbedtls_mpi_read_binary( &rsa->QP, p, len ) ) != 0 )
-        goto cleanup;
-    p += len;
+    if( ( ret = mbedtls_asn1_get_mpi( &p, end, &rsa->QP ) ) != 0)
+       goto cleanup;
+
 #else
     /* Verify existance of the CRT params */
     if( ( ret = mbedtls_asn1_get_mpi( &p, end, &T ) ) != 0 ||

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -769,14 +769,29 @@ static int pk_parse_key_pkcs1_der( mbedtls_rsa_context *rsa,
         goto cleanup;
     p += len;
 
+    /* Import DP */
+    if( ( ret = mbedtls_asn1_get_tag( &p, end, &len,
+                                      MBEDTLS_ASN1_INTEGER ) ) != 0 ||
+        ( ret = mbedtls_mpi_read_binary( &rsa->DP, p, len ) ) != 0 )
+        goto cleanup;
+    p += len;
+
+    /* Import DQ */
+    if( ( ret = mbedtls_asn1_get_tag( &p, end, &len,
+                                      MBEDTLS_ASN1_INTEGER ) ) != 0 ||
+        ( ret = mbedtls_mpi_read_binary( &rsa->DQ, p, len ) ) != 0 )
+        goto cleanup;
+    p += len;
+
+    /* Import QP */
+    if( ( ret = mbedtls_asn1_get_tag( &p, end, &len,
+                                      MBEDTLS_ASN1_INTEGER ) ) != 0 ||
+        ( ret = mbedtls_mpi_read_binary( &rsa->QP, p, len ) ) != 0 )
+        goto cleanup;
+    p += len;
+
     /* Complete the RSA private key */
     if( ( ret = mbedtls_rsa_complete( rsa ) ) != 0 )
-        goto cleanup;
-
-    /* Check optional parameters */
-    if( ( ret = mbedtls_asn1_get_mpi( &p, end, &T ) ) != 0 ||
-        ( ret = mbedtls_asn1_get_mpi( &p, end, &T ) ) != 0 ||
-        ( ret = mbedtls_asn1_get_mpi( &p, end, &T ) ) != 0 )
         goto cleanup;
 
     if( p != end )

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -769,6 +769,7 @@ static int pk_parse_key_pkcs1_der( mbedtls_rsa_context *rsa,
         goto cleanup;
     p += len;
 
+#if !defined(MBEDTLS_RSA_NO_CRT)
     /*
     * The RSA CRT parameters DP, DQ and QP are nominally redundant, in
     * that they can be easily recomputed from D, P and Q. However by
@@ -800,6 +801,13 @@ static int pk_parse_key_pkcs1_der( mbedtls_rsa_context *rsa,
         ( ret = mbedtls_mpi_read_binary( &rsa->QP, p, len ) ) != 0 )
         goto cleanup;
     p += len;
+#else
+    /* Verify existance of the CRT params */
+    if( ( ret = mbedtls_asn1_get_mpi( &p, end, &T ) ) != 0 ||
+        ( ret = mbedtls_asn1_get_mpi( &p, end, &T ) ) != 0 ||
+        ( ret = mbedtls_asn1_get_mpi( &p, end, &T ) ) != 0 )
+       goto cleanup;
+#endif
 
     /* Complete the RSA private key */
     if( ( ret = mbedtls_rsa_complete( rsa ) ) != 0 )

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -769,6 +769,17 @@ static int pk_parse_key_pkcs1_der( mbedtls_rsa_context *rsa,
         goto cleanup;
     p += len;
 
+    /*
+    * The RSA CRT parameters DP, DQ and QP are nominally redundant, in
+    * that they can be easily recomputed from D, P and Q. However by
+    * parsing them from the PKCS1 structure it is possible to avoid
+    * recalculating them which both reduces the overhead of loading
+    * RSA private keys into memory and also avoids side channels which
+    * can arise when computing those values, since all of D, P, and Q
+    * are secret. See https://eprint.iacr.org/2020/055 for a
+    * description of one such attack.
+    */
+
     /* Import DP */
     if( ( ret = mbedtls_asn1_get_tag( &p, end, &len,
                                       MBEDTLS_ASN1_INTEGER ) ) != 0 ||

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -249,7 +249,10 @@ static int rsa_check_context( mbedtls_rsa_context const *ctx, int is_priv,
 int mbedtls_rsa_complete( mbedtls_rsa_context *ctx )
 {
     int ret = 0;
-    int have_N, have_P, have_Q, have_D, have_E, have_DP, have_DQ, have_QP;
+    int have_N, have_P, have_Q, have_D, have_E;
+#if !defined(MBEDTLS_RSA_NO_CRT)
+    int have_DP, have_DQ, have_QP;
+#endif
     int n_missing, pq_missing, d_missing, is_pub, is_priv;
 
     RSA_VALIDATE_RET( ctx != NULL );
@@ -259,10 +262,12 @@ int mbedtls_rsa_complete( mbedtls_rsa_context *ctx )
     have_Q = ( mbedtls_mpi_cmp_int( &ctx->Q, 0 ) != 0 );
     have_D = ( mbedtls_mpi_cmp_int( &ctx->D, 0 ) != 0 );
     have_E = ( mbedtls_mpi_cmp_int( &ctx->E, 0 ) != 0 );
+
+#if !defined(MBEDTLS_RSA_NO_CRT)
     have_DP = ( mbedtls_mpi_cmp_int( &ctx->DP, 0 ) != 0 );
     have_DQ = ( mbedtls_mpi_cmp_int( &ctx->DQ, 0 ) != 0 );
     have_QP = ( mbedtls_mpi_cmp_int( &ctx->QP, 0 ) != 0 );
-
+#endif
 
     /*
      * Check whether provided parameters are enough

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -249,7 +249,7 @@ static int rsa_check_context( mbedtls_rsa_context const *ctx, int is_priv,
 int mbedtls_rsa_complete( mbedtls_rsa_context *ctx )
 {
     int ret = 0;
-    int have_N, have_P, have_Q, have_D, have_E;
+    int have_N, have_P, have_Q, have_D, have_E, have_DP, have_DQ, have_QP;
     int n_missing, pq_missing, d_missing, is_pub, is_priv;
 
     RSA_VALIDATE_RET( ctx != NULL );
@@ -259,6 +259,10 @@ int mbedtls_rsa_complete( mbedtls_rsa_context *ctx )
     have_Q = ( mbedtls_mpi_cmp_int( &ctx->Q, 0 ) != 0 );
     have_D = ( mbedtls_mpi_cmp_int( &ctx->D, 0 ) != 0 );
     have_E = ( mbedtls_mpi_cmp_int( &ctx->E, 0 ) != 0 );
+    have_DP = ( mbedtls_mpi_cmp_int( &ctx->DP, 0 ) != 0 );
+    have_DQ = ( mbedtls_mpi_cmp_int( &ctx->DQ, 0 ) != 0 );
+    have_QP = ( mbedtls_mpi_cmp_int( &ctx->QP, 0 ) != 0 );
+
 
     /*
      * Check whether provided parameters are enough
@@ -325,7 +329,7 @@ int mbedtls_rsa_complete( mbedtls_rsa_context *ctx )
      */
 
 #if !defined(MBEDTLS_RSA_NO_CRT)
-    if( is_priv )
+    if( is_priv && !(have_DP && have_DQ && have_QP))
     {
         ret = mbedtls_rsa_deduce_crt( &ctx->P,  &ctx->Q,  &ctx->D,
                                       &ctx->DP, &ctx->DQ, &ctx->QP );

--- a/library/rsa.c
+++ b/library/rsa.c
@@ -334,7 +334,7 @@ int mbedtls_rsa_complete( mbedtls_rsa_context *ctx )
      */
 
 #if !defined(MBEDTLS_RSA_NO_CRT)
-    if( is_priv && !(have_DP && have_DQ && have_QP))
+    if( is_priv && ! ( have_DP && have_DQ && have_QP ) )
     {
         ret = mbedtls_rsa_deduce_crt( &ctx->P,  &ctx->Q,  &ctx->D,
                                       &ctx->DP, &ctx->DQ, &ctx->QP );


### PR DESCRIPTION
Otherwise these values are recomputed in `mbedtls_rsa_deduce_crt`, which currently suffers from side channel issues in the computation of QP (see https://eprint.iacr.org/2020/055). By loading the pre-computed values not only is the side channel avoided, but runtime overhead of loading RSA keys is reduced.

Discussion in https://github.com/ARMmbed/mbed-crypto/issues/347