### PR TITLE
 Remove temporary allocation in mbedtls_mpi_sub_abs - single subtract implementation

### DIFF
--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1328,7 +1328,8 @@ cleanup:
 }
 
 /*
- * Helper for mbedtls_mpi subtraction
+ * Helper for mbedtls_mpi subtraction.
+ * This function assumes that X->n >= A->n.
  */
 static void mpi_sub_hlp( const mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi *B )
 {

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1354,6 +1354,9 @@ static void mpi_sub_hlp( size_t n, mbedtls_mpi_uint *s, mbedtls_mpi_uint *d )
 int mbedtls_mpi_sub_abs( mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi *B )
 {
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
+    size_t i, width;
+    mbedtls_mpi_uint c = 0;
+
     MPI_VALIDATE_RET( X != NULL );
     MPI_VALIDATE_RET( A != NULL );
     MPI_VALIDATE_RET( B != NULL );
@@ -1368,10 +1371,7 @@ int mbedtls_mpi_sub_abs( mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi
     ret = 0;
 
     MBEDTLS_MPI_CHK( mbedtls_mpi_grow( X, A->n ) );
-
-    size_t width = A->n > B->n ? B->n : A->n;
-    size_t i;
-    mbedtls_mpi_uint c = 0;
+    width = A->n > B->n ? B->n : A->n;
 
     for( i = 0; i < width; i++ )
     {

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -1331,7 +1331,7 @@ cleanup:
  * Helper for mbedtls_mpi subtraction.
  * This function assumes that X->n >= A->n.
  */
-static void mpi_sub_hlp( const mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi *B )
+static void mpi_sub_hlp( mbedtls_mpi *X, const mbedtls_mpi *A, const mbedtls_mpi *B )
 {
     size_t i;
     mbedtls_mpi_uint c = 0;
@@ -1979,7 +1979,7 @@ static void mpi_montg_init( mbedtls_mpi_uint *mm, const mbedtls_mpi *N )
  * Montgomery multiplication: A = A * B * R^-1 mod N  (HAC 14.36)
  */
 static int mpi_montmul( mbedtls_mpi *A, const mbedtls_mpi *B, const mbedtls_mpi *N, mbedtls_mpi_uint mm,
-                         const mbedtls_mpi *T )
+                         mbedtls_mpi *T )
 {
     size_t i, n, m;
     mbedtls_mpi_uint u0, u1, *d;
@@ -2022,7 +2022,7 @@ static int mpi_montmul( mbedtls_mpi *A, const mbedtls_mpi *B, const mbedtls_mpi 
  * Montgomery reduction: A = A * R^-1 mod N
  */
 static int mpi_montred( mbedtls_mpi *A, const mbedtls_mpi *N,
-                        mbedtls_mpi_uint mm, const mbedtls_mpi *T )
+                        mbedtls_mpi_uint mm, mbedtls_mpi *T )
 {
     mbedtls_mpi_uint z = 1;
     mbedtls_mpi U;

--- a/tests/suites/test_suite_mpi.function
+++ b/tests/suites/test_suite_mpi.function
@@ -959,10 +959,26 @@ void mbedtls_mpi_sub_abs( int radix_X, char * input_X, int radix_Y,
     TEST_ASSERT( mbedtls_mpi_read_string( &Y, radix_Y, input_Y ) == 0 );
     TEST_ASSERT( mbedtls_mpi_read_string( &A, radix_A, input_A ) == 0 );
 
+    /* Z = X - Y */
     res = mbedtls_mpi_sub_abs( &Z, &X, &Y );
     TEST_ASSERT( res == sub_result );
     if( res == 0 )
         TEST_ASSERT( mbedtls_mpi_cmp_mpi( &Z, &A ) == 0 );
+
+    /* X = X - Y */
+    test_set_step( 1 );
+    res = mbedtls_mpi_sub_abs( &X, &X, &Y );
+    TEST_ASSERT( res == sub_result );
+    if( res == 0 )
+        TEST_ASSERT( mbedtls_mpi_cmp_mpi( &X, &A ) == 0 );
+    TEST_ASSERT( mbedtls_mpi_read_string( &X, radix_X, input_X ) == 0 );
+
+    /* Y = X - Y */
+    test_set_step( 2 );
+    res = mbedtls_mpi_sub_abs( &Y, &X, &Y );
+    TEST_ASSERT( res == sub_result );
+    if( res == 0 )
+        TEST_ASSERT( mbedtls_mpi_cmp_mpi( &Y, &A ) == 0 );
 
 exit:
     mbedtls_mpi_free( &X ); mbedtls_mpi_free( &Y ); mbedtls_mpi_free( &Z ); mbedtls_mpi_free( &A );


### PR DESCRIPTION
As requested in https://github.com/ARMmbed/mbed-crypto/pull/366 here's a new pull request that uses a single subtraction implementation.