### PR TITLE
Build: Updated CMAKE_C_FLAGS for IAR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,7 +156,10 @@ if(CMAKE_COMPILER_IS_CLANG)
 endif(CMAKE_COMPILER_IS_CLANG)
 
 if(CMAKE_COMPILER_IS_IAR)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --warn_about_c_style_casts --warnings_are_errors -Ohz")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --warn_about_c_style_casts")
+    set(CMAKE_C_FLAGS_RELEASE     "-Ohz")
+    set(CMAKE_C_FLAGS_DEBUG       "--debug -On")
+    set(CMAKE_C_FLAGS_CHECK       "--warnings_are_errors")
 endif(CMAKE_COMPILER_IS_IAR)
 
 if(CMAKE_COMPILER_IS_MSVC)


### PR DESCRIPTION
Updated the IAR specific CMAKE_C_FLAGS settings in CMakeLists.txt to
allow building TF-M (Trusted Firmware) with mbed-crypto as a subproject.

Signed-off-by: TTornblom <thomas.tornblom@iar.com>