### PR TITLE
Fix incrementing pointer instead of value

### DIFF
--- a/library/ecdsa.c
+++ b/library/ecdsa.c
@@ -298,7 +298,7 @@ static int ecdsa_sign_restartable( mbedtls_ecp_group *grp,
     *p_sign_tries = 0;
     do
     {
-        if( *p_sign_tries++ > 10 )
+        if( (*p_sign_tries)++ > 10 )
         {
             ret = MBEDTLS_ERR_ECP_RANDOM_FAILED;
             goto cleanup;
@@ -311,7 +311,7 @@ static int ecdsa_sign_restartable( mbedtls_ecp_group *grp,
         *p_key_tries = 0;
         do
         {
-            if( *p_key_tries++ > 10 )
+            if( (*p_key_tries)++ > 10 )
             {
                 ret = MBEDTLS_ERR_ECP_RANDOM_FAILED;
                 goto cleanup;


### PR DESCRIPTION
This was introduced by a hasty search-and-replace that embarrassingly didn't account for C's
operator precedence when changing those variables to pointer types.

## Backports

- [x] Mbed TLS 2.16: https://github.com/ARMmbed/mbedtls/pull/3007
- [x] Mbed TLS 2.7 is not affected (restartable ECC not introduced yet, so these variables are not pointers).

## Impact assessment

See the ChangeLog entry in the backport to 2.16.