### PR TITLE
Bump version to Mbed TLS 2.21.0

### DIFF
--- a/doxygen/mbedtls.doxyfile
+++ b/doxygen/mbedtls.doxyfile
@@ -28,7 +28,7 @@ DOXYFILE_ENCODING      = UTF-8
 # identify the project. Note that if you do not use Doxywizard you need
 # to put quotes around the project name if it contains spaces.
 
-PROJECT_NAME           = "mbed TLS v2.20.0"
+PROJECT_NAME           = "mbed TLS v2.21.0"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number.
 # This could be handy for archiving the generated documentation or

--- a/include/mbedtls/version.h
+++ b/include/mbedtls/version.h
@@ -39,7 +39,7 @@
  * Major, Minor, Patchlevel
  */
 #define MBEDTLS_VERSION_MAJOR  2
-#define MBEDTLS_VERSION_MINOR  20
+#define MBEDTLS_VERSION_MINOR  21
 #define MBEDTLS_VERSION_PATCH  0
 
 /**
@@ -47,9 +47,9 @@
  *    MMNNPP00
  *    Major version | Minor version | Patch version
  */
-#define MBEDTLS_VERSION_NUMBER         0x02140000
-#define MBEDTLS_VERSION_STRING         "2.20.0"
-#define MBEDTLS_VERSION_STRING_FULL    "mbed TLS 2.20.0"
+#define MBEDTLS_VERSION_NUMBER         0x02150000
+#define MBEDTLS_VERSION_STRING         "2.21.0"
+#define MBEDTLS_VERSION_STRING_FULL    "mbed TLS 2.21.0"
 
 #if defined(MBEDTLS_VERSION_C)
 

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -157,7 +157,7 @@ endif(USE_STATIC_MBEDTLS_LIBRARY)
 
 if(USE_SHARED_MBEDTLS_LIBRARY)
     add_library(mbedcrypto SHARED ${src_crypto})
-    set_target_properties(mbedcrypto PROPERTIES VERSION 2.20.0 SOVERSION 4)
+    set_target_properties(mbedcrypto PROPERTIES VERSION 2.21.0 SOVERSION 4)
     target_link_libraries(mbedcrypto ${libs})
     target_include_directories(mbedcrypto
         PUBLIC ${MBEDTLS_DIR}/include/

--- a/tests/suites/test_suite_version.data
+++ b/tests/suites/test_suite_version.data
@@ -1,8 +1,8 @@
 Check compiletime library version
-check_compiletime_version:"2.20.0"
+check_compiletime_version:"2.21.0"
 
 Check runtime library version
-check_runtime_version:"2.20.0"
+check_runtime_version:"2.21.0"
 
 Check for MBEDTLS_VERSION_C
 check_feature:"MBEDTLS_VERSION_C":0


### PR DESCRIPTION
Not bumping the SO version:

The API/ABI breaking changes only affect internal APIs (changes related to `mbedtls_asn1_traverse_sequence_of()`) and to PSA, which is from the point of view of Mbed TLS is an unstable API.