### PR TITLE
Fix warning with gcc7 - maximum allocation exceeded

### DIFF
--- a/tests/suites/test_suite_psa_crypto.function
+++ b/tests/suites/test_suite_psa_crypto.function
@@ -5297,6 +5297,8 @@ void generate_random( int bytes_arg )
     size_t i;
     unsigned run;
 
+    TEST_ASSERT( bytes_arg >= 0 );
+
     ASSERT_ALLOC( output, bytes + sizeof( trail ) );
     ASSERT_ALLOC( changed, bytes );
     memcpy( output + bytes, trail, sizeof( trail ) );


### PR DESCRIPTION
Adds additional limits checks on the `ASSERT_ALLOC` macros in the test suite helper functions to remove the warning of an allocation potentially exceeding the maximum object size. eg `-Werror=alloc-size-larger-than`.

The warning is present in GCC 7, and is the reason that the `test_m32_everest` component in `all.sh` is failing with the `ubuntu-18.04` docker image.

### Long explanation of the fix

In the test suite `test_suite_psa` there's a test case function of `generate_random()` which takes `int` as a parameter `bytes_arg` and assigns it to `bytes` as a `size_t`. The parameter comes from the data file so comes in via standard IO so could be at the limit. Within this function, it makes a call to the macro `ASSERT_ALLOC()`, passing that parameter `bytes` + `sizeof(trail)`, without any boundary checks on `bytes` unchecked.

Within `ASSERT_ALLOC` there is then a call to `calloc` that takes a parameter of size as `size_t`, and passes `bytes_arg` an `int` into it.

In the Everest m32 test, this is failing with the warning? Why? Well, we've moved from LP64, where `int` is 32bits, and `size_t` is 64 bits, to ILP32 where `int` is 32bits and `size_t` is 32 bits

In LP64, an `int` (32 bits) plus `sizeof(trail)` (constant, small), will always be less than the limit of a `size_t` (64 bits), whilst in ILP32, it could exceed the size of the `size_t` (32 bits).

And so we get the warning.