### PR TITLE
Support x_drbg_set_reseed_interval before x_drbg_seed

### DIFF
--- a/include/mbedtls/ctr_drbg.h
+++ b/include/mbedtls/ctr_drbg.h
@@ -220,49 +220,57 @@ void mbedtls_ctr_drbg_init( mbedtls_ctr_drbg_context *ctx );
  * \brief               This function seeds and sets up the CTR_DRBG
  *                      entropy source for future reseeds.
  *
- * A typical choice for the \p f_entropy and \p p_entropy parameters is
- * to use the entropy module:
- * - \p f_entropy is mbedtls_entropy_func();
- * - \p p_entropy is an instance of ::mbedtls_entropy_context initialized
- *   with mbedtls_entropy_init() (which registers the platform's default
- *   entropy sources).
+ *                      A typical choice for the \p f_entropy and \p p_entropy
+ *                      parameters is to use the entropy module:
+ *                      - \p f_entropy is mbedtls_entropy_func();
+ *                      - \p p_entropy is an instance of
+ *                        ::mbedtls_entropy_context initialized with
+ *                        mbedtls_entropy_init() (which registers the
+ *                        platform's default entropy sources).
  *
- * The entropy length is #MBEDTLS_CTR_DRBG_ENTROPY_LEN by default.
- * You can override it by calling mbedtls_ctr_drbg_set_entropy_len().
+ *                      The entropy length is #MBEDTLS_CTR_DRBG_ENTROPY_LEN by
+ *                      default. You can override it by calling
+ *                      mbedtls_ctr_drbg_set_entropy_len().
  *
- * The entropy nonce length is:
- * - \c 0 if the entropy length is at least 3/2 times the entropy length,
- *   which guarantees that the security strength is the maximum permitted
- *   by the key size and entropy length according to NIST SP 800-90A §10.2.1;
- * - Half the entropy length otherwise.
- * You can override it by calling mbedtls_ctr_drbg_set_nonce_len().
- * With the default entropy length, the entropy nonce length is
- * #MBEDTLS_CTR_DRBG_ENTROPY_NONCE_LEN.
+ *                      The entropy nonce length is:
+ *                      - \c 0 if the entropy length is at least 3/2 times the
+ *                        entropy length, which guarantees that the security
+ *                        strength is the maximum permitted by the key size
+ *                        and entropy length according to NIST SP 800-90A
+ *                        §10.2.1;
+ *                      - Half the entropy length otherwise. You can override
+ *                        it by calling mbedtls_ctr_drbg_set_nonce_len(). With
+ *                        the default entropy length, the entropy nonce length
+ *                        is #MBEDTLS_CTR_DRBG_ENTROPY_NONCE_LEN.
  *
- * You can provide a nonce and personalization string in addition to the
- * entropy source, to make this instantiation as unique as possible.
- * See SP 800-90A §8.6.7 for more details about nonces.
+ *                      You can provide a nonce and personalization string in
+ *                      addition to the entropy source, to make this
+ *                      instantiation as unique as possible. See SP 800-90A
+ *                      §8.6.7 for more details about nonces.
  *
- * The _seed_material_ value passed to the derivation function in
- * the CTR_DRBG Instantiate Process described in NIST SP 800-90A §10.2.1.3.2
- * is the concatenation of the following strings:
- * - A string obtained by calling \p f_entropy function for the entropy
- *   length.
+ *                      The _seed_material_ value passed to the derivation
+ *                      function in the CTR_DRBG Instantiate Process described
+ *                      in NIST SP 800-90A §10.2.1.3.2 is the concatenation of
+ *                      the following strings:
+ *                      - A string obtained by calling \p f_entropy function
+ *                        for the entropy length.
  */
 #if MBEDTLS_CTR_DRBG_ENTROPY_NONCE_LEN == 0
 /**
- * - If mbedtls_ctr_drbg_set_nonce_len() has been called, a string
- *   obtained by calling \p f_entropy function for the specified length.
+ *                      - If mbedtls_ctr_drbg_set_nonce_len() has been called,
+ *                        a string obtained by calling \p f_entropy function
+ *                        for the specified length.
  */
 #else
 /**
- * - A string obtained by calling \p f_entropy function for the entropy nonce
- *   length. If the entropy nonce length is \c 0, this function does not
- *   make a second call to \p f_entropy.
+ *                      - A string obtained by calling \p f_entropy function
+ *                        for the entropy nonce length. If the entropy nonce
+ *                        length is \c 0, this function does not make a second
+ *                        call to \p f_entropy.
  */
 #endif
 /**
- * - The \p custom string.
+ *                      - The \p custom string.
  *
  * \note                To achieve the nominal security strength permitted
  *                      by CTR_DRBG, the entropy length must be:
@@ -278,6 +286,11 @@ void mbedtls_ctr_drbg_init( mbedtls_ctr_drbg_context *ctx );
  *                      (maximum achievable strength when using AES-128);
  *                      - at least 48 bytes for a 256-bit strength
  *                      (maximum achievable strength when using AES-256).
+ *
+ * \note                The reseed interval is
+ *                      #MBEDTLS_CTR_DRBG_RESEED_INTERVAL by default.
+ *                      You can override it by calling
+ *                      mbedtls_ctr_drbg_set_reseed_interval().
  *
  * \param ctx           The CTR_DRBG context to seed.
  *                      It must have been initialized with
@@ -364,8 +377,9 @@ void mbedtls_ctr_drbg_set_entropy_len( mbedtls_ctr_drbg_context *ctx,
  * \brief               This function sets the amount of entropy grabbed
  *                      as a nonce for the initial seeding.
  *
- * Call this function before calling mbedtls_ctr_drbg_seed() to read
- * a nonce from the entropy source during the initial seeding.
+ *                      Call this function before calling
+ *                      mbedtls_ctr_drbg_seed() to read a nonce from the
+ *                      entropy source during the initial seeding.
  *
  * \param ctx           The CTR_DRBG context.
  * \param len           The amount of entropy to grab for the nonce, in bytes.

--- a/include/mbedtls/hmac_drbg.h
+++ b/include/mbedtls/hmac_drbg.h
@@ -148,6 +148,10 @@ void mbedtls_hmac_drbg_init( mbedtls_hmac_drbg_context *ctx );
  * \note                During the initial seeding, this function calls
  *                      the entropy source to obtain a nonce
  *                      whose length is half the entropy length.
+ * 
+ * \note                The reseed interval is MBEDTLS_HMAC_DRBG_RESEED_INTERVAL
+ *                      by default. Override this value by calling
+ *                      mbedtls_hmac_drbg_set_reseed_interval().
  *
  * \param ctx           HMAC_DRBG context to be seeded.
  * \param md_info       MD algorithm to use for HMAC_DRBG.
@@ -185,8 +189,8 @@ int mbedtls_hmac_drbg_seed( mbedtls_hmac_drbg_context *ctx,
 /**
  * \brief               Initilisation of simpified HMAC_DRBG (never reseeds).
  *
- * This function is meant for use in algorithms that need a pseudorandom
- * input such as deterministic ECDSA.
+ *                      This function is meant for use in algorithms that need
+ *                      a pseudorandom input such as deterministic ECDSA.
  *
  * \param ctx           HMAC_DRBG context to be initialised.
  * \param md_info       MD algorithm to use for HMAC_DRBG.

--- a/library/ctr_drbg.c
+++ b/library/ctr_drbg.c
@@ -474,7 +474,8 @@ int mbedtls_ctr_drbg_seed( mbedtls_ctr_drbg_context *ctx,
                   (size_t) ctx->reseed_counter :
                   good_nonce_len( ctx->entropy_len ) );
 
-    ctx->reseed_interval = MBEDTLS_CTR_DRBG_RESEED_INTERVAL;
+    if ( ctx->reseed_interval == 0 )
+        ctx->reseed_interval = MBEDTLS_CTR_DRBG_RESEED_INTERVAL;
 
     /* Initialize with an empty key. */
     if( ( ret = mbedtls_aes_setkey_enc( &ctx->aes_ctx, key,

--- a/library/hmac_drbg.c
+++ b/library/hmac_drbg.c
@@ -272,7 +272,8 @@ int mbedtls_hmac_drbg_seed( mbedtls_hmac_drbg_context *ctx,
     ctx->f_entropy = f_entropy;
     ctx->p_entropy = p_entropy;
 
-    ctx->reseed_interval = MBEDTLS_HMAC_DRBG_RESEED_INTERVAL;
+    if ( ctx->reseed_interval == 0 ) 
+        ctx->reseed_interval = MBEDTLS_HMAC_DRBG_RESEED_INTERVAL;
 
     if( ctx->entropy_len == 0 )
     {

--- a/tests/suites/test_suite_ctr_drbg.function
+++ b/tests/suites/test_suite_ctr_drbg.function
@@ -240,6 +240,9 @@ void ctr_drbg_entropy_usage( int entropy_nonce_len )
     if( entropy_nonce_len >= 0 )
         TEST_ASSERT( mbedtls_ctr_drbg_set_nonce_len( &ctx, entropy_nonce_len ) == 0 );
 
+    /* Set reseed interval before seed */
+    mbedtls_ctr_drbg_set_reseed_interval( &ctx, (2 * reps) );
+
     /* Init must use entropy */
     TEST_ASSERT( mbedtls_ctr_drbg_seed( &ctx, mbedtls_test_entropy_func, entropy, NULL, 0 ) == 0 );
     expected_idx += MBEDTLS_CTR_DRBG_ENTROPY_LEN;
@@ -249,8 +252,8 @@ void ctr_drbg_entropy_usage( int entropy_nonce_len )
         expected_idx += MBEDTLS_CTR_DRBG_ENTROPY_NONCE_LEN;
     TEST_EQUAL( test_offset_idx, expected_idx );
 
-    /* By default, PR is off and reseed_interval is large,
-     * so the next few calls should not use entropy */
+    /* By default, PR is off, and reseed interval was set to
+     * 2 * reps so the next few calls should not use entropy */
     for( i = 0; i < reps; i++ )
     {
         TEST_ASSERT( mbedtls_ctr_drbg_random( &ctx, out, sizeof( out ) - 4 ) == 0 );
@@ -265,9 +268,7 @@ void ctr_drbg_entropy_usage( int entropy_nonce_len )
     TEST_ASSERT( out[sizeof( out ) - 2] == 0 );
     TEST_ASSERT( out[sizeof( out ) - 1] == 0 );
 
-    /* Set reseed_interval to the number of calls done,
-     * so the next call should reseed */
-    mbedtls_ctr_drbg_set_reseed_interval( &ctx, 2 * reps );
+    /* There have been 2 * reps calls to random. The next call should reseed */
     TEST_ASSERT( mbedtls_ctr_drbg_random( &ctx, out, sizeof( out ) ) == 0 );
     expected_idx += MBEDTLS_CTR_DRBG_ENTROPY_LEN;
     TEST_EQUAL( test_offset_idx, expected_idx );

--- a/tests/suites/test_suite_hmac_drbg.function
+++ b/tests/suites/test_suite_hmac_drbg.function
@@ -57,6 +57,9 @@ void hmac_drbg_entropy_usage( int md_alg )
     else
         default_entropy_len = 32;
 
+    /* Set reseed interval before seed */
+    mbedtls_hmac_drbg_set_reseed_interval( &ctx, (2 * reps) );
+
     /* Init must use entropy */
     TEST_ASSERT( mbedtls_hmac_drbg_seed( &ctx, md_info, mbedtls_test_entropy_func, &entropy,
                                  NULL, 0 ) == 0 );
@@ -64,8 +67,8 @@ void hmac_drbg_entropy_usage( int md_alg )
     expected_consumed_entropy += default_entropy_len * 3 / 2;
     TEST_EQUAL( sizeof( buf )  - entropy.len, expected_consumed_entropy );
 
-    /* By default, PR is off and reseed_interval is large,
-     * so the next few calls should not use entropy */
+    /* By default, PR is off, and reseed interval was set to
+     * 2 * reps so the next few calls should not use entropy */
     for( i = 0; i < reps; i++ )
     {
         TEST_ASSERT( mbedtls_hmac_drbg_random( &ctx, out, sizeof( out ) - 4 ) == 0 );
@@ -80,9 +83,7 @@ void hmac_drbg_entropy_usage( int md_alg )
     TEST_ASSERT( out[sizeof( out ) - 2] == 0 );
     TEST_ASSERT( out[sizeof( out ) - 1] == 0 );
 
-    /* Set reseed_interval to the number of calls done,
-     * so the next call should reseed */
-    mbedtls_hmac_drbg_set_reseed_interval( &ctx, 2 * reps );
+    /* There have been 2 * reps calls to random so the next call should reseed */
     TEST_ASSERT( mbedtls_hmac_drbg_random( &ctx, out, sizeof( out ) ) == 0 );
     expected_consumed_entropy += default_entropy_len;
     TEST_EQUAL( sizeof( buf )  - entropy.len, expected_consumed_entropy );


### PR DESCRIPTION
### Description
Fixes ARMmbed/mbedtls#2927
##### Summary of change
`mbedtls_hmac_drbg_seed()` and `mbedtls_ctr_drbg_seed()` were setting the entropy context `reseed_interval` to the default value of 10 000 even when `set_reseed_interval()` had been called prior to `seed()`. The documentation did not describe the API behaving this way, and it doesn't make sense that `seed()` would remove any prior preference for `reseed_interval` so this behavior has been fixed. Now, the value set by `set_reseed_interval()` will persist through after a call to `seed()`.

###### Impact of changes
This change would break any application that

- set the `reseed_interval` and expected it to be reset to the default value once they called `seed()`
- set the `reseed_interval` and was unknowingly using the default value for the lifetime of the `DRBG` object

The first situation could be dangerous if the set interval was very high and the PRNG was never reseeded. It is an unlikely scenario however because a user that understood the prior behavior would probably not design their application in this way anyways.

In the second situation, this change could expose a vulnerability in the user's application, so this could provide them with a net benefit.

###### Migration actions required
None

##### Documentation
Comments have been updated.

----------------------------------------------------------------------------------------------------------------
### Pull request type

    [x] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results

    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [x] Tests / results supplied as part of this PR

The first commit in the PR modifies `*_drbg_entropy_usage()` so that `set_reseed_interval()` is called before `seed()`. This will fail before including the next two commits which fix the bug in `mbedtls_hmac_drbg_seed()` and `mbedtls_ctr_drbg_seed()`.