### PR TITLE
Have issue and PR templates redirect to Mbed TLS

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,44 +1,10 @@
-<!--
+We are no longer accepting new issues in this repository
+========================================================
 
-   ************************************** WARNING **************************************
+Mbed Crypto is now maintained as part of Mbed TLS, see
+https://github.com/ARMmbed/mbedtls/issues/3064
 
-   The ciarcom bot parses this header automatically. Any deviation from the 
-   template may cause the bot to automatically correct this header or may result in a 
-   warning message, requesting updates.
+Please open your issue in the mbedtls repository:
+https://github.com/ARMmbed/mbedtls/issues/new
 
-   Please ensure that nothing follows the Issue request type section, all 
-   issue details are within the Description section and no changes are made to the 
-   template format (as detailed below).
-
-   *************************************************************************************
-
--->
-
-### Description
-
-<!--
-    Required
-    Add detailed description of what you are reporting.
-    Good example: https://os.mbed.com/docs/latest/reference/workflow.html
-    Things to consider sharing:
-    - What target does this relate to?
-    - What toolchain (name + version) are you using?
-    - What tools (name + version - is it mbed-cli, online compiler or IDE) are you using?
-    - What is the SHA of Mbed OS (git log -n1 --oneline)?
-    - Steps to reproduce. (Did you publish code or a test case that exhibits the problem?)
--->
-
-
-### Issue request type
-
-<!--
-    Required
-    Please add only one X to one of the following types. Do not fill multiple types (split the issue otherwise.)
-    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
-    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
-    description heading and to add a 'x' to the correct box.
--->
-    [ ] Question
-    [ ] Enhancement
-    [ ] Bug
-
+Thanks for your interest in Mbed Crypto!

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+We are no longer accepting new pull requests in this repository
+===============================================================
+
+Mbed Crypto is now maintained as part of Mbed TLS, see
+https://github.com/ARMmbed/mbedtls/issues/3064
+
+Please open your pull request in the mbedtls repository:
+https://github.com/ARMmbed/mbedtls/pulls
+
+Thanks for your interest in Mbed Crypto!


### PR DESCRIPTION
This is a follow-up to https://github.com/ARMmbed/mbedtls/pull/3085

We don't really want to disable issues and PR completely for this repo (for now), as this would make the existing ones invisible, and there are issues we want to track and PRs that are on their way to getting merged, and I don't think github offers and middle ground of keeping the existing ones but forbidding new ones.

So the second best thing is what this PR does: discourage people to create new issues and PRs here, and encourage them to open them in the mbedtls repo instead.