### PR TITLE
Remove temporary allocation in mbedtls_mpi_sub_abs

### DIFF
--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1354,6 +1354,9 @@ static void mpi_sub_hlp( size_t n, mbedtls_mpi_uint *s, mbedtls_mpi_uint *d )
 int mbedtls_mpi_sub_abs( mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi *B )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+    size_t i, width;
+    mbedtls_mpi_uint c = 0;
+
     MPI_VALIDATE_RET( X != NULL );
     MPI_VALIDATE_RET( A != NULL );
     MPI_VALIDATE_RET( B != NULL );
@@ -1368,10 +1371,7 @@ int mbedtls_mpi_sub_abs( mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi
     ret = 0;
 
     MBEDTLS_MPI_CHK( mbedtls_mpi_grow( X, A->n ) );
-
-    size_t width = A->n > B->n ? B->n : A->n;
-    size_t i;
-    mbedtls_mpi_uint c = 0;
+    width = A->n > B->n ? B->n : A->n;
 
     for( i = 0; i < width; i++ )
     {

--- a/tests/suites/test_suite_mpi.function
+++ b/tests/suites/test_suite_mpi.function
@@ -959,10 +959,26 @@ void mbedtls_mpi_sub_abs( int radix_X, char * input_X, int radix_Y,
     TEST_ASSERT( mbedtls_mpi_read_string( &Y, radix_Y, input_Y ) == 0 );
     TEST_ASSERT( mbedtls_mpi_read_string( &A, radix_A, input_A ) == 0 );
 
+    /* Z = X - Y */
     res = mbedtls_mpi_sub_abs( &Z, &X, &Y );
     TEST_ASSERT( res == sub_result );
     if( res == 0 )
         TEST_ASSERT( mbedtls_mpi_cmp_mpi( &Z, &A ) == 0 );
+
+    /* X = X - Y */
+    test_set_step( 1 );
+    res = mbedtls_mpi_sub_abs( &X, &X, &Y );
+    TEST_ASSERT( res == sub_result );
+    if( res == 0 )
+        TEST_ASSERT( mbedtls_mpi_cmp_mpi( &X, &A ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_read_string( &X, radix_X, input_X ) == 0 );
+
+    /* Y = X - Y */
+    test_set_step( 2 );
+    res = mbedtls_mpi_sub_abs( &Y, &X, &Y );
+    TEST_ASSERT( res == sub_result );
+    if( res == 0 )
+        TEST_ASSERT( mbedtls_mpi_cmp_mpi( &Y, &A ) == 0 );
 
 exit:
     mbedtls_mpi_free( &X ); mbedtls_mpi_free( &Y ); mbedtls_mpi_free( &Z ); mbedtls_mpi_free( &A );


### PR DESCRIPTION
In cases where X == B the code now no longer requires an extra call to
mbedtls_calloc if X->n >= A->n.  This reduces calls to mbedtls_calloc in
test_suite_ecdsa by 52% and in test_suite_ecdh by 36%.

This does not update mpi_sub_hlp - in mpi_montmul this translates to a
performance decrease for rsa and dhm since in all cases X == A.